### PR TITLE
chore: Removed assignees from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -3,8 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: "(module name): short issue description"
 labels: bug, triage
-assignees: saragerion, alan-churley
-
 ---
 
 <!--- Before you start, make sure that the bug hasn't been reported already https://github.com/awslabs/aws-lambda-powertools-typescript/issues -->

--- a/.github/ISSUE_TEMPLATE/DOC_IMPROVEMENT.md
+++ b/.github/ISSUE_TEMPLATE/DOC_IMPROVEMENT.md
@@ -3,8 +3,6 @@ name: Documentation improvement
 about: Suggest a documentation update, improvement
 title: "(module name): short issue description"
 labels: documentation
-assignees: saragerion, alan-churley
-
 ---
 
 <!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -3,8 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: "(module name): short issue description"
 labels: feature-request, triage
-assignees: saragerion, alan-churley
-
 ---
 
 <!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes
Removed default assignees names from the issue templates in `.github` folder. This is a followup of PR #144, that PR addressed the workflow that runs _after_ the issue is created while this change affects the templates used to open the issues in the first place.
<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->
A new issue, opened with one of the templates should not have assignees.
<img width="421" alt="image" src="https://user-images.githubusercontent.com/7353869/127458622-5a9fd5c1-9238-4765-86b6-2fbff9d03040.png">

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
[#141](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/141)

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
