### PR TITLE
feat(commons): update types to have optional callback

### DIFF
--- a/packages/commons/src/utils/lambda/LambdaInterface.ts
+++ b/packages/commons/src/utils/lambda/LambdaInterface.ts
@@ -1,9 +1,20 @@
 import { Handler } from 'aws-lambda';
 
+export type SyncHandler<T extends Handler> = (
+  event: Parameters<T>[0],
+  context: Parameters<T>[1],
+  callback: Parameters<T>[2],
+) => void;
+
+export type AsyncHandler<T extends Handler> = (
+  event: Parameters<T>[0],
+  context: Parameters<T>[1],
+) => Promise<NonNullable<Parameters<Parameters<T>[2]>[1]>>;
+
 interface LambdaInterface {
-  handler: Handler
+  handler: SyncHandler<Handler> | AsyncHandler<Handler>
 }
 
 export {
-  LambdaInterface,
+  LambdaInterface
 };

--- a/packages/commons/tests/unit/LambdaInterface.test.ts
+++ b/packages/commons/tests/unit/LambdaInterface.test.ts
@@ -1,23 +1,128 @@
+import { Handler } from 'aws-lambda';
 import { Callback, Context } from 'aws-lambda';
-import { ContextExamples, LambdaInterface } from '../../src';
+import { ContextExamples, SyncHandler, AsyncHandler, LambdaInterface } from '../../src';
 
-describe('LambdaInterface', () => {
-  test('it compiles', async () => {
+describe('LambdaInterface with arrow function', () => {
+  test('it compiles when given a callback', async () => {
     class LambdaFunction implements LambdaInterface {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      public handler<TEvent, TResult>(
-        _event: TEvent,
-        context: Context,
-        _callback: Callback<TResult>,
-      ): void | Promise<TResult> {
+
+      public handler: SyncHandler<Handler> = async (_event: unknown, context: Context, _callback: Callback) => {
         context.done();
         context.fail(new Error('test Error'));
         context.succeed('test succeed');
         context.getRemainingTimeInMillis();
+        _callback(null, 'Hello World');
+      };
+    }
+
+    await new LambdaFunction().handler({}, ContextExamples.helloworldContext, () => console.log('Lambda invoked!'));
+  });
+
+  test('it compiles when not given a callback', async () => {
+    class LambdaFunction implements LambdaInterface {
+
+      public handler: AsyncHandler<Handler> = async (_event: unknown, context: Context) => {
+        context.getRemainingTimeInMillis();
+      };
+    }
+
+    await new LambdaFunction().handler({}, ContextExamples.helloworldContext);
+  });
+});
+
+describe('LambdaInterface with standard function', () => {
+  test('it compiles when given a callback', async () => {
+    class LambdaFunction implements LambdaInterface {
+
+      public handler(_event: unknown, context: Context, _callback: Callback): void {
+        context.getRemainingTimeInMillis();
+        _callback(null, 'Hello World');
       }
     }
 
     await new LambdaFunction().handler({}, ContextExamples.helloworldContext, () => console.log('Lambda invoked!'));
+  });
+
+  test('it compiles when not given a callback', async () => {
+    class LambdaFunction implements LambdaInterface {
+
+      public async handler (_event: unknown, context: Context): Promise<string> {
+        context.getRemainingTimeInMillis();
+        
+        return new Promise((resolve) => {
+          resolve('test promise');
+        });
+      }
+    }
+
+    await new LambdaFunction().handler({}, ContextExamples.helloworldContext);
+  });
+
+});
+
+describe('LambdaInterface with decorator', () => {
+  type HandlerMethodDecorator = (
+    target: LambdaInterface,
+    propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<SyncHandler<Handler>> | TypedPropertyDescriptor<AsyncHandler<Handler>>
+  ) => void;
+
+  class DummyModule {
+
+    public dummyDecorator(): HandlerMethodDecorator {
+      return (target, _propertyKey, descriptor) => {
+        const originalMethod = descriptor.value;
+  
+        descriptor.value = ( async (event, context, callback) => {
+            
+          let result: unknown;
+          try {
+            console.log(`Invoking ${String(_propertyKey)}`);
+            result = await originalMethod?.apply(this, [ event, context, callback ]);
+            console.log(`Invoked ${String(_propertyKey)}`);
+          } catch (error) {
+            throw error;
+          } finally {
+            console.log(`Finally from decorator`);
+          }
+            
+          return result;
+        });
+  
+        return descriptor;
+      };
+    }
+  }
+
+  const dummyModule = new DummyModule();
+
+  test('decorator without callback compile', async () => {
+
+    // WHEN
+    class LambdaFunction implements LambdaInterface {
+      
+      @dummyModule.dummyDecorator()
+      public async handler(_event: unknown, context: Context): Promise<unknown> {
+        context.getRemainingTimeInMillis();
+        
+        return 'test';
+      }
+    }
+
+    await new LambdaFunction().handler({}, ContextExamples.helloworldContext); 
+  });
+
+  test('decorator with callback compile', async () => {
+
+    // WHEN
+    class LambdaFunction implements LambdaInterface {
+      
+      @dummyModule.dummyDecorator()
+      public handler(_event: unknown, context: Context, _callback: Callback): void {
+        context.getRemainingTimeInMillis();
+      }
+    }
+
+    await new LambdaFunction().handler({}, ContextExamples.helloworldContext, () => console.log('Lambda invoked!')); 
   });
 });


### PR DESCRIPTION
## Description of your changes

Following discussions made here: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/38342#issuecomment-576021035 and the proposed solution made here: https://www.npmjs.com/package/aws-lambda-consumer , this PR enable to specify lambda handlers with or without callback depending on if it's a sync or async call.

### How to verify this change

```
cd packages/commons
npm run test
```

Also tested against Metrics decorator . PR will follw

### Related issues, RFCs

#381

### PR status

***Is this ready for review?:*** YES 
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] My changes generate *no new warnings*
- [ ] The *code coverage* hasn't decreased
- [ ] I have *added tests* that prove my change is effective and works
- [ ] New and existing *unit tests pass* locally and in Github Actions
- [ ] Any *dependent changes have been merged and published* in downstream module
- [ ] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
