### PR TITLE
feat(parameters): review types and exports

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -4,3 +4,4 @@ export * from './config';
 export * as ContextExamples from './samples/resources/contexts';
 export * as Events from './samples/resources/events';
 export * from './types/middy';
+export * from './types/utils';

--- a/packages/commons/src/types/utils.ts
+++ b/packages/commons/src/types/utils.ts
@@ -32,12 +32,29 @@ const isTruthy = (value: unknown): boolean => {
   }
 };
 
+/**
+ * TODO: write docs for isNullOrUndefined()
+ * @param value
+ * @returns
+ */
 const isNullOrUndefined = (value: unknown): value is null | undefined => {
   return Object.is(value, null) || Object.is(value, undefined);
 };
 
+/**
+ * TODO: write docs for isString()
+ * @param value
+ * @returns
+ */
 const isString = (value: unknown): value is string => {
   return typeof value === 'string';
 };
 
 export { isRecord, isString, isTruthy, isNullOrUndefined };
+
+type JSONPrimitive = string | number | boolean | null | undefined;
+type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+type JSONObject = { [key: string]: JSONValue };
+type JSONArray = Array<JSONValue>;
+
+export type { JSONPrimitive, JSONValue, JSONObject, JSONArray };

--- a/packages/commons/src/types/utils.ts
+++ b/packages/commons/src/types/utils.ts
@@ -1,8 +1,7 @@
 /**
- * TODO: write docs for isRecord() type guard
+ * Returns true if the passed value is a record (object).
  *
  * @param value
- * @returns
  */
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return (
@@ -12,9 +11,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> => {
 };
 
 /**
- * TODO: write docs for isTruthy()
+ * Returns true if the passed value is truthy.
+ *
  * @param value
- * @returns
  */
 const isTruthy = (value: unknown): boolean => {
   if (typeof value === 'string') {
@@ -28,21 +27,21 @@ const isTruthy = (value: unknown): boolean => {
   } else if (isRecord(value)) {
     return Object.keys(value).length > 0;
   } else {
-    return Object.is(value, true);
+    return false;
   }
 };
 
 /**
- * TODO: write docs for isNullOrUndefined()
+ * Returns true if the passed value is null or undefined.
+ *
  * @param value
- * @returns
  */
 const isNullOrUndefined = (value: unknown): value is null | undefined => {
   return Object.is(value, null) || Object.is(value, undefined);
 };
 
 /**
- * TODO: write docs for isString()
+ * Returns true if the passed value is a string.
  * @param value
  * @returns
  */

--- a/packages/commons/tests/unit/utils.test.ts
+++ b/packages/commons/tests/unit/utils.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Test utils functions
+ *
+ * @group unit/commons/utils
+ */
+import {
+  isRecord,
+  isTruthy,
+  isNullOrUndefined,
+  isString,
+} from '../../src/types/utils';
+
+describe('Functions: utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  describe('Function: isRecord', () => {
+    it('returns true when the passed object is a Record', () => {
+      // Prepare
+      const obj = { a: 1, b: 2, c: 3 };
+
+      // Act
+      const result = isRecord(obj);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the passed object is not a Record', () => {
+      // Prepare
+      const obj = [1, 2, 3];
+
+      // Act
+      const result = isRecord(obj);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Function: isTruthy', () => {
+    it.each(['hello', 1, true, [1], { foo: 1 }])(
+      'returns true when the passed value is truthy',
+      (testValue) => {
+        // Prepare
+        const value = testValue;
+
+        // Act
+        const result = isTruthy(value);
+
+        // Assert
+        expect(result).toBe(true);
+      }
+    );
+
+    it.each(['', 0, false, [], {}, Symbol])(
+      'returns true when the passed value is falsy',
+      (testValue) => {
+        // Prepare
+        const value = testValue;
+
+        // Act
+        const result = isTruthy(value);
+
+        // Assert
+        expect(result).toBe(false);
+      }
+    );
+  });
+
+  describe('Function: isNullOrUndefined', () => {
+    it('returns true when the passed value is null or undefined', () => {
+      // Prepare
+      const value = undefined;
+
+      // Act
+      const result = isNullOrUndefined(value);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the passed value is not null or undefined', () => {
+      // Prepare
+      const value = 'hello';
+
+      // Act
+      const result = isNullOrUndefined(value);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('Function: isString', () => {
+    it('returns true when the passed value is a string', () => {
+      // Prepare
+      const value = 'hello';
+
+      // Act
+      const result = isString(value);
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the passed value is not a string', () => {
+      // Prepare
+      const value = 123;
+
+      // Act
+      const result = isString(value);
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -35,21 +35,41 @@
       "import": "./lib/index.js",
       "require": "./lib/index.js"
     },
+    "./base/types": {
+      "import": "./lib/types/BaseProvider.d.ts",
+      "require": "./lib/types/BaseProvider.d.ts"
+    },
     "./base": {
       "import": "./lib/base/index.js",
       "require": "./lib/base/index.js"
+    },
+    "./ssm/types": {
+      "import": "./lib/types/SSMProvider.d.ts",
+      "require": "./lib/types/SSMProvider.d.ts"
     },
     "./ssm": {
       "import": "./lib/ssm/index.js",
       "require": "./lib/ssm/index.js"
     },
+    "./secrets/types": {
+      "import": "./lib/types/SecretsProvider.d.ts",
+      "require": "./lib/types/SecretsProvider.d.ts"
+    },
     "./secrets": {
       "import": "./lib/secrets/index.js",
       "require": "./lib/secrets/index.js"
     },
+    "./dynamodb/types": {
+      "import": "./lib/types/AppConfigProvider.d.ts",
+      "require": "./lib/types/AppConfigProvider.d.ts"
+    },
     "./dynamodb": {
       "import": "./lib/dynamodb/index.js",
       "require": "./lib/dynamodb/index.js"
+    },
+    "./appconfig/types": {
+      "import": "./lib/appconfig/index.js",
+      "require": "./lib/appconfig/index.js"
     },
     "./appconfig": {
       "import": "./lib/appconfig/index.js",
@@ -58,34 +78,42 @@
     "./errors": {
       "import": "./lib/errors.js",
       "require": "./lib/errors.js"
-    },
-    "./types": {
-      "import": "./lib/types/index.d.ts",
-      "require": "./lib/types/index.d.ts"
     }
   },
   "typesVersions": {
     "*": {
+      "base/types": [
+        "lib/types/BaseProvider.d.ts"
+      ],
       "base": [
         "lib/base/index.d.ts"
+      ],
+      "ssm/types": [
+        "lib/types/SSMProvider.d.ts"
       ],
       "ssm": [
         "lib/ssm/index.d.ts"
       ],
+      "secrets/types": [
+        "lib/types/SecretsProvider.d.ts"
+      ],
       "secrets": [
         "lib/secrets/index.d.ts"
       ],
+      "dynamodb/types": [
+        "./lib/types/DynamoDBProvider.d.ts"
+      ],
       "dynamodb": [
         "lib/dynamodb/index.d.ts"
+      ],
+      "appconfig/types": [
+        "./lib/types/AppConfigProvider.d.ts"
       ],
       "appconfig": [
         "lib/appconfig/index.d.ts"
       ],
       "errors": [
-        "lib/Exceptions.d.ts"
-      ],
-      "types": [
-        "lib/types/index.d.ts"
+        "lib/errors.d.ts"
       ]
     }
   },

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -10,7 +10,8 @@
     "access": "public"
   },
   "scripts": {
-    "test": "npm run test:unit",
+    "test": "npm run stuff",
+    "stuff": "jest --group=unit/parameters/DynamoDBProvider/class --detectOpenHandles --verbose",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
     "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",
@@ -55,8 +56,8 @@
       "require": "./lib/appconfig/index.js"
     },
     "./errors": {
-      "import": "./lib/Exceptions.js",
-      "require": "./lib/Exceptions.js"
+      "import": "./lib/errors.js",
+      "require": "./lib/errors.js"
     },
     "./types": {
       "import": "./lib/types/index.d.ts",

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -10,8 +10,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "npm run stuff",
-    "stuff": "jest --group=unit/parameters/DynamoDBProvider/class --detectOpenHandles --verbose",
+    "test": "npm run test:unit",
     "test:unit": "jest --group=unit --detectOpenHandles --coverage --verbose",
     "test:e2e:nodejs14x": "RUNTIME=nodejs14x jest --group=e2e",
     "test:e2e:nodejs16x": "RUNTIME=nodejs16x jest --group=e2e",

--- a/packages/parameters/src/BaseProvider.ts
+++ b/packages/parameters/src/BaseProvider.ts
@@ -1,4 +1,4 @@
-import { isNullOrUndefined, isString } from './utils';
+import { isNullOrUndefined, isRecord, isString } from './utils';
 import { isUint8Array } from 'node:util/types';
 import { fromBase64 } from '@aws-sdk/util-base64-node';
 import { GetOptions } from './GetOptions';
@@ -121,9 +121,14 @@ abstract class BaseProvider implements BaseProviderInterface {
       return this.store.get(key)!.value as Record<string, unknown>;
     }
 
-    let values: Record<string, unknown> = {};
+    let values;
     try {
       values = await this._getMultiple(path, options);
+      if (!isRecord(values)) {
+        throw new GetParameterError(
+          `Expected result to be a Record<string, unknown> but got ${typeof values}`
+        );
+      }
     } catch (error) {
       throw new GetParameterError((error as Error).message);
     }
@@ -186,7 +191,7 @@ abstract class BaseProvider implements BaseProviderInterface {
   protected abstract _getMultiple(
     path: string,
     options?: unknown
-  ): Promise<Record<string, unknown>>;
+  ): Promise<Record<string, unknown> | void>;
 }
 
 /**

--- a/packages/parameters/src/ExpirableValue.ts
+++ b/packages/parameters/src/ExpirableValue.ts
@@ -8,17 +8,14 @@ import type { ExpirableValueInterface } from './types';
  */
 class ExpirableValue implements ExpirableValueInterface {
   public ttl: number;
-  public value: string | Uint8Array | Record<string, unknown>;
+  public value: unknown;
 
   /**
    *
    * @param value - Value to be cached
    * @param maxAge - Maximum age in seconds for the value to be cached
    */
-  public constructor(
-    value: string | Uint8Array | Record<string, unknown>,
-    maxAge: number
-  ) {
+  public constructor(value: unknown, maxAge: number) {
     this.value = value;
     const timeNow = new Date();
     this.ttl = timeNow.setSeconds(timeNow.getSeconds() + maxAge);

--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -7,7 +7,8 @@ import {
 import type { StartConfigurationSessionCommandInput } from '@aws-sdk/client-appconfigdata';
 import type {
   AppConfigProviderOptions,
-  AppConfigGetOptionsInterface,
+  AppConfigGetOptions,
+  AppConfigGetOutput,
 } from '../types/AppConfigProvider';
 
 /**
@@ -31,7 +32,10 @@ import type {
  * ```typescript
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
- * const configProvider = new AppConfigProvider();
+ * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
+ * });
  *
  * export const handler = async (): Promise<void> => {
  *   // Retrieve a configuration profile
@@ -52,7 +56,10 @@ import type {
  * ```typescript
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
- * const configProvider = new AppConfigProvider();
+ * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
+ * });
  *
  * export const handler = async (): Promise<void> => {
  *   // Retrieve a configuration profile and cache it for 10 seconds
@@ -67,7 +74,10 @@ import type {
  * ```typescript
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
- * const configProvider = new AppConfigProvider();
+ * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
+ * });
  *
  * export const handler = async (): Promise<void> => {
  *   // Retrieve a config and always fetch the latest value
@@ -84,7 +94,10 @@ import type {
  * ```typescript
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
- * const configProvider = new AppConfigProvider();
+ * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
+ * });
  *
  * export const handler = async (): Promise<void> => {
  *   // Retrieve a JSON config or Feature Flag and parse it as JSON
@@ -98,7 +111,10 @@ import type {
  * ```typescript
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
- * const configProvider = new AppConfigProvider();
+ * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
+ * });
  *
  * export const handler = async (): Promise<void> => {
  *   // Retrieve a base64-encoded string and decode it
@@ -114,7 +130,10 @@ import type {
  * ```typescript
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
- * const configProvider = new AppConfigProvider();
+ * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
+ * });
  *
  * export const handler = async (): Promise<void> => {
  *   // Retrieve a config and pass extra options to the AWS SDK v3 for JavaScript client
@@ -140,6 +159,8 @@ import type {
  * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
  *
  * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
  *   clientConfig: { region: 'eu-west-1' },
  * });
  * ```
@@ -155,6 +176,8 @@ import type {
  *
  * const client = new AppConfigDataClient({ region: 'eu-west-1' });
  * const configProvider = new AppConfigProvider({
+ *   application: 'my-app',
+ *   environment: 'prod',
  *   awsSdkV3Client: client,
  * });
  * ```
@@ -204,7 +227,10 @@ class AppConfigProvider extends BaseProvider {
    * ```typescript
    * import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
    *
-   * const configProvider = new AppConfigProvider();
+   * const configProvider = new AppConfigProvider({
+   *   application: 'my-app',
+   *   environment: 'prod',
+   * });
    *
    * export const handler = async (): Promise<void> => {
    *   // Retrieve a configuration profile
@@ -222,35 +248,43 @@ class AppConfigProvider extends BaseProvider {
    * For usage examples check {@link AppConfigProvider}.
    *
    * @param {string} name - The name of the configuration profile or its ID
-   * @param {GetAppConfigCombinedInterface} options - Options to configure the provider
+   * @param {AppConfigGetOptions} options - Options to configure the provider
    * @see https://docs.powertools.aws.dev/lambda-typescript/latest/utilities/parameters/
    */
-  public async get(
+  public async get<
+    ExplicitUserProvidedType = undefined,
+    InferredFromOptionsType extends
+      | AppConfigGetOptions
+      | undefined = AppConfigGetOptions
+  >(
     name: string,
-    options?: AppConfigGetOptionsInterface
-  ): Promise<undefined | string | Uint8Array | Record<string, unknown>> {
-    return super.get(name, options);
+    options?: InferredFromOptionsType & AppConfigGetOptions
+  ): Promise<
+    | AppConfigGetOutput<ExplicitUserProvidedType, InferredFromOptionsType>
+    | undefined
+  > {
+    return super.get(name, options) as Promise<
+      | AppConfigGetOutput<ExplicitUserProvidedType, InferredFromOptionsType>
+      | undefined
+    >;
   }
 
   /**
    * Retrieving multiple configurations is not supported by AWS AppConfig.
    */
-  public async getMultiple(
-    path: string,
-    _options?: unknown
-  ): Promise<undefined | Record<string, unknown>> {
-    return super.getMultiple(path);
+  public async getMultiple(path: string, _options?: unknown): Promise<void> {
+    await super.getMultiple(path);
   }
 
   /**
    * Retrieve a configuration from AWS AppConfig.
    *
    * @param {string} name - Name of the configuration or its ID
-   * @param {AppConfigGetOptionsInterface} options - SDK options to propagate to `StartConfigurationSession` API call
+   * @param {AppConfigGetOptions} options - SDK options to propagate to `StartConfigurationSession` API call
    */
   protected async _get(
     name: string,
-    options?: AppConfigGetOptionsInterface
+    options?: AppConfigGetOptions
   ): Promise<Uint8Array | undefined> {
     /**
      * The new AppConfig APIs require two API calls to return the configuration
@@ -321,7 +355,7 @@ class AppConfigProvider extends BaseProvider {
   protected async _getMultiple(
     _path: string,
     _sdkOptions?: unknown
-  ): Promise<Record<string, string | undefined>> {
+  ): Promise<void> {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -1,4 +1,4 @@
-import { BaseProvider, DEFAULT_PROVIDERS } from '../BaseProvider';
+import { BaseProvider, DEFAULT_PROVIDERS } from '../base';
 import {
   AppConfigDataClient,
   StartConfigurationSessionCommand,

--- a/packages/parameters/src/base/BaseProvider.ts
+++ b/packages/parameters/src/base/BaseProvider.ts
@@ -1,22 +1,20 @@
-import { isNullOrUndefined, isRecord, isString } from './utils';
+import {
+  isNullOrUndefined,
+  isRecord,
+  isString,
+} from '@aws-lambda-powertools/commons';
 import { isUint8Array } from 'node:util/types';
-import { fromBase64 } from '@aws-sdk/util-base64-node';
 import { GetOptions } from './GetOptions';
 import { GetMultipleOptions } from './GetMultipleOptions';
 import { ExpirableValue } from './ExpirableValue';
-import { TRANSFORM_METHOD_BINARY, TRANSFORM_METHOD_JSON } from './constants';
-import { GetParameterError, TransformParameterError } from './Exceptions';
-import { EnvironmentVariablesService } from './config/EnvironmentVariablesService';
+import { GetParameterError, TransformParameterError } from '../errors';
+import { EnvironmentVariablesService } from '../config/EnvironmentVariablesService';
+import { transformValue } from './transformValue';
 import type {
   BaseProviderInterface,
   GetMultipleOptionsInterface,
   GetOptionsInterface,
-  JSONValue,
-  TransformOptions,
-} from './types';
-
-// These providers are dinamycally intialized on first use of the helper functions
-const DEFAULT_PROVIDERS: Record<string, BaseProvider> = {};
+} from '../types';
 
 /**
  * Base class for all providers.
@@ -194,69 +192,4 @@ abstract class BaseProvider implements BaseProviderInterface {
   ): Promise<Record<string, unknown> | void>;
 }
 
-/**
- * Utility function to transform a value.
- *
- * It supports JSON and binary transformations, as well as an 'auto' mode that will try to transform the value based on the key.
- *
- * @param {string | Uint8Array} value - Value to be transformed
- * @param {TransformOptions} transform - Transform to be applied, can be 'json', 'binary', or 'auto'
- * @param {boolean} throwOnTransformError - Whether to throw an error if the transformation fails, when transforming multiple values this can be set to false
- * @param {string} key - Key of the value to be transformed, used to determine the transformation method when using 'auto'
- */
-const transformValue = (
-  value: string | Uint8Array,
-  transform: TransformOptions,
-  throwOnTransformError: boolean,
-  key: string
-): string | JSONValue | Uint8Array | undefined => {
-  try {
-    const normalizedTransform = transform.toLowerCase();
-
-    if (
-      (normalizedTransform === TRANSFORM_METHOD_JSON ||
-        (normalizedTransform === 'auto' &&
-          key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_JSON}`))) &&
-      isString(value)
-    ) {
-      return JSON.parse(value) as JSONValue;
-    } else if (
-      (normalizedTransform === TRANSFORM_METHOD_BINARY ||
-        (normalizedTransform === 'auto' &&
-          key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_BINARY}`))) &&
-      (isString(value) || isUint8Array(value))
-    ) {
-      if (value instanceof Uint8Array) {
-        value = new TextDecoder('utf-8').decode(value);
-      }
-
-      return new TextDecoder('utf-8').decode(fromBase64(value));
-    } else {
-      return value;
-    }
-  } catch (error) {
-    if (throwOnTransformError)
-      throw new TransformParameterError(transform, (error as Error).message);
-
-    return;
-  }
-};
-
-/**
- * Utility function to clear all the caches of the default providers.
- *
- * This is useful when you want to clear the cache of all the providers at once, for example during testing.
- */
-const clearCaches = (): void => {
-  for (const provider of Object.values(DEFAULT_PROVIDERS)) {
-    provider.clearCache();
-  }
-};
-
-export {
-  BaseProvider,
-  ExpirableValue,
-  transformValue,
-  DEFAULT_PROVIDERS,
-  clearCaches,
-};
+export { BaseProvider };

--- a/packages/parameters/src/base/BaseProvider.ts
+++ b/packages/parameters/src/base/BaseProvider.ts
@@ -14,7 +14,7 @@ import type {
   BaseProviderInterface,
   GetMultipleOptionsInterface,
   GetOptionsInterface,
-} from '../types';
+} from '../types/BaseProvider';
 
 /**
  * Base class for all providers.

--- a/packages/parameters/src/base/BaseProvider.ts
+++ b/packages/parameters/src/base/BaseProvider.ts
@@ -3,7 +3,6 @@ import {
   isRecord,
   isString,
 } from '@aws-lambda-powertools/commons';
-import { isUint8Array } from 'node:util/types';
 import { GetOptions } from './GetOptions';
 import { GetMultipleOptions } from './GetMultipleOptions';
 import { ExpirableValue } from './ExpirableValue';
@@ -86,7 +85,10 @@ abstract class BaseProvider implements BaseProviderInterface {
 
       if (isNullOrUndefined(value)) return undefined;
 
-      if (configs.transform && (isString(value) || isUint8Array(value))) {
+      if (
+        configs.transform &&
+        (isString(value) || value instanceof Uint8Array)
+      ) {
         value = transformValue(value, configs.transform, true, name);
       }
 
@@ -133,7 +135,8 @@ abstract class BaseProvider implements BaseProviderInterface {
 
     if (configs.transform) {
       for (const [entryKey, entryValue] of Object.entries(values)) {
-        if (!(isString(entryValue) || isUint8Array(entryValue))) continue;
+        if (!(isString(entryValue) || entryValue instanceof Uint8Array))
+          continue;
         try {
           values[entryKey] = transformValue(
             entryValue,

--- a/packages/parameters/src/base/DefaultProviders.ts
+++ b/packages/parameters/src/base/DefaultProviders.ts
@@ -1,0 +1,17 @@
+import type { BaseProviderInterface } from '../types/BaseProvider';
+
+// These providers are dinamycally intialized on first use of the helper functions
+const DEFAULT_PROVIDERS: Record<string, BaseProviderInterface> = {};
+
+/**
+ * Utility function to clear all the caches of the default providers.
+ *
+ * This is useful when you want to clear the cache of all the providers at once, for example during testing.
+ */
+const clearCaches = (): void => {
+  for (const provider of Object.values(DEFAULT_PROVIDERS)) {
+    provider.clearCache();
+  }
+};
+
+export { DEFAULT_PROVIDERS, clearCaches };

--- a/packages/parameters/src/base/DefaultProviders.ts
+++ b/packages/parameters/src/base/DefaultProviders.ts
@@ -10,7 +10,9 @@ const DEFAULT_PROVIDERS: Record<string, BaseProviderInterface> = {};
  */
 const clearCaches = (): void => {
   for (const provider of Object.values(DEFAULT_PROVIDERS)) {
-    provider.clearCache();
+    if (provider.clearCache) {
+      provider.clearCache();
+    }
   }
 };
 

--- a/packages/parameters/src/base/ExpirableValue.ts
+++ b/packages/parameters/src/base/ExpirableValue.ts
@@ -1,4 +1,4 @@
-import type { ExpirableValueInterface } from './types';
+import type { ExpirableValueInterface } from '../types';
 
 /**
  * Class to represent a value that can expire.

--- a/packages/parameters/src/base/ExpirableValue.ts
+++ b/packages/parameters/src/base/ExpirableValue.ts
@@ -1,4 +1,4 @@
-import type { ExpirableValueInterface } from '../types';
+import type { ExpirableValueInterface } from '../types/BaseProvider';
 
 /**
  * Class to represent a value that can expire.

--- a/packages/parameters/src/base/GetMultipleOptions.ts
+++ b/packages/parameters/src/base/GetMultipleOptions.ts
@@ -1,6 +1,6 @@
 import { GetOptions } from './GetOptions';
 import { EnvironmentVariablesService } from '../config/EnvironmentVariablesService';
-import type { GetMultipleOptionsInterface } from '../types';
+import type { GetMultipleOptionsInterface } from '../types/BaseProvider';
 
 /**
  * Options for the `getMultiple` method.

--- a/packages/parameters/src/base/GetMultipleOptions.ts
+++ b/packages/parameters/src/base/GetMultipleOptions.ts
@@ -1,6 +1,6 @@
 import { GetOptions } from './GetOptions';
-import { EnvironmentVariablesService } from './config/EnvironmentVariablesService';
-import type { GetMultipleOptionsInterface } from './types';
+import { EnvironmentVariablesService } from '../config/EnvironmentVariablesService';
+import type { GetMultipleOptionsInterface } from '../types';
 
 /**
  * Options for the `getMultiple` method.

--- a/packages/parameters/src/base/GetOptions.ts
+++ b/packages/parameters/src/base/GetOptions.ts
@@ -1,6 +1,9 @@
-import { DEFAULT_MAX_AGE_SECS } from '../constants';
 import { EnvironmentVariablesService } from '../config/EnvironmentVariablesService';
-import type { GetOptionsInterface, TransformOptions } from '../types';
+import { DEFAULT_MAX_AGE_SECS } from '../constants';
+import type {
+  GetOptionsInterface,
+  TransformOptions,
+} from '../types/BaseProvider';
 
 /**
  * Options for the `get` method.

--- a/packages/parameters/src/base/GetOptions.ts
+++ b/packages/parameters/src/base/GetOptions.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_MAX_AGE_SECS } from './constants';
-import { EnvironmentVariablesService } from './config/EnvironmentVariablesService';
-import type { GetOptionsInterface, TransformOptions } from './types';
+import { DEFAULT_MAX_AGE_SECS } from '../constants';
+import { EnvironmentVariablesService } from '../config/EnvironmentVariablesService';
+import type { GetOptionsInterface, TransformOptions } from '../types';
 
 /**
  * Options for the `get` method.

--- a/packages/parameters/src/base/index.ts
+++ b/packages/parameters/src/base/index.ts
@@ -1,0 +1,4 @@
+export * from './DefaultProviders';
+export * from './BaseProvider';
+export * from './GetOptions';
+export * from './GetMultipleOptions';

--- a/packages/parameters/src/base/transformValue.ts
+++ b/packages/parameters/src/base/transformValue.ts
@@ -1,9 +1,10 @@
+import type { JSONValue } from '@aws-lambda-powertools/commons';
 import { isString } from '@aws-lambda-powertools/commons';
-import { isUint8Array } from 'node:util/types';
 import { fromBase64 } from '@aws-sdk/util-base64-node';
+import { isUint8Array } from 'node:util/types';
 import { TRANSFORM_METHOD_BINARY, TRANSFORM_METHOD_JSON } from '../constants';
 import { TransformParameterError } from '../errors';
-import type { JSONValue, TransformOptions } from '../types';
+import type { TransformOptions } from '../types/BaseProvider';
 
 /**
  * Utility function to transform a value.

--- a/packages/parameters/src/base/transformValue.ts
+++ b/packages/parameters/src/base/transformValue.ts
@@ -29,8 +29,12 @@ const transformValue = (
       (normalizedTransform === TRANSFORM_METHOD_JSON ||
         (normalizedTransform === 'auto' &&
           key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_JSON}`))) &&
-      isString(value)
+      (isString(value) || isUint8Array(value))
     ) {
+      if (value instanceof Uint8Array) {
+        value = new TextDecoder('utf-8').decode(value);
+      }
+
       return JSON.parse(value) as JSONValue;
     } else if (
       (normalizedTransform === TRANSFORM_METHOD_BINARY ||

--- a/packages/parameters/src/base/transformValue.ts
+++ b/packages/parameters/src/base/transformValue.ts
@@ -8,10 +8,23 @@ import type { TransformOptions } from '../types/BaseProvider';
 /**
  * Utility function to transform a value.
  *
- * It supports JSON and binary transformations, as well as an 'auto' mode that will try to transform the value based on the key.
+ * It supports JSON and binary transformations, as well as an `auto` mode that will try to transform the value based on the key.
+ *
+ * The function supports both `string` and `Uint8Array` values as input. Other types will be returned as-is.
+ *
+ * If the value is a `Uint8Array`, it will be decoded to a string first. Then, when the transform is `json` or `auto` and the key ends with `.json`,
+ * the value will be parsed as JSON using the `JSON.parse` function.
+ *
+ * When the transform is `binary` or `auto` and the key ends with `.binary`, the value will be decoded from base64 using the `fromBase64` function
+ * from the `@aws-sdk/util-base64-node` package.
+ *
+ * If the transformation fails, the function will return the value as-is unless `throwOnTransformError` is set to `true`.
+ *
+ * @note When using `auto` mode, the key must end with either `.json` or `.binary` to be transformed. Automatic transformation is supported only for
+ * `getMultiple` calls.
  *
  * @param {string | Uint8Array} value - Value to be transformed
- * @param {TransformOptions} transform - Transform to be applied, can be 'json', 'binary', or 'auto'
+ * @param {TransformOptions} transform - Transform to be applied, can be `json`, `binary`, or `auto`
  * @param {boolean} throwOnTransformError - Whether to throw an error if the transformation fails, when transforming multiple values this can be set to false
  * @param {string} key - Key of the value to be transformed, used to determine the transformation method when using 'auto'
  */

--- a/packages/parameters/src/base/transformValue.ts
+++ b/packages/parameters/src/base/transformValue.ts
@@ -1,0 +1,56 @@
+import { isString } from '@aws-lambda-powertools/commons';
+import { isUint8Array } from 'node:util/types';
+import { fromBase64 } from '@aws-sdk/util-base64-node';
+import { TRANSFORM_METHOD_BINARY, TRANSFORM_METHOD_JSON } from '../constants';
+import { TransformParameterError } from '../errors';
+import type { JSONValue, TransformOptions } from '../types';
+
+/**
+ * Utility function to transform a value.
+ *
+ * It supports JSON and binary transformations, as well as an 'auto' mode that will try to transform the value based on the key.
+ *
+ * @param {string | Uint8Array} value - Value to be transformed
+ * @param {TransformOptions} transform - Transform to be applied, can be 'json', 'binary', or 'auto'
+ * @param {boolean} throwOnTransformError - Whether to throw an error if the transformation fails, when transforming multiple values this can be set to false
+ * @param {string} key - Key of the value to be transformed, used to determine the transformation method when using 'auto'
+ */
+const transformValue = (
+  value: string | Uint8Array,
+  transform: TransformOptions,
+  throwOnTransformError: boolean,
+  key: string
+): string | JSONValue | Uint8Array | undefined => {
+  try {
+    const normalizedTransform = transform.toLowerCase();
+
+    if (
+      (normalizedTransform === TRANSFORM_METHOD_JSON ||
+        (normalizedTransform === 'auto' &&
+          key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_JSON}`))) &&
+      isString(value)
+    ) {
+      return JSON.parse(value) as JSONValue;
+    } else if (
+      (normalizedTransform === TRANSFORM_METHOD_BINARY ||
+        (normalizedTransform === 'auto' &&
+          key.toLowerCase().endsWith(`.${TRANSFORM_METHOD_BINARY}`))) &&
+      (isString(value) || isUint8Array(value))
+    ) {
+      if (value instanceof Uint8Array) {
+        value = new TextDecoder('utf-8').decode(value);
+      }
+
+      return new TextDecoder('utf-8').decode(fromBase64(value));
+    } else {
+      return value;
+    }
+  } catch (error) {
+    if (throwOnTransformError)
+      throw new TransformParameterError(transform, (error as Error).message);
+
+    return;
+  }
+};
+
+export { transformValue };

--- a/packages/parameters/src/constants.ts
+++ b/packages/parameters/src/constants.ts
@@ -1,3 +1,30 @@
-export const DEFAULT_MAX_AGE_SECS = 5;
-export const TRANSFORM_METHOD_JSON = 'json';
-export const TRANSFORM_METHOD_BINARY = 'binary';
+const DEFAULT_MAX_AGE_SECS = 5;
+const TRANSFORM_METHOD_JSON = 'json';
+const TRANSFORM_METHOD_BINARY = 'binary';
+const TRANSFORM_METHOD_AUTO = 'auto';
+
+/**
+ * Transform methods for values retrieved by parameter providers.
+ */
+const Transform = {
+  /**
+   * Transform the retrieved value using `JSON.parse`.
+   */
+  JSON: TRANSFORM_METHOD_JSON,
+  /**
+   * Transform a base64-encoded value from `Uint8Array` to `string`.
+   */
+  BINARY: TRANSFORM_METHOD_BINARY,
+  /**
+   * Automatically detect the transform method based on the parameter' name suffix.
+   */
+  AUTO: TRANSFORM_METHOD_AUTO,
+} as const;
+
+export {
+  DEFAULT_MAX_AGE_SECS,
+  TRANSFORM_METHOD_JSON,
+  TRANSFORM_METHOD_BINARY,
+  TRANSFORM_METHOD_AUTO,
+  Transform,
+};

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -66,6 +66,7 @@ import type { JSONValue } from '@aws-lambda-powertools/commons';
  *  // Retrieve multiple values from DynamoDB
  *  const values = await tableProvider.getMultiple('my-values-path');
  * };
+ * ```
  *
  * ## Advanced usage
  *

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -4,17 +4,19 @@ import {
   GetItemCommand,
   paginateQuery,
 } from '@aws-sdk/client-dynamodb';
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import type {
   DynamoDBProviderOptions,
-  DynamoDBGetOptionsInterface,
-  DynamoDBGetMultipleOptionsInterface,
+  DynamoDBGetOptions,
+  DynamoDBGetMultipleOptions,
+  DynamoDBGetOutput,
 } from '../types/DynamoDBProvider';
 import type {
   GetItemCommandInput,
   QueryCommandInput,
 } from '@aws-sdk/client-dynamodb';
-import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
 import type { PaginationConfiguration } from '@aws-sdk/types';
+import { JSONValue } from 'types';
 
 /**
  * ## Intro
@@ -297,12 +299,21 @@ class DynamoDBProvider extends BaseProvider {
    * @param {DynamoDBGetOptionsInterface} options - Options to configure the provider
    * @see https://docs.powertools.aws.dev/lambda-typescript/latest/utilities/parameters/
    */
-  public async get(
+  public async get<
+    ExplicitUserProvidedType = undefined,
+    InferredFromOptionsType extends
+      | DynamoDBGetOptions
+      | undefined = DynamoDBGetOptions
+  >(
     name: string,
-    options?: DynamoDBGetOptionsInterface
-  ): Promise<undefined | string | Record<string, unknown>> {
+    options?: InferredFromOptionsType & DynamoDBGetOptions
+  ): Promise<
+    | DynamoDBGetOutput<ExplicitUserProvidedType, InferredFromOptionsType>
+    | undefined
+  > {
     return super.get(name, options) as Promise<
-      undefined | string | Record<string, unknown>
+      | DynamoDBGetOutput<ExplicitUserProvidedType, InferredFromOptionsType>
+      | undefined
     >;
   }
 
@@ -333,13 +344,13 @@ class DynamoDBProvider extends BaseProvider {
    * For usage examples check {@link DynamoDBProvider}.
    *
    * @param {string} path - The path of the values to retrieve (i.e. the partition key)
-   * @param {DynamoDBGetMultipleOptionsInterface} options - Options to configure the provider
+   * @param {DynamoDBGetMultipleOptions} options - Options to configure the provider
    * @see https://docs.powertools.aws.dev/lambda-typescript/latest/utilities/parameters/
    */
   public async getMultiple(
     path: string,
-    options?: DynamoDBGetMultipleOptionsInterface
-  ): Promise<undefined | Record<string, unknown>> {
+    options?: DynamoDBGetMultipleOptions
+  ): Promise<Record<string, JSONValue>> {
     return super.getMultiple(path, options);
   }
 
@@ -347,12 +358,12 @@ class DynamoDBProvider extends BaseProvider {
    * Retrieve an item from Amazon DynamoDB.
    *
    * @param {string} name - Key of the item to retrieve (i.e. the partition key)
-   * @param {DynamoDBGetOptionsInterface} options - Options to customize the retrieval
+   * @param {DynamoDBGetOptions} options - Options to customize the retrieval
    */
   protected async _get(
     name: string,
-    options?: DynamoDBGetOptionsInterface
-  ): Promise<string | undefined> {
+    options?: DynamoDBGetOptions
+  ): Promise<JSONValue | undefined> {
     const sdkOptions: GetItemCommandInput = {
       ...(options?.sdkOptions || {}),
       TableName: this.tableName,
@@ -371,12 +382,12 @@ class DynamoDBProvider extends BaseProvider {
    * Retrieve multiple items from Amazon DynamoDB.
    *
    * @param {string} path - The path of the values to retrieve (i.e. the partition key)
-   * @param {DynamoDBGetMultipleOptionsInterface} options - Options to customize the retrieval
+   * @param {DynamoDBGetMultipleOptions} options - Options to customize the retrieval
    */
   protected async _getMultiple(
     path: string,
-    options?: DynamoDBGetMultipleOptionsInterface
-  ): Promise<Record<string, string | undefined>> {
+    options?: DynamoDBGetMultipleOptions
+  ): Promise<Record<string, JSONValue>> {
     const sdkOptions: QueryCommandInput = {
       ...(options?.sdkOptions || {}),
       TableName: this.tableName,
@@ -394,7 +405,7 @@ class DynamoDBProvider extends BaseProvider {
       pageSize: options?.sdkOptions?.Limit,
     };
 
-    const parameters: Record<string, string | undefined> = {};
+    const parameters: Record<string, JSONValue> = {};
     for await (const page of paginateQuery(paginationOptions, sdkOptions)) {
       for (const item of page.Items || []) {
         const unmarshalledItem = unmarshall(item);

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -1,4 +1,4 @@
-import { BaseProvider } from '../BaseProvider';
+import { BaseProvider } from '../base';
 import {
   DynamoDBClient,
   GetItemCommand,
@@ -10,13 +10,14 @@ import type {
   DynamoDBGetOptions,
   DynamoDBGetMultipleOptions,
   DynamoDBGetOutput,
+  DynamoDBGetMultipleOutput,
 } from '../types/DynamoDBProvider';
 import type {
   GetItemCommandInput,
   QueryCommandInput,
 } from '@aws-sdk/client-dynamodb';
 import type { PaginationConfiguration } from '@aws-sdk/types';
-import { JSONValue } from 'types';
+import type { JSONValue } from '@aws-lambda-powertools/commons';
 
 /**
  * ## Intro
@@ -347,11 +348,28 @@ class DynamoDBProvider extends BaseProvider {
    * @param {DynamoDBGetMultipleOptions} options - Options to configure the provider
    * @see https://docs.powertools.aws.dev/lambda-typescript/latest/utilities/parameters/
    */
-  public async getMultiple(
+  public async getMultiple<
+    ExplicitUserProvidedType = undefined,
+    InferredFromOptionsType extends
+      | DynamoDBGetMultipleOptions
+      | undefined = DynamoDBGetMultipleOptions
+  >(
     path: string,
-    options?: DynamoDBGetMultipleOptions
-  ): Promise<Record<string, JSONValue>> {
-    return super.getMultiple(path, options);
+    options?: InferredFromOptionsType & DynamoDBGetMultipleOptions
+  ): Promise<
+    | DynamoDBGetMultipleOutput<
+        ExplicitUserProvidedType,
+        InferredFromOptionsType
+      >
+    | undefined
+  > {
+    return super.getMultiple(path, options) as Promise<
+      | DynamoDBGetMultipleOutput<
+          ExplicitUserProvidedType,
+          InferredFromOptionsType
+        >
+      | undefined
+    >;
   }
 
   /**

--- a/packages/parameters/src/errors.ts
+++ b/packages/parameters/src/errors.ts
@@ -1,4 +1,12 @@
-class GetParameterError extends Error {}
+/**
+ * Error thrown when a parameter cannot be retrieved.
+ */
+class GetParameterError extends Error {
+  public constructor(message?: string) {
+    super(message);
+    this.name = 'GetParameterError';
+  }
+}
 
 /**
  * Error thrown when a transform fails.
@@ -6,7 +14,7 @@ class GetParameterError extends Error {}
 class TransformParameterError extends Error {
   public constructor(transform: string, message: string) {
     super(message);
-
+    this.name = 'TransformParameterError';
     this.message = `Unable to transform value using '${transform}' transform: ${message}`;
   }
 }

--- a/packages/parameters/src/index.ts
+++ b/packages/parameters/src/index.ts
@@ -1,1 +1,2 @@
 export * from './errors';
+export * from './constants';

--- a/packages/parameters/src/index.ts
+++ b/packages/parameters/src/index.ts
@@ -1,2 +1,1 @@
-export * from './BaseProvider';
-export * from './Exceptions';
+export * from './errors';

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -222,7 +222,7 @@ class SecretsProvider extends BaseProvider {
    * Retrieving multiple parameter values is not supported with AWS Secrets Manager.
    */
   public async getMultiple(path: string, _options?: unknown): Promise<void> {
-    super.getMultiple(path);
+    await super.getMultiple(path);
   }
 
   /**

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -8,7 +8,6 @@ import type {
   SecretsProviderOptions,
   SecretsGetOptions,
   SecretsGetOutput,
-  SecretsGetOptionsUnion,
 } from '../types/SecretsProvider';
 
 /**
@@ -204,8 +203,8 @@ class SecretsProvider extends BaseProvider {
   public async get<
     ExplicitUserProvidedType = undefined,
     InferredFromOptionsType extends
-      | SecretsGetOptionsUnion
-      | undefined = SecretsGetOptionsUnion
+      | SecretsGetOptions
+      | undefined = SecretsGetOptions
   >(
     name: string,
     options?: InferredFromOptionsType & SecretsGetOptions
@@ -222,15 +221,12 @@ class SecretsProvider extends BaseProvider {
   /**
    * Retrieving multiple parameter values is not supported with AWS Secrets Manager.
    */
-  public async getMultiple(
-    path: string,
-    _options?: unknown
-  ): Promise<undefined | Record<string, unknown>> {
-    return super.getMultiple(path);
+  public async getMultiple(path: string, _options?: unknown): Promise<void> {
+    super.getMultiple(path);
   }
 
   /**
-   * Retrieve a configuration from AWS AppConfig.
+   * Retrieve a configuration from AWS Secrets Manager.
    *
    * @param {string} name - Name of the configuration or its ID
    * @param {SecretsGetOptions} options - SDK options to propagate to the AWS SDK v3 for JavaScript client
@@ -261,7 +257,7 @@ class SecretsProvider extends BaseProvider {
   protected async _getMultiple(
     _path: string,
     _options?: unknown
-  ): Promise<Record<string, string | undefined>> {
+  ): Promise<void> {
     throw new Error('Method not implemented.');
   }
 }

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -1,4 +1,4 @@
-import { BaseProvider } from '../BaseProvider';
+import { BaseProvider } from '../base';
 import {
   SecretsManagerClient,
   GetSecretValueCommand,

--- a/packages/parameters/src/secrets/getSecret.ts
+++ b/packages/parameters/src/secrets/getSecret.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PROVIDERS } from '../BaseProvider';
+import { DEFAULT_PROVIDERS } from '../base';
 import { SecretsProvider } from './SecretsProvider';
 import type {
   SecretsGetOptions,

--- a/packages/parameters/src/secrets/getSecret.ts
+++ b/packages/parameters/src/secrets/getSecret.ts
@@ -3,7 +3,6 @@ import { SecretsProvider } from './SecretsProvider';
 import type {
   SecretsGetOptions,
   SecretsGetOutput,
-  SecretsGetOptionsUnion,
 } from '../types/SecretsProvider';
 
 /**
@@ -110,8 +109,8 @@ import type {
 const getSecret = async <
   ExplicitUserProvidedType = undefined,
   InferredFromOptionsType extends
-    | SecretsGetOptionsUnion
-    | undefined = SecretsGetOptionsUnion
+    | SecretsGetOptions
+    | undefined = SecretsGetOptions
 >(
   name: string,
   options?: InferredFromOptionsType & SecretsGetOptions
@@ -123,13 +122,7 @@ const getSecret = async <
     DEFAULT_PROVIDERS.secrets = new SecretsProvider();
   }
 
-  return (DEFAULT_PROVIDERS.secrets as SecretsProvider).get(
-    name,
-    options
-  ) as Promise<
-    | SecretsGetOutput<ExplicitUserProvidedType, InferredFromOptionsType>
-    | undefined
-  >;
+  return (DEFAULT_PROVIDERS.secrets as SecretsProvider).get(name, options);
 };
 
 export { getSecret };

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_PROVIDERS,
   transformValue,
 } from '../BaseProvider';
-import { GetParameterError } from '../Exceptions';
+import { GetParameterError } from '../errors';
 import { DEFAULT_MAX_AGE_SECS } from '../constants';
 import {
   SSMClient,

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -1,8 +1,5 @@
-import {
-  BaseProvider,
-  DEFAULT_PROVIDERS,
-  transformValue,
-} from '../BaseProvider';
+import { BaseProvider, DEFAULT_PROVIDERS } from '../base';
+import { transformValue } from '../base/transformValue';
 import { GetParameterError } from '../errors';
 import { DEFAULT_MAX_AGE_SECS } from '../constants';
 import {

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -22,7 +22,6 @@ import type {
   SSMGetOptions,
   SSMGetOutput,
   SSMGetMultipleOptions,
-  SSMGetMultipleOptionsUnion,
   SSMGetMultipleOutput,
   SSMGetParametersByNameOutput,
   SSMGetParametersByNameOutputInterface,
@@ -371,7 +370,7 @@ class SSMProvider extends BaseProvider {
   public async getMultiple<
     ExplicitUserProvidedType = undefined,
     InferredFromOptionsType extends
-      | SSMGetMultipleOptionsUnion
+      | SSMGetMultipleOptions
       | undefined = undefined
   >(
     path: string,

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -73,6 +73,7 @@ import type { PaginationConfiguration } from '@aws-sdk/types';
  *  // Retrieve multiple parameters by path from SSM
  *  const parameters = await parametersProvider.getMultiple('/my-parameters-path');
  * };
+ * ```
  *
  * If you don't need to customize the provider, you can also use the {@link getParameters} function instead.
  *

--- a/packages/parameters/src/ssm/getParameter.ts
+++ b/packages/parameters/src/ssm/getParameter.ts
@@ -1,9 +1,5 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
-import type {
-  SSMGetOptions,
-  SSMGetOutput,
-  SSMGetOptionsUnion,
-} from '../types/SSMProvider';
+import type { SSMGetOptions, SSMGetOutput } from '../types/SSMProvider';
 
 /**
  * ## Intro
@@ -142,9 +138,7 @@ import type {
  */
 const getParameter = async <
   ExplicitUserProvidedType = undefined,
-  InferredFromOptionsType extends
-    | SSMGetOptionsUnion
-    | undefined = SSMGetOptionsUnion
+  InferredFromOptionsType extends SSMGetOptions | undefined = SSMGetOptions
 >(
   name: string,
   options?: InferredFromOptionsType & SSMGetOptions

--- a/packages/parameters/src/ssm/getParameters.ts
+++ b/packages/parameters/src/ssm/getParameters.ts
@@ -1,7 +1,6 @@
 import { SSMProvider, DEFAULT_PROVIDERS } from './SSMProvider';
 import type {
   SSMGetMultipleOptions,
-  SSMGetMultipleOptionsUnion,
   SSMGetMultipleOutput,
 } from '../types/SSMProvider';
 
@@ -144,8 +143,8 @@ import type {
 const getParameters = async <
   ExplicitUserProvidedType = undefined,
   InferredFromOptionsType extends
-    | SSMGetMultipleOptionsUnion
-    | undefined = SSMGetMultipleOptionsUnion
+    | SSMGetMultipleOptions
+    | undefined = SSMGetMultipleOptions
 >(
   path: string,
   options?: InferredFromOptionsType & SSMGetMultipleOptions

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -72,7 +72,7 @@ interface BaseProviderInterface {
   getMultiple(
     path: string,
     options?: GetMultipleOptionsInterface
-  ): Promise<unknown>;
+  ): Promise<unknown | void>;
 }
 
 type JSONPrimitive = string | number | boolean | null | undefined;

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -73,12 +73,8 @@ interface BaseProviderInterface {
     path: string,
     options?: GetMultipleOptionsInterface
   ): Promise<unknown | void>;
+  clearCache?(): void;
 }
-
-type JSONPrimitive = string | number | boolean | null | undefined;
-type JSONValue = JSONPrimitive | JSONObject | JSONArray;
-type JSONObject = { [key: string]: JSONValue };
-type JSONArray = Array<JSONValue>;
 
 export type {
   GetOptionsInterface,
@@ -86,8 +82,4 @@ export type {
   BaseProviderInterface,
   ExpirableValueInterface,
   TransformOptions,
-  JSONPrimitive,
-  JSONValue,
-  JSONObject,
-  JSONArray,
 };

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -57,7 +57,7 @@ interface ExpirableValueInterface {
   /**
    * Value of the parameter.
    */
-  value: string | Uint8Array | Record<string, unknown>;
+  value: unknown;
   /**
    * Expiration timestamp of the value.
    */
@@ -68,15 +68,17 @@ interface ExpirableValueInterface {
  * Interface for a parameter store provider.
  */
 interface BaseProviderInterface {
-  get(
-    name: string,
-    options?: GetOptionsInterface
-  ): Promise<undefined | string | Uint8Array | Record<string, unknown>>;
+  get(name: string, options?: GetOptionsInterface): Promise<unknown>;
   getMultiple(
     path: string,
     options?: GetMultipleOptionsInterface
-  ): Promise<void | Record<string, unknown>>;
+  ): Promise<unknown>;
 }
+
+type JSONPrimitive = string | number | boolean | null | undefined;
+type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+type JSONObject = { [key: string]: JSONValue };
+type JSONArray = Array<JSONValue>;
 
 export type {
   GetOptionsInterface,
@@ -84,4 +86,8 @@ export type {
   BaseProviderInterface,
   ExpirableValueInterface,
   TransformOptions,
+  JSONPrimitive,
+  JSONValue,
+  JSONObject,
+  JSONArray,
 };

--- a/packages/parameters/src/types/BaseProvider.ts
+++ b/packages/parameters/src/types/BaseProvider.ts
@@ -1,7 +1,9 @@
+import { Transform } from '../constants';
+
 /**
  * Type for the transform option.
  */
-type TransformOptions = 'auto' | 'binary' | 'json';
+type TransformOptions = (typeof Transform)[keyof typeof Transform];
 
 /**
  * Options for the `get` method.

--- a/packages/parameters/src/types/DynamoDBProvider.ts
+++ b/packages/parameters/src/types/DynamoDBProvider.ts
@@ -113,12 +113,12 @@ type DynamoDBGetOutput<
 > = undefined extends ExplicitUserProvidedType
   ? undefined extends InferredFromOptionsType
     ? JSONValue
-    : InferredFromOptionsType extends DynamoDBGetOptionsTransformNone
+    : InferredFromOptionsType extends
+        | DynamoDBGetOptionsTransformNone
+        | DynamoDBGetOptionsTransformJson
     ? JSONValue
     : InferredFromOptionsType extends DynamoDBGetOptionsTransformBinary
     ? string
-    : InferredFromOptionsType extends DynamoDBGetOptionsTransformJson
-    ? Record<string, unknown>
     : never
   : ExplicitUserProvidedType;
 
@@ -133,13 +133,59 @@ type DynamoDBGetOutput<
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  * @property {boolean} throwOnTransformError - Whether to throw an error if the transform fails (default: `true`)
  */
-interface DynamoDBGetMultipleOptions extends GetMultipleOptionsInterface {
+interface DynamoDBGetMultipleOptionsBase extends GetMultipleOptionsInterface {
   sdkOptions?: Partial<QueryCommandInput>;
 }
+
+interface DynamoDBGetMultipleOptionsTransformJson
+  extends DynamoDBGetMultipleOptionsBase {
+  transform: 'json';
+}
+
+interface DynamoDBGetMultipleOptionsTransformBinary
+  extends DynamoDBGetMultipleOptionsBase {
+  transform: 'binary';
+}
+
+interface DynamoDBGetMultipleOptionsTransformAuto
+  extends DynamoDBGetMultipleOptionsBase {
+  transform: 'auto';
+}
+
+interface DynamoDBGetMultipleOptionsTransformNone
+  extends DynamoDBGetMultipleOptionsBase {
+  transform?: never;
+}
+
+type DynamoDBGetMultipleOptions =
+  | DynamoDBGetMultipleOptionsTransformJson
+  | DynamoDBGetMultipleOptionsTransformBinary
+  | DynamoDBGetMultipleOptionsTransformAuto
+  | DynamoDBGetMultipleOptionsTransformNone;
+
+/**
+ * Generic output type for DynamoDBProvider getMultiple method.
+ */
+type DynamoDBGetMultipleOutput<
+  ExplicitUserProvidedType = undefined,
+  InferredFromOptionsType = undefined
+> = undefined extends ExplicitUserProvidedType
+  ? undefined extends InferredFromOptionsType
+    ? JSONValue
+    : InferredFromOptionsType extends
+        | DynamoDBGetMultipleOptionsTransformNone
+        | DynamoDBGetMultipleOptionsTransformAuto
+        | DynamoDBGetMultipleOptionsTransformJson
+    ? JSONValue
+    : InferredFromOptionsType extends DynamoDBGetOptionsTransformBinary
+    ? string
+    : never
+  : ExplicitUserProvidedType;
 
 export type {
   DynamoDBProviderOptions,
   DynamoDBGetOptions,
   DynamoDBGetOutput,
   DynamoDBGetMultipleOptions,
+  DynamoDBGetMultipleOutput,
 };

--- a/packages/parameters/src/types/DynamoDBProvider.ts
+++ b/packages/parameters/src/types/DynamoDBProvider.ts
@@ -1,6 +1,7 @@
 import type {
   GetOptionsInterface,
   GetMultipleOptionsInterface,
+  JSONValue,
 } from './BaseProvider';
 import type {
   DynamoDBClient,
@@ -18,7 +19,7 @@ import type {
  * @property {string} [sortAttr] - The DynamoDB table sort attribute name. Defaults to 'sk'.
  * @property {string} [valueAttr] - The DynamoDB table value attribute name. Defaults to 'value'.
  */
-interface DynamoDBProviderOptionsBaseInterface {
+interface DynamoDBProviderOptionsBase {
   tableName: string;
   keyAttr?: string;
   sortAttr?: string;
@@ -29,12 +30,12 @@ interface DynamoDBProviderOptionsBaseInterface {
  * Interface for DynamoDBProviderOptions with clientConfig property.
  *
  * @interface
- * @extends DynamoDBProviderOptionsBaseInterface
- * @property {AppConfigDataClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region.
+ * @extends DynamoDBProviderOptionsBase
+ * @property {DynamoDBClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region.
  * @property {never} [awsSdkV3Client] - This property should never be passed.
  */
 interface DynamoDBProviderOptionsWithClientConfig
-  extends DynamoDBProviderOptionsBaseInterface {
+  extends DynamoDBProviderOptionsBase {
   clientConfig?: DynamoDBClientConfig;
   awsSdkV3Client?: never;
 }
@@ -43,26 +44,26 @@ interface DynamoDBProviderOptionsWithClientConfig
  * Interface for DynamoDBProviderOptions with awsSdkV3Client property.
  *
  * @interface
- * @extends DynamoDBProviderOptionsBaseInterface
- * @property {AppConfigDataClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during AppConfigProvider class instantiation
+ * @extends DynamoDBProviderOptionsBase
+ * @property {DynamoDBClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during DynamoDBProvider class instantiation
  * @property {never} [clientConfig] - This property should never be passed.
  */
 interface DynamoDBProviderOptionsWithClientInstance
-  extends DynamoDBProviderOptionsBaseInterface {
+  extends DynamoDBProviderOptionsBase {
   awsSdkV3Client?: DynamoDBClient;
   clientConfig?: never;
 }
 
 /**
- * Options for the AppConfigProvider class constructor.
+ * Options for the DynamoDBProvider class constructor.
  *
- * @type AppConfigProviderOptions
+ * @type DynamoDBProviderOptions
  * @property {string} tableName - The DynamoDB table name.
  * @property {string} [keyAttr] - The DynamoDB table key attribute name. Defaults to 'id'.
  * @property {string} [sortAttr] - The DynamoDB table sort attribute name. Defaults to 'sk'.
  * @property {string} [valueAttr] - The DynamoDB table value attribute name. Defaults to 'value'.
- * @property {AppConfigDataClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region. Mutually exclusive with awsSdkV3Client.
- * @property {AppConfigDataClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during DynamoDBProvider class instantiation. Mutually exclusive with clientConfig.
+ * @property {DynamoDBClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region. Mutually exclusive with awsSdkV3Client.
+ * @property {DynamoDBClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during DynamoDBProvider class instantiation. Mutually exclusive with clientConfig.
  */
 type DynamoDBProviderOptions =
   | DynamoDBProviderOptionsWithClientConfig
@@ -71,24 +72,60 @@ type DynamoDBProviderOptions =
 /**
  * Options for the DynamoDBProvider get method.
  *
- * @interface DynamoDBGetOptionsInterface
+ * @interface DynamoDBGetOptionsBase
  * @extends {GetOptionsInterface}
  * @property {number} maxAge - Maximum age of the value in the cache, in seconds.
  * @property {boolean} forceFetch - Force fetch the value from the parameter store, ignoring the cache.
  * @property {GetItemCommandInput} [sdkOptions] - Additional options to pass to the AWS SDK v3 client.
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  */
-interface DynamoDBGetOptionsInterface extends GetOptionsInterface {
+interface DynamoDBGetOptionsBase extends GetOptionsInterface {
   sdkOptions?: Omit<
     Partial<GetItemCommandInput>,
     'Key' | 'TableName' | 'ProjectionExpression'
   >;
 }
 
+interface DynamoDBGetOptionsTransformJson extends DynamoDBGetOptionsBase {
+  transform: 'json';
+}
+
+interface DynamoDBGetOptionsTransformBinary extends DynamoDBGetOptionsBase {
+  transform: 'binary';
+}
+
+interface DynamoDBGetOptionsTransformNone extends DynamoDBGetOptionsBase {
+  transform?: never;
+}
+
+type DynamoDBGetOptions =
+  | DynamoDBGetOptionsTransformNone
+  | DynamoDBGetOptionsTransformJson
+  | DynamoDBGetOptionsTransformBinary
+  | undefined;
+
+/**
+ * Generic output type for DynamoDBProvider get method.
+ */
+type DynamoDBGetOutput<
+  ExplicitUserProvidedType = undefined,
+  InferredFromOptionsType = undefined
+> = undefined extends ExplicitUserProvidedType
+  ? undefined extends InferredFromOptionsType
+    ? JSONValue
+    : InferredFromOptionsType extends DynamoDBGetOptionsTransformNone
+    ? JSONValue
+    : InferredFromOptionsType extends DynamoDBGetOptionsTransformBinary
+    ? string
+    : InferredFromOptionsType extends DynamoDBGetOptionsTransformJson
+    ? Record<string, unknown>
+    : never
+  : ExplicitUserProvidedType;
+
 /**
  * Options for the DynamoDBProvider getMultiple method.
  *
- * @interface DynamoDBGetMultipleOptionsInterface
+ * @interface DynamoDBGetMultipleOptions
  * @extends {GetMultipleOptionsInterface}
  * @property {number} maxAge - Maximum age of the value in the cache, in seconds.
  * @property {boolean} forceFetch - Force fetch the value from the parameter store, ignoring the cache.
@@ -96,13 +133,13 @@ interface DynamoDBGetOptionsInterface extends GetOptionsInterface {
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  * @property {boolean} throwOnTransformError - Whether to throw an error if the transform fails (default: `true`)
  */
-interface DynamoDBGetMultipleOptionsInterface
-  extends GetMultipleOptionsInterface {
+interface DynamoDBGetMultipleOptions extends GetMultipleOptionsInterface {
   sdkOptions?: Partial<QueryCommandInput>;
 }
 
 export type {
   DynamoDBProviderOptions,
-  DynamoDBGetOptionsInterface,
-  DynamoDBGetMultipleOptionsInterface,
+  DynamoDBGetOptions,
+  DynamoDBGetOutput,
+  DynamoDBGetMultipleOptions,
 };

--- a/packages/parameters/src/types/DynamoDBProvider.ts
+++ b/packages/parameters/src/types/DynamoDBProvider.ts
@@ -1,14 +1,14 @@
-import type {
-  GetOptionsInterface,
-  GetMultipleOptionsInterface,
-  JSONValue,
-} from './BaseProvider';
+import type { JSONValue } from '@aws-lambda-powertools/commons';
 import type {
   DynamoDBClient,
+  DynamoDBClientConfig,
   GetItemCommandInput,
   QueryCommandInput,
-  DynamoDBClientConfig,
 } from '@aws-sdk/client-dynamodb';
+import type {
+  GetMultipleOptionsInterface,
+  GetOptionsInterface,
+} from './BaseProvider';
 
 /**
  * Base interface for DynamoDBProviderOptions.

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -1,14 +1,14 @@
+import type { JSONValue } from '@aws-lambda-powertools/commons';
 import type {
-  SSMClient,
-  SSMClientConfig,
   GetParameterCommandInput,
   GetParametersByPathCommandInput,
+  SSMClient,
+  SSMClientConfig,
 } from '@aws-sdk/client-ssm';
 import type {
-  GetOptionsInterface,
   GetMultipleOptionsInterface,
+  GetOptionsInterface,
   TransformOptions,
-  JSONValue,
 } from './BaseProvider';
 
 /**

--- a/packages/parameters/src/types/SSMProvider.ts
+++ b/packages/parameters/src/types/SSMProvider.ts
@@ -8,6 +8,7 @@ import type {
   GetOptionsInterface,
   GetMultipleOptionsInterface,
   TransformOptions,
+  JSONValue,
 } from './BaseProvider';
 
 /**
@@ -48,7 +49,7 @@ type SSMProviderOptions =
 /**
  * Options for the SSMProvider getMultiple method.
  *
- * @interface SSMGetOptionsInterface
+ * @interface SSMGetOptionsBase
  * @extends {GetOptionsInterface}
  * @property {number} maxAge - Maximum age of the value in the cache, in seconds.
  * @property {boolean} forceFetch - Force fetch the value from the parameter store, ignoring the cache.
@@ -56,7 +57,7 @@ type SSMProviderOptions =
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  * @property {boolean} decrypt - If true, the parameter will be decrypted. Defaults to `false`.
  */
-interface SSMGetOptions extends GetOptionsInterface {
+interface SSMGetOptionsBase extends GetOptionsInterface {
   /**
    * If true, the parameter will be decrypted. Defaults to `false`.
    */
@@ -69,19 +70,19 @@ interface SSMGetOptions extends GetOptionsInterface {
   transform?: Exclude<TransformOptions, 'auto'>;
 }
 
-interface SSMGetOptionsTransformJson extends SSMGetOptions {
+interface SSMGetOptionsTransformJson extends SSMGetOptionsBase {
   transform: 'json';
 }
 
-interface SSMGetOptionsTransformBinary extends SSMGetOptions {
+interface SSMGetOptionsTransformBinary extends SSMGetOptionsBase {
   transform: 'binary';
 }
 
-interface SSMGetOptionsTransformNone extends SSMGetOptions {
+interface SSMGetOptionsTransformNone extends SSMGetOptionsBase {
   transform?: never;
 }
 
-type SSMGetOptionsUnion =
+type SSMGetOptions =
   | SSMGetOptionsTransformJson
   | SSMGetOptionsTransformBinary
   | SSMGetOptionsTransformNone
@@ -101,14 +102,14 @@ type SSMGetOutput<
         | SSMGetOptionsTransformBinary
     ? string
     : InferredFromOptionsType extends SSMGetOptionsTransformJson
-    ? Record<string, unknown>
+    ? JSONValue
     : never
   : ExplicitUserProvidedType;
 
 /**
  * Options for the SSMProvider getMultiple method.
  *
- * @interface SSMGetMultipleOptionsInterface
+ * @interface SSMGetMultipleOptionsBase
  * @extends {GetMultipleOptionsInterface}
  * @property {number} maxAge - Maximum age of the value in the cache, in seconds.
  * @property {boolean} forceFetch - Force fetch the value from the parameter store, ignoring the cache.
@@ -118,7 +119,7 @@ type SSMGetOutput<
  * @property {boolean} recursive - If true, the parameter will be fetched recursively.
  * @property {boolean} throwOnTransformError - If true, the method will throw an error if the transform fails.
  */
-interface SSMGetMultipleOptions extends GetMultipleOptionsInterface {
+interface SSMGetMultipleOptionsBase extends GetMultipleOptionsInterface {
   /**
    * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetParametersByPathCommandInput`.
    */
@@ -137,23 +138,24 @@ interface SSMGetMultipleOptions extends GetMultipleOptionsInterface {
   throwOnTransformError?: boolean;
 }
 
-interface SSMGetMultipleOptionsTransformJson extends SSMGetMultipleOptions {
+interface SSMGetMultipleOptionsTransformJson extends SSMGetMultipleOptionsBase {
   transform: 'json';
 }
 
-interface SSMGetMultipleOptionsTransformBinary extends SSMGetMultipleOptions {
+interface SSMGetMultipleOptionsTransformBinary
+  extends SSMGetMultipleOptionsBase {
   transform: 'binary';
 }
 
-interface SSMGetMultipleOptionsTransformAuto extends SSMGetMultipleOptions {
+interface SSMGetMultipleOptionsTransformAuto extends SSMGetMultipleOptionsBase {
   transform: 'auto';
 }
 
-interface SSMGetMultipleOptionsTransformNone extends SSMGetMultipleOptions {
+interface SSMGetMultipleOptionsTransformNone extends SSMGetMultipleOptionsBase {
   transform?: never;
 }
 
-type SSMGetMultipleOptionsUnion =
+type SSMGetMultipleOptions =
   | SSMGetMultipleOptionsTransformJson
   | SSMGetMultipleOptionsTransformBinary
   | SSMGetMultipleOptionsTransformAuto
@@ -174,9 +176,9 @@ type SSMGetMultipleOutput<
         | SSMGetMultipleOptionsTransformBinary
     ? Record<string, string>
     : InferredFromOptionsType extends SSMGetMultipleOptionsTransformAuto
-    ? Record<string, unknown>
+    ? Record<string, JSONValue>
     : InferredFromOptionsType extends SSMGetMultipleOptionsTransformJson
-    ? Record<string, Record<string, unknown>>
+    ? Record<string, JSONValue>
     : never
   : Record<string, ExplicitUserProvidedType>;
 
@@ -231,10 +233,8 @@ type SSMGetParametersByNameOutput<InferredFromOptionsType = undefined> =
 export type {
   SSMProviderOptions,
   SSMGetOptions,
-  SSMGetOptionsUnion,
   SSMGetOutput,
   SSMGetMultipleOptions,
-  SSMGetMultipleOptionsUnion,
   SSMGetMultipleOutput,
   SSMGetParametersByNameOptions,
   SSMSplitBatchAndDecryptParametersOutputType,

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -1,4 +1,8 @@
-import type { GetOptionsInterface, TransformOptions } from './BaseProvider';
+import type {
+  GetOptionsInterface,
+  JSONValue,
+  TransformOptions,
+} from './BaseProvider';
 import type {
   SecretsManagerClient,
   SecretsManagerClientConfig,
@@ -34,8 +38,8 @@ interface SecretsProviderOptionsWithClientInstance {
  * Options for the SecretsProvider class constructor.
  *
  * @type SecretsProviderOptions
- * @property {AppConfigDataClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region. Mutually exclusive with awsSdkV3Client.
- * @property {AppConfigDataClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during SecretsProvider class instantiation. Mutually exclusive with clientConfig.
+ * @property {SecretsManagerClientConfig} [clientConfig] - Optional configuration to pass during client initialization, e.g. AWS region. Mutually exclusive with awsSdkV3Client.
+ * @property {SecretsManagerClient} [awsSdkV3Client] - Optional AWS SDK v3 client to pass during SecretsProvider class instantiation. Mutually exclusive with clientConfig.
  */
 type SecretsProviderOptions =
   | SecretsProviderOptionsWithClientConfig
@@ -51,27 +55,27 @@ type SecretsProviderOptions =
  * @property {GetSecretValueCommandInput} sdkOptions - Options to pass to the underlying SDK.
  * @property {TransformOptions} transform - Transform to be applied, can be 'json' or 'binary'.
  */
-interface SecretsGetOptions extends GetOptionsInterface {
+interface SecretsGetOptionsBase extends GetOptionsInterface {
   /**
-   * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetSecretValueCommandInput`.
+   * Additional options to pass to the AWS SDK v3 client. Supports all options from `GetSecretValueCommandInput` except `SecretId`.
    */
   sdkOptions?: Omit<Partial<GetSecretValueCommandInput>, 'SecretId'>;
   transform?: Exclude<TransformOptions, 'auto'>;
 }
 
-interface SecretsGetOptionsTransformJson extends SecretsGetOptions {
+interface SecretsGetOptionsTransformJson extends SecretsGetOptionsBase {
   transform: 'json';
 }
 
-interface SecretsGetOptionsTransformBinary extends SecretsGetOptions {
+interface SecretsGetOptionsTransformBinary extends SecretsGetOptionsBase {
   transform: 'binary';
 }
 
-interface SecretsGetOptionsTransformNone extends SecretsGetOptions {
+interface SecretsGetOptionsTransformNone extends SecretsGetOptionsBase {
   transform?: never;
 }
 
-type SecretsGetOptionsUnion =
+type SecretsGetOptions =
   | SecretsGetOptionsTransformNone
   | SecretsGetOptionsTransformJson
   | SecretsGetOptionsTransformBinary
@@ -91,13 +95,8 @@ type SecretsGetOutput<
     : InferredFromOptionsType extends SecretsGetOptionsTransformBinary
     ? string
     : InferredFromOptionsType extends SecretsGetOptionsTransformJson
-    ? Record<string, unknown>
+    ? JSONValue
     : never
   : ExplicitUserProvidedType;
 
-export type {
-  SecretsProviderOptions,
-  SecretsGetOptions,
-  SecretsGetOutput,
-  SecretsGetOptionsUnion,
-};
+export type { SecretsProviderOptions, SecretsGetOptions, SecretsGetOutput };

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -88,9 +88,7 @@ type SecretsGetOutput<
   ExplicitUserProvidedType = undefined,
   InferredFromOptionsType = undefined
 > = undefined extends ExplicitUserProvidedType
-  ? undefined extends InferredFromOptionsType
-    ? string | Uint8Array
-    : InferredFromOptionsType extends SecretsGetOptionsTransformNone
+  ? undefined extends InferredFromOptionsType | SecretsGetOptionsTransformNone
     ? string | Uint8Array
     : InferredFromOptionsType extends SecretsGetOptionsTransformBinary
     ? string

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -1,13 +1,10 @@
+import type { JSONValue } from '@aws-lambda-powertools/commons';
 import type {
-  GetOptionsInterface,
-  JSONValue,
-  TransformOptions,
-} from './BaseProvider';
-import type {
+  GetSecretValueCommandInput,
   SecretsManagerClient,
   SecretsManagerClientConfig,
-  GetSecretValueCommandInput,
 } from '@aws-sdk/client-secrets-manager';
+import type { GetOptionsInterface, TransformOptions } from './BaseProvider';
 
 /**
  * Base interface for SecretsProviderOptions.

--- a/packages/parameters/src/types/index.ts
+++ b/packages/parameters/src/types/index.ts
@@ -1,5 +1,0 @@
-export * from './BaseProvider';
-export * from './AppConfigProvider';
-export * from './SSMProvider';
-export * from './SecretsProvider';
-export * from './DynamoDBProvider';

--- a/packages/parameters/src/utils.ts
+++ b/packages/parameters/src/utils.ts
@@ -1,0 +1,43 @@
+/**
+ * TODO: write docs for isRecord() type guard
+ *
+ * @param value
+ * @returns
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return (
+    Object.prototype.toString.call(value) === '[object Object]' &&
+    !Object.is(value, null)
+  );
+};
+
+/**
+ * TODO: write docs for isTruthy()
+ * @param value
+ * @returns
+ */
+const isTruthy = (value: unknown): boolean => {
+  if (typeof value === 'string') {
+    return value !== '';
+  } else if (typeof value === 'number') {
+    return value !== 0;
+  } else if (typeof value === 'boolean') {
+    return value;
+  } else if (Array.isArray(value)) {
+    return value.length > 0;
+  } else if (isRecord(value)) {
+    return Object.keys(value).length > 0;
+  } else {
+    return Object.is(value, true);
+  }
+};
+
+const isNullOrUndefined = (value: unknown): value is null | undefined => {
+  return Object.is(value, null) || Object.is(value, undefined);
+};
+
+const isString = (value: unknown): value is string => {
+  return typeof value === 'string';
+};
+
+export { isRecord, isString, isTruthy, isNullOrUndefined };

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.functionCode.ts
@@ -1,6 +1,7 @@
 import { Context } from 'aws-lambda';
+import { Transform } from '../../src';
 import { AppConfigProvider } from '../../src/appconfig';
-import { AppConfigGetOptionsInterface } from '../../src/types';
+import { AppConfigGetOptions } from '../../src/types/AppConfigProvider';
 import { TinyLogger } from '../helpers/tinyLogger';
 import { middleware } from '../helpers/sdkMiddlewareRequestCounter';
 import { AppConfigDataClient } from '@aws-sdk/client-appconfigdata';
@@ -41,7 +42,7 @@ const resolveProvider = (provider?: AppConfigProvider): AppConfigProvider => {
 const _call_get = async (
   paramName: string,
   testName: string,
-  options?: AppConfigGetOptionsInterface,
+  options?: AppConfigGetOptions,
   provider?: AppConfigProvider
 ): Promise<void> => {
   try {
@@ -69,19 +70,19 @@ export const handler = async (
 
   // Test 2 - get a free-form JSON and apply json transformation (should return an object)
   await _call_get(freeFormJsonName, 'get-freeform-json-binary', {
-    transform: 'json',
+    transform: Transform.JSON,
   });
 
   // Test 3 - get a free-form base64-encoded plain text and apply binary transformation (should return a decoded string)
   await _call_get(
     freeFormBase64encodedPlainText,
     'get-freeform-base64-plaintext-binary',
-    { transform: 'binary' }
+    { transform: Transform.BINARY }
   );
 
   // Test 4 - get a feature flag and apply json transformation (should return an object)
   await _call_get(featureFlagName, 'get-feature-flag-binary', {
-    transform: 'json',
+    transform: Transform.JSON,
   });
 
   // Test 5
@@ -130,14 +131,14 @@ export const handler = async (
       freeFormBase64encodedPlainText,
       {
         maxAge: 0,
-        transform: 'base64',
+        transform: Transform.BINARY,
       }
     );
     const expiredResult2 = await providerWithMiddleware.get(
       freeFormBase64encodedPlainText,
       {
         maxAge: 0,
-        transform: 'base64',
+        transform: Transform.BINARY,
       }
     );
     logger.log({

--- a/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/appConfigProvider.class.test.ts
@@ -371,7 +371,7 @@ describe(`parameters E2E tests (appConfigProvider) for runtime ${runtime}`, () =
       async () => {
         const logs = invocationLogs[0].getFunctionLogs();
         const testLog = InvocationLogs.parseFunctionLog(logs[6]);
-        const result = freeFormBase64PlainTextValue;
+        const result = freeFormPlainTextValue;
 
         expect(testLog).toStrictEqual({
           test: 'get-expired',

--- a/packages/parameters/tests/e2e/dynamoDBProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/dynamoDBProvider.class.test.functionCode.ts
@@ -1,9 +1,10 @@
 import { Context } from 'aws-lambda';
+import { Transform } from '../../src';
 import { DynamoDBProvider } from '../../src/dynamodb';
 import {
-  DynamoDBGetOptionsInterface,
-  DynamoDBGetMultipleOptionsInterface,
-} from '../../src/types';
+  DynamoDBGetOptions,
+  DynamoDBGetMultipleOptions,
+} from '../../src/types/DynamoDBProvider';
 import { TinyLogger } from '../helpers/tinyLogger';
 import { middleware } from '../helpers/sdkMiddlewareRequestCounter';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -55,7 +56,7 @@ const _call_get = async (
   paramName: string,
   testName: string,
   provider: DynamoDBProvider,
-  options?: DynamoDBGetOptionsInterface
+  options?: DynamoDBGetOptions
 ): Promise<void> => {
   try {
     const parameterValue = await provider.get(paramName, options);
@@ -76,7 +77,7 @@ const _call_get_multiple = async (
   paramPath: string,
   testName: string,
   provider: DynamoDBProvider,
-  options?: DynamoDBGetMultipleOptionsInterface
+  options?: DynamoDBGetMultipleOptions
 ): Promise<void> => {
   try {
     const parameterValues = await provider.getMultiple(paramPath, options);
@@ -114,12 +115,12 @@ export const handler = async (
 
   // Test 5 - get a single parameter with json transform
   await _call_get('my-param-json', 'get-json-transform', providerGet, {
-    transform: 'json',
+    transform: Transform.JSON,
   });
 
   // Test 6 - get a single parameter with binary transform
   await _call_get('my-param-binary', 'get-binary-transform', providerGet, {
-    transform: 'binary',
+    transform: Transform.BINARY,
   });
 
   // Test 7 - get multiple parameters with auto transform
@@ -128,7 +129,7 @@ export const handler = async (
     'get-multiple-auto-transform',
     providerGetMultiple,
     {
-      transform: 'auto',
+      transform: Transform.AUTO,
     }
   );
 

--- a/packages/parameters/tests/e2e/secretsProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/secretsProvider.class.test.functionCode.ts
@@ -2,8 +2,9 @@ import { Context } from 'aws-lambda';
 import { TinyLogger } from '../helpers/tinyLogger';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { middleware } from '../helpers/sdkMiddlewareRequestCounter';
+import { Transform } from '../../src';
 import { SecretsProvider } from '../../src/secrets';
-import { SecretsGetOptionsInterface } from '../../src/types';
+import { SecretsGetOptions } from '../../src/types/SecretsProvider';
 
 const logger = new TinyLogger();
 const defaultProvider = new SecretsProvider();
@@ -11,10 +12,6 @@ const defaultProvider = new SecretsProvider();
 const secretNamePlain = process.env.SECRET_NAME_PLAIN || '';
 const secretNameObject = process.env.SECRET_NAME_OBJECT || '';
 const secretNameBinary = process.env.SECRET_NAME_BINARY || '';
-const secretNameObjectWithSuffix =
-  process.env.SECRET_NAME_OBJECT_WITH_SUFFIX || '';
-const secretNameBinaryWithSuffix =
-  process.env.SECRET_NAME_BINARY_WITH_SUFFIX || '';
 const secretNamePlainChached = process.env.SECRET_NAME_PLAIN_CACHED || '';
 const secretNamePlainForceFetch =
   process.env.SECRET_NAME_PLAIN_FORCE_FETCH || '';
@@ -29,7 +26,7 @@ const providerWithMiddleware = new SecretsProvider({
 const _call_get = async (
   paramName: string,
   testName: string,
-  options?: SecretsGetOptionsInterface,
+  options?: SecretsGetOptions,
   provider?: SecretsProvider
 ): Promise<void> => {
   try {
@@ -58,25 +55,15 @@ export const handler = async (
 
   // Test 2 get single secret with transform json
   await _call_get(secretNameObject, 'get-transform-json', {
-    transform: 'json',
+    transform: Transform.JSON,
   });
 
   // Test 3 get single secret with transform binary
   await _call_get(secretNameBinary, 'get-transform-binary', {
-    transform: 'binary',
+    transform: Transform.BINARY,
   });
 
-  // Test 4 get single secret with transform auto json
-  await _call_get(secretNameObjectWithSuffix, 'get-transform-auto-json', {
-    transform: 'auto',
-  });
-
-  // Test 5 get single secret with transform auto binary
-  await _call_get(secretNameBinaryWithSuffix, 'get-transform-auto-binary', {
-    transform: 'auto',
-  });
-
-  // Test 6
+  // Test 4
   // get secret twice with middleware, which counts number of SDK requests, we check later if we only called SecretManager API once
   try {
     middleware.counter = 0;
@@ -92,7 +79,7 @@ export const handler = async (
       error: err.message,
     });
   }
-  // Test 7
+  // Test 5
   // get secret twice, but force fetch 2nd time, we count number of SDK requests and  check that we made two API calls
   try {
     middleware.counter = 0;

--- a/packages/parameters/tests/e2e/ssmProvider.class.test.functionCode.ts
+++ b/packages/parameters/tests/e2e/ssmProvider.class.test.functionCode.ts
@@ -1,10 +1,10 @@
 import { Context } from 'aws-lambda';
 import { SSMProvider } from '../../src/ssm';
 import {
-  SSMGetOptionsInterface,
-  SSMGetMultipleOptionsInterface,
-  SSMGetParametersByNameOptionsInterface,
-} from '../../src/types';
+  SSMGetOptions,
+  SSMGetMultipleOptions,
+  SSMGetParametersByNameOptions,
+} from '../../src/types/SSMProvider';
 import { TinyLogger } from '../helpers/tinyLogger';
 import { middleware } from '../helpers/sdkMiddlewareRequestCounter';
 import { SSMClient } from '@aws-sdk/client-ssm';
@@ -37,7 +37,7 @@ const resolveProvider = (provider?: SSMProvider): SSMProvider => {
 const _call_get = async (
   paramName: string,
   testName: string,
-  options?: SSMGetOptionsInterface,
+  options?: SSMGetOptions,
   provider?: SSMProvider
 ): Promise<void> => {
   try {
@@ -60,7 +60,7 @@ const _call_get = async (
 const _call_get_multiple = async (
   paramPath: string,
   testName: string,
-  options?: SSMGetMultipleOptionsInterface,
+  options?: SSMGetMultipleOptions,
   provider?: SSMProvider
 ): Promise<void> => {
   try {
@@ -84,9 +84,9 @@ const _call_get_multiple = async (
 
 // Helper function to call getParametersByName() and log the result
 const _call_get_parameters_by_name = async (
-  params: Record<string, SSMGetParametersByNameOptionsInterface>,
+  params: Record<string, SSMGetParametersByNameOptions>,
   testName: string,
-  options?: SSMGetParametersByNameOptionsInterface,
+  options?: SSMGetParametersByNameOptions,
   provider?: SSMProvider
 ): Promise<void> => {
   try {

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -4,7 +4,7 @@
  * @group unit/parameters/AppConfigProvider/class
  */
 import { AppConfigProvider } from '../../src/appconfig/index';
-import { ExpirableValue } from '../../src/ExpirableValue';
+import { ExpirableValue } from '../../src/base/ExpirableValue';
 import { AppConfigProviderOptions } from '../../src/types/AppConfigProvider';
 import {
   AppConfigDataClient,

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -3,14 +3,9 @@
  *
  * @group unit/parameters/baseProvider/class
  */
-import {
-  BaseProvider,
-  ExpirableValue,
-  GetParameterError,
-  TransformParameterError,
-  clearCaches,
-  DEFAULT_PROVIDERS,
-} from '../../src';
+import { BaseProvider, clearCaches, DEFAULT_PROVIDERS } from '../../src/base';
+import { ExpirableValue } from '../../src/base/ExpirableValue';
+import { GetParameterError, TransformParameterError } from '../../src/errors';
 import { toBase64 } from '@aws-sdk/util-base64-node';
 
 const encoder = new TextEncoder();

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -281,6 +281,23 @@ describe('Class: BaseProvider', () => {
       );
     });
 
+    test('when the underlying _getMultiple does not return an object, it throws a GetParameterError', async () => {
+      // Prepare
+      const provider = new TestProvider();
+      jest.spyOn(provider, '_getMultiple').mockImplementation(
+        () =>
+          new Promise((resolve, _reject) =>
+            // need to type cast to force the error
+            resolve('not an object' as unknown as Record<string, string>)
+          )
+      );
+
+      // Act & Assess
+      await expect(provider.getMultiple('my-parameter')).rejects.toThrowError(
+        GetParameterError
+      );
+    });
+
     test('when called with a json transform, and all the values are a valid string representation of a JSON, it returns an object with all the values', async () => {
       // Prepare
       const mockData = { A: JSON.stringify({ foo: 'bar' }) };

--- a/packages/parameters/tests/unit/SSMProvider.test.ts
+++ b/packages/parameters/tests/unit/SSMProvider.test.ts
@@ -20,7 +20,7 @@ import type {
   SSMSplitBatchAndDecryptParametersOutputType,
   SSMGetParametersByNameOutputInterface,
 } from '../../src/types/SSMProvider';
-import { ExpirableValue } from '../../src/BaseProvider';
+import { ExpirableValue } from '../../src/base/ExpirableValue';
 import { toBase64 } from '@aws-sdk/util-base64';
 
 const encoder = new TextEncoder();

--- a/packages/parameters/tests/unit/getAppConfig.test.ts
+++ b/packages/parameters/tests/unit/getAppConfig.test.ts
@@ -8,6 +8,7 @@ import {
   getAppConfig,
   DEFAULT_PROVIDERS,
 } from '../../src/appconfig';
+import { Transform } from '../../src';
 import {
   AppConfigDataClient,
   StartConfigurationSessionCommand,
@@ -15,8 +16,8 @@ import {
 } from '@aws-sdk/client-appconfigdata';
 import { mockClient } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
-import type { GetAppConfigCombinedInterface } from '../../src/types/AppConfigProvider';
 import { toBase64 } from '@aws-sdk/util-base64-node';
+import { JSONValue } from '@aws-lambda-powertools/commons';
 
 describe('Function: getAppConfig', () => {
   const client = mockClient(AppConfigDataClient);
@@ -28,30 +29,23 @@ describe('Function: getAppConfig', () => {
 
   test('when called and a default provider does not exist, it instantiates one and returns the value', async () => {
     // Prepare
-    const options: GetAppConfigCombinedInterface = {
-      application: 'MyApp',
-      environment: 'MyAppProdEnv',
-    };
-    const name = 'MyAppFeatureFlag';
-    const mockInitialToken =
-      'AYADeNgfsRxdKiJ37A12OZ9vN2cAXwABABVhd3MtY3J5cHRvLXB1YmxpYy1rZXkAREF1RzlLMTg1Tkx2Wjk4OGV2UXkyQ1';
-    const mockNextToken =
-      'ImRmyljpZnxt7FfxeEOE5H8xQF1SfOlWZFnHujbzJmIvNeSAAA8/qA9ivK0ElRMwpvx96damGxt125XtMkmYf6a0OWSqnBw==';
     const mockData = encoder.encode('myAppConfiguration');
-
     client
       .on(StartConfigurationSessionCommand)
       .resolves({
-        InitialConfigurationToken: mockInitialToken,
+        InitialConfigurationToken: 'abcdefg',
       })
       .on(GetLatestConfigurationCommand)
       .resolves({
         Configuration: mockData,
-        NextPollConfigurationToken: mockNextToken,
+        NextPollConfigurationToken: 'hijklmn',
       });
 
     // Act
-    const result = await getAppConfig(name, options);
+    const result: Uint8Array | undefined = await getAppConfig('my-config', {
+      application: 'my-app',
+      environment: 'prod',
+    });
 
     // Assess
     expect(result).toBe(mockData);
@@ -59,32 +53,28 @@ describe('Function: getAppConfig', () => {
 
   test('when called and a default provider exists, it uses it and returns the value', async () => {
     // Prepare
-    const options: GetAppConfigCombinedInterface = {
-      application: 'MyApp',
-      environment: 'MyAppProdEnv',
-    };
-    const provider = new AppConfigProvider(options);
+    const provider = new AppConfigProvider({
+      application: 'my-app',
+      environment: 'prod',
+    });
     DEFAULT_PROVIDERS.appconfig = provider;
-    const name = 'MyAppFeatureFlag';
-    const mockInitialToken =
-      'AYADeNgfsRxdKiJ37A12OZ9vN2cAXwABABVhd3MtY3J5cHRvLXB1YmxpYy1rZXkAREF1RzlLMTg1Tkx2Wjk4OGV2UXkyQ1';
-    const mockNextToken =
-      'ImRmyljpZnxt7FfxeEOE5H8xQF1SfOlWZFnHujbzJmIvNeSAAA8/qA9ivK0ElRMwpvx96damGxt125XtMkmYf6a0OWSqnBw==';
     const mockData = encoder.encode('myAppConfiguration');
-
     client
       .on(StartConfigurationSessionCommand)
       .resolves({
-        InitialConfigurationToken: mockInitialToken,
+        InitialConfigurationToken: 'abcdefg',
       })
       .on(GetLatestConfigurationCommand)
       .resolves({
         Configuration: mockData,
-        NextPollConfigurationToken: mockNextToken,
+        NextPollConfigurationToken: 'hijklmn',
       });
 
     // Act
-    const result = await getAppConfig(name, options);
+    const result: Uint8Array | undefined = await getAppConfig('my-config', {
+      application: 'my-app',
+      environment: 'prod',
+    });
 
     // Assess
     expect(result).toBe(mockData);
@@ -92,35 +82,53 @@ describe('Function: getAppConfig', () => {
 
   test('when called with transform: `binary` option, it returns string value', async () => {
     // Prepare
-    const options: GetAppConfigCombinedInterface = {
-      application: 'MyApp',
-      environment: 'MyAppProdEnv',
-      transform: 'binary',
-    };
-
-    const name = 'MyAppFeatureFlag';
-    const mockInitialToken =
-      'AYADeNgfsRxdKiJ37A12OZ9vN2cAXwABABVhd3MtY3J5cHRvLXB1YmxpYy1rZXkAREF1RzlLMTg1Tkx2Wjk4OGV2UXkyQ1';
-    const mockNextToken =
-      'ImRmyljpZnxt7FfxeEOE5H8xQF1SfOlWZFnHujbzJmIvNeSAAA8/qA9ivK0ElRMwpvx96damGxt125XtMkmYf6a0OWSqnBw==';
     const expectedValue = 'my-value';
     const mockData = encoder.encode(toBase64(encoder.encode(expectedValue)));
-
     client
       .on(StartConfigurationSessionCommand)
       .resolves({
-        InitialConfigurationToken: mockInitialToken,
+        InitialConfigurationToken: 'abcdefg',
       })
       .on(GetLatestConfigurationCommand)
       .resolves({
         Configuration: mockData,
-        NextPollConfigurationToken: mockNextToken,
+        NextPollConfigurationToken: 'hijklmn',
       });
 
     // Act
-    const result = await getAppConfig(name, options);
+    const result: string | undefined = await getAppConfig('my-config', {
+      application: 'my-app',
+      environment: 'prod',
+      transform: Transform.BINARY,
+    });
 
     // Assess
     expect(result).toBe(expectedValue);
+  });
+
+  test('when called with transform: `json` option, it returns a JSON value', async () => {
+    // Prepare
+    const expectedValue = { foo: 'my-value' };
+    const mockData = encoder.encode(JSON.stringify(expectedValue));
+    client
+      .on(StartConfigurationSessionCommand)
+      .resolves({
+        InitialConfigurationToken: 'abcdefg',
+      })
+      .on(GetLatestConfigurationCommand)
+      .resolves({
+        Configuration: mockData,
+        NextPollConfigurationToken: 'hijklmn',
+      });
+
+    // Act
+    const result: JSONValue = await getAppConfig('my-config', {
+      application: 'my-app',
+      environment: 'prod',
+      transform: Transform.JSON,
+    });
+
+    // Assess
+    expect(result).toStrictEqual(expectedValue);
   });
 });

--- a/packages/parameters/tests/unit/getParameter.test.ts
+++ b/packages/parameters/tests/unit/getParameter.test.ts
@@ -3,7 +3,7 @@
  *
  * @group unit/parameters/ssm/getParameter/function
  */
-import { DEFAULT_PROVIDERS } from '../../src/BaseProvider';
+import { DEFAULT_PROVIDERS } from '../../src/base';
 import { SSMProvider, getParameter } from '../../src/ssm';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';

--- a/packages/parameters/tests/unit/getParameters.test.ts
+++ b/packages/parameters/tests/unit/getParameters.test.ts
@@ -3,7 +3,7 @@
  *
  * @group unit/parameters/ssm/getParameters/function
  */
-import { DEFAULT_PROVIDERS } from '../../src/BaseProvider';
+import { DEFAULT_PROVIDERS } from '../../src/base';
 import { SSMProvider, getParameters } from '../../src/ssm';
 import { SSMClient, GetParametersByPathCommand } from '@aws-sdk/client-ssm';
 import { mockClient } from 'aws-sdk-client-mock';

--- a/packages/parameters/tests/unit/getParametersByName.test.ts
+++ b/packages/parameters/tests/unit/getParametersByName.test.ts
@@ -3,7 +3,7 @@
  *
  * @group unit/parameters/ssm/getParametersByName/function
  */
-import { DEFAULT_PROVIDERS } from '../../src/BaseProvider';
+import { DEFAULT_PROVIDERS } from '../../src/base';
 import { SSMProvider, getParametersByName } from '../../src/ssm';
 import type { SSMGetParametersByNameOptions } from '../../src/types/SSMProvider';
 

--- a/packages/parameters/tests/unit/getSecret.test.ts
+++ b/packages/parameters/tests/unit/getSecret.test.ts
@@ -3,7 +3,7 @@
  *
  * @group unit/parameters/SecretsProvider/getSecret/function
  */
-import { DEFAULT_PROVIDERS } from '../../src/BaseProvider';
+import { DEFAULT_PROVIDERS } from '../../src/base';
 import { SecretsProvider, getSecret } from '../../src/secrets';
 import {
   SecretsManagerClient,

--- a/packages/parameters/typedoc.json
+++ b/packages/parameters/typedoc.json
@@ -1,10 +1,19 @@
 {
-  "extends": ["../../typedoc.base.json"],
+  "extends": [
+    "../../typedoc.base.json"
+  ],
   "entryPoints": [
     "./src/appconfig/index.ts",
+    "./src/types/AppConfigProvider.ts",
     "./src/ssm/index.ts",
+    "./src/types/SSMProvider.ts",
     "./src/dynamodb/index.ts",
+    "./src/types/DynamoDBProvider.ts",
     "./src/secrets/index.ts",
-    "./src/types/index.ts"],
+    "./src/types/SecretsProvider.ts",
+    "./src/base/index.ts",
+    "./src/errors.ts",
+    "./src/constants.ts",
+  ],
   "readme": "README.md"
 }


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR touches most of the files in the Parameters utility with the goal of streamlining the types of the inputs & outputs of each provider, as well as finalizing the exports that the utility will make available to customers. Additionally, it also adds a few types/[type guards](https://blog.logrocket.com/how-to-use-type-guards-typescript/) in the commons utility which are currently used by the parameters utility but that will be used by others as well.

### Exports

As mentioned in previous issues/PRs/discussions, we want customers to be able to tree-shake the library as much as possible and be able to build the project without the need of installing dependencies that might needed by parts of the code that they are not using.

For example, in Parameters, customers using the `SecretsProvider` might not be interested in bringing into their project `@aws-sdk/client-appconfigdata`, a dependency needed by the `AppConfigProvider`. To allow for this, we need to create granular exports in the `package.json` of the utility.

The exports are governed by the `exports` and `typeVersions` sections of the `package.json` of the utility. The first one tells Node.js where to resolve a certain path in the `node_modules` entry of the utility, whereas the `typeVersions` section tells TypeScript where to find the types for that same path.

The exports that we are offering are:
```ts
import { Transform } from '@aws-lambda-powertools/parameters';
import { GetParameterError } from '@aws-lambda-powertools/parameters/errors';
import { ... } from '@aws-lambda-powertools/parameters/<PROVIDER>';
import type { ... } from '@aws-lambda-powertools/parameters/<PROVIDER>/types';
```

The first export, and only top-level one, is a readonly object that contains the different transform available so that customers can use it like `Transform.JSON` or `Transform.AUTO` and not have to worry about spelling or case (although the regular string is still allowed).

The second export, under `/errors` exposes the types of errors that can be thrown by the utility. This can be used by customers to catch & handle errors or during tests.

The other exports are all specific to the providers, for example, the SSM provider, exports the following things:
```ts
import {
  getParameter,
  getParameters,
  getParametersByName,
  SSMProvider,
 } from '@aws-lambda-powertools/parameters/ssm';
import type { ... } from '@aws-lambda-powertools/parameters/ssm/types'; // all the types specific to SSMProvider & functions
```

The other providers follow the same logic. We are also exposing the `BaseProvider` under the `/base` path, this way customers will be able to extend this class to create their own custom provider.

In order to support these exports I had to partially reorganize the folder structure of the utility; this is the main driver behind the large diff.

#### Base Provider

Before this PR, the `BaseProvider` was quite strict in the return types for the `get` and `getMultiple` methods. Specifically, it allowed only to return `string`, `Uint8Array`, `Record<string, unknown>`, and `undefined`. These types were overly restrictive and would have hindered the extensibility of the provider.

When researching HashiCorp Vault for #1320 I discovered that this particular store returned types that were incompatible with the types described above, this sparked also the discussion in aws-powertools/powertools-lambda-python#2250.

Starting from this PR, the `BaseProvider` is free to return a promise that resolves to `unknown`. The `BaseProvider` handles caching and transformations only, so it doesn't need to know the types it's handling when returning. The actual value retrieval is done by the `_get` & `_getMultiple` methods, which are `abstract` and leave the actual implementation to more specific providers.

With this in mind, `BaseProvider` can return `unknown` and not care about the return types as long as the downstream providers (i.e. `SecretsProvider`, `DynamoDBProvider`, or `VaultProvider`) handle and validate the types they retrieve and return as needed.

Once made this change I had to do some light rework of the types & add some runtime type-checks to the transform function so that we are able to work with unknown types most of the time and still apply the transform only on types we want.

#### Adaptive types for `DynamoDBProvider` and `AppConfigProvider`

Continuing the work started in previous releases for the other providers, I have applied generics to these two providers so that we can make some assumptions on the return type based on the transformations applied, or allow customers to specify a type if they know more than the compiler.

This closes #1425, and closes #1424

#### Updates to JSON transform types

Before this PR I mistakenly assumed that when applying a JSON transform the result type would always be an object (`{}` / `Record<string, unknown>`. This was a naïve assumption.

In reality, the JSON specification allows to parse and considers many/most primitive types as valid JSON documents. For instance, `"hello"`, `5`, `true`, and `[]` among others, are all valid JSON documents that can be processed with `JSON.parse()`.

For this reason I introduced some new types in the `commons` utility that represent these primitives. The new `JSONValue`, which includes the combinations of primitives as well as arrays and objects containing these primitives, is now used as default return type whenever a JSON transform is applied.

As a side note, the types just discussed will be useful also for the Idempotency utility and for other utilities handling unknown payloads that can be JSON parsed/stringified.

#### Miscellaneous 

While working on the PR I also had to do changes here & there, these don't fit in any specific category:
- Shortened/standardized the names of most customer-facing types/interfaces (i.e. `SSMGetOptionsUnion` becomes simply `SSMGetOptions`)
- Fixed some formatting issues in the docstrings as I encountered & updated the `typedoc.json` config to reflect the new exports
- Updates to unit & integration tests to reflect the changes above (mostly imports & types-related)

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1424

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.