### PR TITLE
feat(metric): bring feature parity between decorator and utility function

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -25,7 +25,7 @@ class Metrics implements MetricsInterface {
   private isSingleMetric: boolean = false;
   private metadata: { [key: string]: string } = {};
   private namespace?: string;
-  private raiseOnEmptyMetrics: boolean = false;
+  private shouldRaiseOnEmptyMetrics: boolean = false;
   private storedMetrics: StoredMetrics = {};
 
   public constructor(options: MetricsOptions = {}) {
@@ -80,9 +80,19 @@ class Metrics implements MetricsInterface {
     this.storedMetrics = {};
   }
 
+  public captureColdStartMetric(): void {
+    this.captureColdStart();
+  }
+
+  public raiseOnEmptyMetrics(): void {
+    this.shouldRaiseOnEmptyMetrics = true;
+  }
+
   public logMetrics(options: DecoratorOptions = {}): HandlerMethodDecorator {
     const { raiseOnEmptyMetrics, defaultDimensions, captureColdStartMetric } = options;
-    this.raiseOnEmptyMetrics = raiseOnEmptyMetrics || false;
+    if (raiseOnEmptyMetrics) {
+      this.raiseOnEmptyMetrics();
+    }
     if (defaultDimensions !== undefined) {
       this.setDefaultDimensions(defaultDimensions);
     }
@@ -114,7 +124,7 @@ class Metrics implements MetricsInterface {
       Name: metricDefinition.name,
       Unit: metricDefinition.unit,
     }));
-    if (metricDefinitions.length === 0 && this.raiseOnEmptyMetrics) {
+    if (metricDefinitions.length === 0 && this.shouldRaiseOnEmptyMetrics) {
       throw new RangeError('The number of metrics recorded must be higher than zero');
     }
 


### PR DESCRIPTION
## Description of your changes

Bringing capture cold start metric and raise on empty metrics features to standard utility functions set.

### How to verify this change

Now you can call `captureColdStartMetric()` and `raiseOnEmptyMetrics()` and get same behavior as of `@metrics.logMetrics({captureColdStartMetric: true, raiseOnEmptyMetrics: true })` :

```typecsript

const metrics = new Metrics({ namespace: 'test' });

const handler = async (event: any, context: Context) => {
  metrics.captureColdStartMetric();
  metrics.raiseOnEmptyMetrics();
  // Logic goes here
  metrics.purgeStoredMetrics();
};
```



### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

## Checklist

- [X] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [X] I have performed a *self-review* of my own code
- [X] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [] I have made corresponding changes to the *documentation*
- [X] My changes generate *no new warnings*
- [X] The *code coverage* hasn't decreased
- [X] I have *added tests* that prove my change is effective and works
- [X] New and existing *unit tests pass* locally and in Github Actions
- [X] Any *dependent changes have been merged and published* in downstream module
- [X] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
