### PR TITLE
chore: Enable auto-merge for dependabot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -65,4 +65,4 @@ jobs:
               pull_number: pullNumber,
               merge_method: 'squash'
             })
-          github-token: ${{ secrets.AUTOMERGE_DEPENDABOT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

Following the discussion in [issue #126](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/126) and on Slack I have added a new workflow called `Dependabot PR auto-merge - auto-merge.yml`. 

<!--- Include here a summary of the change. -->
that should run when these conditions happen:
* [`on-pull-request` workflow](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/workflows/on-pull-request.yml) runs and completes successfully. This means that all the checks around linting, unit tests, and code coverage have passed.
* The actor of the PR was `dependabot`.

At this point the workflow identifies and downloads locally the PR artifact, after which adds a review and merges the PR.

<!--- Please include also relevant motivation and context. -->

The idea behind this workflow is to automate repetitive & undifferentiated work for maintainers. The definition of the workflow is heavily inspired by [the one used in the Java version of Powertools](https://github.com/awslabs/aws-lambda-powertools-java/blob/master/.github/workflows/auto-merge.yml).

<!--- List any dependencies that are required for this change. -->

<del>**NOTE:** This workflow relies on the existence of a repository secret called `AUTOMERGE_DEPENDABOT` that will need to be added if this PR gets merged.</del> _Changed in [88c2046](https://github.com/awslabs/aws-lambda-powertools-typescript/pull/169/commits/88c2046c24399c6b50daa849ca4d46e684e8cf95)_

More info on this [here](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#enable-auto-merge-on-a-pull-request).

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

When `dependabot` opens the next PR, if the `on-pull-request` checks are successful, this new workflow should run and merge the PR automatically.
<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->

### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
[#126](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/126)  

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [ ] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [x] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
