### PR TITLE
chore: lerna downstream dependancy security issues

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -803,7 +803,7 @@
         "normalize-package-data": "^2.4.0",
         "npm-package-arg": "^6.1.0",
         "semver": "^5.5.1",
-        "ssri": "^6.0.1"
+        "ssri": "^8.0.1"
       }
     },
     "node_modules/@evocateur/libnpmpublish/node_modules/get-stream": {
@@ -873,7 +873,7 @@
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.2.0",
         "semver": "^5.7.0",
-        "ssri": "^6.0.1",
+        "ssri": "^8.0.1",
         "tar": "^4.4.10",
         "unique-filename": "^1.1.1",
         "which": "^1.3.1"
@@ -1148,7 +1148,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2050,9 +2049,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2137,9 +2133,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2356,9 +2349,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2569,7 +2559,7 @@
       "dev": true,
       "dependencies": {
         "fs-extra": "^8.1.0",
-        "ssri": "^6.0.1",
+        "ssri": "^8.0.1",
         "tar": "^4.4.8"
       }
     },
@@ -2592,9 +2582,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2733,9 +2720,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2798,9 +2782,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3011,9 +2992,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3066,9 +3044,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3231,9 +3206,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3674,9 +3646,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3757,9 +3726,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3892,9 +3858,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3945,9 +3908,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5385,7 +5345,7 @@
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
         "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
+        "ssri": "^8.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
       }
@@ -7251,8 +7211,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -9011,7 +8970,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -10284,7 +10242,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -10779,7 +10736,6 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -11238,7 +11194,7 @@
         "node-fetch-npm": "^2.0.2",
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
-        "ssri": "^6.0.0"
+        "ssri": "^8.0.1"
       }
     },
     "node_modules/makeerror": {
@@ -14454,9 +14410,7 @@
       }
     },
     "node_modules/ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "8.0.1",
       "dev": true,
       "dependencies": {
         "figgy-pudding": "^3.5.1"
@@ -16867,7 +16821,7 @@
         "normalize-package-data": "^2.4.0",
         "npm-package-arg": "^6.1.0",
         "semver": "^5.5.1",
-        "ssri": "^6.0.1"
+        "ssri": "^8.0.1"
       },
       "dependencies": {
         "get-stream": {
@@ -16933,7 +16887,7 @@
         "rimraf": "^2.6.3",
         "safe-buffer": "^5.2.0",
         "semver": "^5.7.0",
-        "ssri": "^6.0.1",
+        "ssri": "^8.0.1",
         "tar": "^4.4.10",
         "unique-filename": "^1.1.1",
         "which": "^1.3.1"
@@ -18307,7 +18261,7 @@
       "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
-        "ssri": "^6.0.1",
+        "ssri": "^8.0.1",
         "tar": "^4.4.8"
       },
       "dependencies": {
@@ -20641,7 +20595,7 @@
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
         "rimraf": "^2.6.3",
-        "ssri": "^6.0.1",
+        "ssri": "^8.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
       },
@@ -25288,7 +25242,7 @@
         "node-fetch-npm": "^2.0.2",
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
-        "ssri": "^6.0.0"
+        "ssri": "^8.0.1"
       }
     },
     "makeerror": {
@@ -27870,9 +27824,7 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "8.0.1",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -41,7 +41,6 @@
     "@typescript-eslint/parser": "^4.11.1",
     "eslint": "^7.16.0",
     "jest": "^26.6.3",
-    "lerna": "^3.22.1",
     "ts-jest": "^26.4.4",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Lerna has some downstream dependancies with dependabot security issues, these packages do not yet have updates with a recent enough version of SSRI to have the correct fix in place. To work round this issue in the shorterm I have implemented [NPM Shrinkwrap](https://docs.npmjs.com/cli/v7/commands/npm-shrinkwrap) to force a higher version of SSRI.

I have also remove the dev dependancy on Lerna from within the logger module, as we are not actually using it there as far as I could tell, and tests still pass correctly without it

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-typescript/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
