### PR TITLE
fix(ci): documentation generation on on-release.yml workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   publish:
     #########################
-    # Ensure that we only a single job (with the same group) will run at a time
-    # This is to prevent "race-condition" in publishing a new version of doc to `gh-pages`
+    # Force Github action to run only a single job at a time (based on the group name)
+    # This is to prevent "race-condition" in publishing a new version of doc to `gh-pages` (#365)
     #########################
     concurrency:
       group: on-release-publish
@@ -79,8 +79,8 @@ jobs:
         mkdocs build
         mike deploy --push --update-aliases --no-redirect "$VERSION" "$ALIAS"
         # Once we have agreed on release process, we will also use "main" 
-        # to track the latest development version. For now, we make it the same
-        # as the latest version.
+        # to track the development version (on main branch). 
+        # For now, we make it the same as the latest version.
         mike deploy --push --update-aliases --no-redirect "main" "$ALIAS"
         # Set latest version as a default
         mike set-default --push latest


### PR DESCRIPTION
## Description of your changes
* Limit concurrency of "publish" job to just one to avoid concurrency issue (Issue: #365) 
* Generate "latest" alias doc instead of just redirect to the latest version (Issue: #367)
* Generate `main` version 

### How to verify this change

I've run this workflow in a feature branch. You can verify output in this site: https://awslabs.github.io/aws-lambda-powertools-typescript/latest/ 

### Related issues, RFCs

#365 
#367 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)


---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
