### PR TITLE
chore(docs): temporarily override publish branch for docs

### DIFF
--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -78,9 +78,9 @@ jobs:
         run: |
           rm -rf site
           mkdocs build
-          mike deploy --push --update-aliases --no-redirect ${{ env.VERSION }} ${{ env.ALIAS }}
+          mike deploy --push --update-aliases --no-redirect ${{ env.VERSION }} ${{ env.ALIAS }} --branch backup-gh-pages
           # Set latest version as a default
-          mike set-default --push latest
+          mike set-default --push latest --branch backup-gh-pages
       - name: Build API docs
         run: |
           rm -rf api
@@ -92,6 +92,7 @@ jobs:
           publish_dir: ./api
           keep_files: true
           destination_dir: ${{ env.VERSION }}/api
+          publish_branch: 'backup-gh-pages'
       - name: Release API docs to latest
         if: ${{ inputs.alias == 'latest' }}
         uses: peaceiris/actions-gh-pages@bd8c6b06eba6b3d25d72b7a1767993c0aeee42e7 # v3.9.2
@@ -100,6 +101,7 @@ jobs:
           publish_dir: ./api
           keep_files: true
           destination_dir: latest/api
+          publish_branch: 'backup-gh-pages'
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
         with:


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

After the migration of the repo to the new org started in #1475, the idea is to remove GitHub Pages as destination. This is tracked in #1509. In the meanwhile, in order to avoid being unable to publish docs, I am overriding the configs related to GitHub Pages to be able to publish to the current branch designated for the docs (`backup-gh-pages`).

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1509

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.