### PR TITLE
docs(all): do not generate main version

### DIFF
--- a/.github/workflows/on-release-prod.yml
+++ b/.github/workflows/on-release-prod.yml
@@ -70,10 +70,6 @@ jobs:
         echo "Publishing doc for version: $VERSION"
         mkdocs build
         mike deploy --push --update-aliases --no-redirect "$VERSION" "$ALIAS"
-        # Once we have agreed on release process, we will also use "main" 
-        # to track the development version (on main branch). 
-        # For now, we make it the same as the latest version.
-        mike deploy --push --update-aliases --no-redirect "main" "$ALIAS"
         # Set latest version as a default
         mike set-default --push latest
     - name: Build API docs


### PR DESCRIPTION
## Description of your changes
We are generating `dev` version in `on-merge-to-main.yml`.  

This part of the script isn't needed anymore as we agree to use `dev` version instead of `main`.  The current code is also in the wrong place (in `on-release-prod.yml`). This will cause us to generate `main` every time we release.

### How to verify this change
Rerun release workflow manually!  So we can't test it. But the change is simple enough to be safe.

### Related issues, RFCs
N/A

### PR status

***Is this ready for review?:*** YES  
***Is it a breaking change?:*** NO

## Checklist

- [x] [My changes meet the tenets criteria](https://awslabs.github.io/aws-lambda-powertools-python/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] The *code coverage* hasn't decreased
- [x] I have *added tests* that prove my change is effective and works
- [x] New and existing *unit tests pass* locally and in Github Actions
- [x] Any *dependent changes have been merged and published* in downstream module
- [x] The PR title follows the [conventional commit semantics](https://github.com/awslabs/aws-lambda-powertools-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
