### PR TITLE
chore(docs): Add credits section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ align them with the style guides. Please run this before creating a PR, and comm
 
 `npm run lerna-format`
 
+## Credits
+
+* Structured logging initial implementation from [aws-lambda-logging](https://gitlab.com/hadrien/aws_lambda_logging)
+* Powertools idea [DAZN Powertools](https://github.com/getndazn/dazn-lambda-powertools/)
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.


### PR DESCRIPTION
## Description of your changes

Added credits section to the README file as mentioned in #303 and using the same format as [Python PowerTools repo](https://github.com/awslabs/aws-lambda-powertools-python/).

### How to verify this change
<img width="639" alt="image" src="https://user-images.githubusercontent.com/7353869/145987354-1dba58b9-1899-4789-abd1-617ff705890f.png">

Checkout branch & open `README.md` file.

### Related issues, RFCs

[#303](https://github.com/awslabs/aws-lambda-powertools-typescript/issues/303)

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] My changes generate *no new warnings*
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
