### PR TITLE
docs(logger): improve mkdocs and examples of sample rate feature

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -456,21 +456,26 @@ For example, by setting the "sample rate" to `0.5`, roughly 50% of your lambda i
 
 === "handler.ts"
 
-    ```typescript hl_lines="5"
+    ```typescript hl_lines="6"
     import { Logger } from "@aws-lambda-powertools/logger";
 
+    // Notice the log level set to 'ERROR'
     const logger = new Logger({
         logLevel: "ERROR",
         sampleRateValue: 0.5
     });
     
     const lambdaHandler = async () => {
-    
-        // 0.5 means that you have 50% chance that these logs will be printed
-        logger.info("This is INFO log #1");
-        logger.info("This is INFO log #2");
-        logger.info("This is INFO log #3");
-        logger.info("This is INFO log #4");
+
+        // This log item (equal to log level 'ERROR') will be printed to standard output
+        // in all Lambda invocations
+        logger.error("This is an ERROR log");
+
+        // These log items (below the log level 'ERROR') have ~50% chance 
+        // of being printed in a Lambda invocation
+        logger.debug("This is a DEBUG log that has 50% chance of being printed");
+        logger.info("This is an INFO log that has 50% chance of being printed");
+        logger.warn("This is a WARN log that has 50% chance of being printed");
         
         // Optional: refresh sample rate calculation on runtime
         // logger.refreshSampleRateCalculation();
@@ -478,20 +483,20 @@ For example, by setting the "sample rate" to `0.5`, roughly 50% of your lambda i
     };
     ```
 
-=== "Example CloudWatch Logs excerpt"
+=== "Example CloudWatch Logs excerpt - Invocation #1"
 
-    ```json hl_lines="4 12 20 28"
+    ```json
     {
-        "level": "INFO",
-        "message": "This is INFO log #1",
+        "level": "ERROR",
+        "message": "This is an ERROR log",
         "sampling_rate": "0.5",
         "service": "shopping-cart-api",
         "timestamp": "2021-12-12T22:59:06.334Z",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     {
-        "level": "INFO",
-        "message": "This is INFO log #2",
+        "level": "DEBUG",
+        "message": "This is a DEBUG log that has 50% chance of being printed",
         "sampling_rate": "0.5", 
         "service": "shopping-cart-api",
         "timestamp": "2021-12-12T22:59:06.337Z",
@@ -499,18 +504,81 @@ For example, by setting the "sample rate" to `0.5`, roughly 50% of your lambda i
     }
     {
         "level": "INFO",
-        "message": "This is INFO log #3",
+        "message": "This is an INFO log that has 50% chance of being printed",
         "sampling_rate": "0.5", 
         "service": "shopping-cart-api",
         "timestamp": "2021-12-12T22:59:06.338Z",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     {
-        "level": "INFO",
-        "message": "This is INFO log #4",
+        "level": "WARN",
+        "message": "This is a WARN log that has 50% chance of being printed",
         "sampling_rate": "0.5", 
         "service": "shopping-cart-api",
         "timestamp": "2021-12-12T22:59:06.338Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
+    }
+    ```
+
+=== "Example CloudWatch Logs excerpt - Invocation #2"
+
+    ```json
+    {
+        "level": "ERROR",
+        "message": "This is an ERROR log",
+        "sampling_rate": "0.5",
+        "service": "shopping-cart-api",
+        "timestamp": "2021-12-12T22:59:06.334Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
+    }
+    ```
+
+=== "Example CloudWatch Logs excerpt - Invocation #3"
+
+    ```json
+    {
+        "level": "ERROR",
+        "message": "This is an ERROR log",
+        "sampling_rate": "0.5",
+        "service": "shopping-cart-api",
+        "timestamp": "2021-12-12T22:59:06.334Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
+    }
+    {
+        "level": "DEBUG",
+        "message": "This is a DEBUG log that has 50% chance of being printed",
+        "sampling_rate": "0.5", 
+        "service": "shopping-cart-api",
+        "timestamp": "2021-12-12T22:59:06.337Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
+    }
+    {
+        "level": "INFO",
+        "message": "This is an INFO log that has 50% chance of being printed",
+        "sampling_rate": "0.5", 
+        "service": "shopping-cart-api",
+        "timestamp": "2021-12-12T22:59:06.338Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
+    }
+    {
+        "level": "WARN",
+        "message": "This is a WARN log that has 50% chance of being printed",
+        "sampling_rate": "0.5", 
+        "service": "shopping-cart-api",
+        "timestamp": "2021-12-12T22:59:06.338Z",
+        "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
+    }
+    ```
+
+=== "Example CloudWatch Logs excerpt - Invocation #4"
+
+    ```json
+    {
+        "level": "ERROR",
+        "message": "This is an ERROR log",
+        "sampling_rate": "0.5",
+        "service": "shopping-cart-api",
+        "timestamp": "2021-12-12T22:59:06.334Z",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     ```

--- a/packages/logger/examples/sample-rate.ts
+++ b/packages/logger/examples/sample-rate.ts
@@ -2,7 +2,7 @@
 require('./../tests/helpers/populateEnvironmentVariables');
 
 // Additional runtime variables
-process.env.LOG_LEVEL = 'WARN';
+process.env.LOG_LEVEL = 'ERROR';
 process.env.POWERTOOLS_SERVICE_NAME = 'hello-world';
 process.env.POWERTOOLS_LOGGER_SAMPLE_RATE = '0.5';
 
@@ -15,13 +15,18 @@ const logger = new Logger();
 
 const lambdaHandler: Handler = async () => {
 
-  logger.info('This is INFO log #1');
-  logger.info('This is INFO log #2');
-  logger.info('This is INFO log #3');
-  logger.info('This is INFO log #4');
+  // This log item (equal to log level 'ERROR') will be printed to standard output
+  // in all Lambda invocations
+  logger.error('This is an ERROR log');
 
-  // Refresh sample rate calculation on runtime
-  logger.refreshSampleRateCalculation();
+  // These log items (below the log level 'ERROR') have ~50% chance
+  // of being printed in a Lambda invocation
+  logger.debug('This is a DEBUG log that has 50% chance of being printed');
+  logger.info('This is an INFO log that has 50% chance of being printed');
+  logger.warn('This is a WARN log that has 50% chance of being printed');
+
+  // Optional: refresh sample rate calculation on runtime
+  // logger.refreshSampleRateCalculation();
 
   return {
     foo: 'bar'


### PR DESCRIPTION
<!--- 1. Make sure you follow our Contributing Guidelines: https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/CONTRIBUTING.md -->
<!--- 2. Please follow the template, and do not remove any section in the template. If something is not applicable leave it empty, but leave it in the PR. -->

## Description of your changes

The current version of the docs related to sample rate might be confusing and misleading, as they don't clarify the expected behaviour enough.

This PR includes some updates to mkdocs and examples of sample rate feature to clarify the feature and its behaviour.

<!--- Include here a summary of the change. -->

<!--- Please include also relevant motivation and context. -->

<!--- List any dependencies that are required for this change. -->

<!--- If this PR is part of a sequence of related PRs or TODOs, list the high level TODO items. -->

### How to verify this change

<!--- Add any applicable config, projects, screenshots or other resources -->
<!--- that can help us verify your changes. -->

You can build and start a local docs website by running these two commands.

`npm run docs-buildDockerImage` OR `docker build -t squidfunk/mkdocs-material ./docs/`
`npm run docs-runLocalDocker` OR `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`

Verify: http://0.0.0.0:8000/core/logger/#sampling-logs

<!--- Examples: -->
<!--- Screenshots, cloud configuration, anything helping us evaluate better. -->
![Screenshot 2022-01-03 at 19 29 55](https://user-images.githubusercontent.com/47529391/147966325-8c0660d7-81cf-4779-852d-6eb3c809952b.png)
![Screenshot 2022-01-03 at 19 30 04](https://user-images.githubusercontent.com/47529391/147966323-f1150d1a-9ae9-4d40-981c-be9607fd92ee.png)
![Screenshot 2022-01-03 at 19 30 26](https://user-images.githubusercontent.com/47529391/147966319-db8e9c15-16d2-4e78-bfd2-65534ac5bcab.png)


### Related issues, RFCs

<!--- Add here the link to one or more Github Issues or RFCs that are related to this PR. -->
#388 

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
