### PR TITLE
fix(cicd): skip ci on bump commit

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,6 @@
     "packages/*"
   ],
   "version": "0.2.0-beta.3",
-  "npmClient": "npm"
+  "npmClient": "npm",
+  "message": "chore(release): %s [skip ci]"
 }


### PR DESCRIPTION
## Description of your changes

Avoid infinite loop in release workflow.

Current workflow is auto bumping and releasing ALL commit to main (following conventional commit and semantic release)  as beta pre release.
But this autobump phase creates a new commit for changelog and version bump in package.json which it self was generating a new release. 

Using [skip ci] flag in commit message fix this.

### PR status

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
