### PR TITLE
chore: Disabled auto-assign-issues integration

### DIFF
--- a/.github/auto_assign-issues.yml
+++ b/.github/auto_assign-issues.yml
@@ -1,7 +1,6 @@
-addAssignees: true
+addAssignees: false
 
 # The list of users to assign to new issues.
 # If empty or not provided, the repository owner is assigned
-assignees:
-  - alan-churley
-  - saragerion
+# If addAssignees above is false the below is ignored
+assignees: ~


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

Updated the workflow file (`.github/auto_assign-issues.yml`) which should cause the workflow to do nothing.

Details on the changes can be found in this [comment](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/141#issuecomment-888163818).

<!--- Include here a summary of the change. -->
Changes:
* Set `addAssignees: false` which should cause the workflow to return early and exit.
* Set `assignees: ~` (empty list) which should anyway be ignored due to change in previous line.
<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->
The next time an issue is created it should NOT have any assignees by default.
<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
[#141](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/141)

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
