### PR TITLE
fix(idempotency): pass lambda context remaining time to save inprogress

### DIFF
--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -141,7 +141,8 @@ export class IdempotencyHandler<U> {
 
     try {
       await this.persistenceStore.saveInProgress(
-        this.functionPayloadToBeHashed
+        this.functionPayloadToBeHashed,
+        this.idempotencyConfig.lambdaContext?.getRemainingTimeInMillis()
       );
     } catch (e) {
       if (e instanceof IdempotencyItemAlreadyExistsError) {

--- a/packages/idempotency/src/idempotentDecorator.ts
+++ b/packages/idempotency/src/idempotentDecorator.ts
@@ -5,6 +5,16 @@ import {
 } from './types';
 import { IdempotencyHandler } from './IdempotencyHandler';
 import { IdempotencyConfig } from './IdempotencyConfig';
+import { Context } from 'aws-lambda';
+
+const isContext = (arg: unknown): arg is Context => {
+  return (
+    arg !== undefined &&
+    arg !== null &&
+    typeof arg === 'object' &&
+    'getRemainingTimeInMillis' in arg
+  );
+};
 
 /**
  * use this function to narrow the type of options between IdempotencyHandlerOptions and IdempotencyFunctionOptions
@@ -28,14 +38,20 @@ const idempotent = function (
     descriptor: PropertyDescriptor
   ) {
     const childFunction = descriptor.value;
-    descriptor.value = function (record: GenericTempRecord) {
+    descriptor.value = function (
+      record: GenericTempRecord,
+      ...args: unknown[]
+    ) {
       const functionPayloadtoBeHashed = isFunctionOption(options)
         ? record[(options as IdempotencyFunctionOptions).dataKeywordArgument]
         : record;
-
       const idempotencyConfig = options.config
         ? options.config
         : new IdempotencyConfig({});
+      const context = args[0];
+      if (isContext(context)) {
+        idempotencyConfig.registerLambdaContext(context);
+      }
       const idempotencyHandler = new IdempotencyHandler<GenericTempRecord>({
         functionToMakeIdempotent: childFunction,
         functionPayloadToBeHashed: functionPayloadtoBeHashed,

--- a/packages/idempotency/src/idempotentDecorator.ts
+++ b/packages/idempotency/src/idempotentDecorator.ts
@@ -32,6 +32,7 @@ const idempotent = function (
       const functionPayloadtoBeHashed = isFunctionOption(options)
         ? record[(options as IdempotencyFunctionOptions).dataKeywordArgument]
         : record;
+
       const idempotencyConfig = options.config
         ? options.config
         : new IdempotencyConfig({});

--- a/packages/idempotency/tests/e2e/makeFunctionIdempotent.test.FunctionCode.ts
+++ b/packages/idempotency/tests/e2e/makeFunctionIdempotent.test.FunctionCode.ts
@@ -2,6 +2,7 @@ import type { Context } from 'aws-lambda';
 import { DynamoDBPersistenceLayer } from '../../src/persistence/DynamoDBPersistenceLayer';
 import { makeFunctionIdempotent } from '../../src';
 import { Logger } from '@aws-lambda-powertools/logger';
+import { IdempotencyConfig } from '../../src';
 
 const IDEMPOTENCY_TABLE_NAME =
   process.env.IDEMPOTENCY_TABLE_NAME || 'table_name';
@@ -32,15 +33,19 @@ const processRecord = (record: Record<string, unknown>): string => {
   return 'Processing done: ' + record['foo'];
 };
 
+const idempotencyConfig = new IdempotencyConfig({});
+
 const processIdempotently = makeFunctionIdempotent(processRecord, {
   persistenceStore: dynamoDBPersistenceLayer,
   dataKeywordArgument: 'foo',
+  config: idempotencyConfig,
 });
 
 export const handler = async (
   _event: EventRecords,
   _context: Context
 ): Promise<void> => {
+  idempotencyConfig.registerLambdaContext(_context);
   for (const record of _event.records) {
     const result = await processIdempotently(record);
     logger.info(result.toString());
@@ -52,12 +57,14 @@ export const handler = async (
 const processIdempotentlyCustomized = makeFunctionIdempotent(processRecord, {
   persistenceStore: ddbPersistenceLayerCustomized,
   dataKeywordArgument: 'foo',
+  config: idempotencyConfig,
 });
 
 export const handlerCustomized = async (
   _event: EventRecords,
   _context: Context
 ): Promise<void> => {
+  idempotencyConfig.registerLambdaContext(_context);
   for (const record of _event.records) {
     const result = await processIdempotentlyCustomized(record);
     logger.info(result.toString());

--- a/packages/idempotency/tests/e2e/makeFunctionIdempotent.test.ts
+++ b/packages/idempotency/tests/e2e/makeFunctionIdempotent.test.ts
@@ -109,6 +109,7 @@ describe('Idempotency e2e test function wrapper, default settings', () => {
           { id: 3, foo: 'bar' },
         ],
       };
+      const invokeStart = Date.now();
       await invokeFunction(
         functionNameDefault,
         2,
@@ -136,6 +137,10 @@ describe('Idempotency e2e test function wrapper, default settings', () => {
         })
       );
       expect(resultFirst?.Item?.data).toEqual('Processing done: bar');
+      expect(resultFirst?.Item?.expiration).toBeGreaterThan(Date.now() / 1000);
+      expect(resultFirst?.Item?.in_progress_expiration).toBeGreaterThan(
+        invokeStart
+      );
       expect(resultFirst?.Item?.status).toEqual('COMPLETED');
 
       const resultSecond = await ddb.send(
@@ -145,6 +150,10 @@ describe('Idempotency e2e test function wrapper, default settings', () => {
         })
       );
       expect(resultSecond?.Item?.data).toEqual('Processing done: baz');
+      expect(resultSecond?.Item?.expiration).toBeGreaterThan(Date.now() / 1000);
+      expect(resultSecond?.Item?.in_progress_expiration).toBeGreaterThan(
+        invokeStart
+      );
       expect(resultSecond?.Item?.status).toEqual('COMPLETED');
     },
     TEST_CASE_TIMEOUT

--- a/packages/idempotency/tests/unit/idempotentDecorator.test.ts
+++ b/packages/idempotency/tests/unit/idempotentDecorator.test.ts
@@ -47,7 +47,6 @@ const functionalityToDecorate = jest.fn();
 class TestinClassWithLambdaHandler {
   @idempotentLambdaHandler({
     persistenceStore: new PersistenceLayerTestClass(),
-    config: new IdempotencyConfig({ lambdaContext: mockLambaContext }),
   })
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public testing(record: Record<string, unknown>, context: Context): string {
@@ -113,10 +112,7 @@ describe('Given a class with a function to decorate', (classWithLambdaHandler = 
     });
 
     test('Then it will save the record to INPROGRESS', () => {
-      expect(mockSaveInProgress).toBeCalledWith(
-        inputRecord,
-        mockLambaContext.getRemainingTimeInMillis()
-      );
+      expect(mockSaveInProgress).toBeCalledWith(inputRecord, undefined);
     });
 
     test('Then it will call the function that was decorated', () => {
@@ -149,10 +145,7 @@ describe('Given a class with a function to decorate', (classWithLambdaHandler = 
     });
 
     test('Then it will attempt to save the record to INPROGRESS', () => {
-      expect(mockSaveInProgress).toBeCalledWith(
-        inputRecord,
-        mockLambaContext.getRemainingTimeInMillis()
-      );
+      expect(mockSaveInProgress).toBeCalledWith(inputRecord, undefined);
     });
 
     test('Then it will get the previous execution record', () => {
@@ -189,10 +182,7 @@ describe('Given a class with a function to decorate', (classWithLambdaHandler = 
     });
 
     test('Then it will attempt to save the record to INPROGRESS', () => {
-      expect(mockSaveInProgress).toBeCalledWith(
-        inputRecord,
-        mockLambaContext.getRemainingTimeInMillis()
-      );
+      expect(mockSaveInProgress).toBeCalledWith(inputRecord, undefined);
     });
 
     test('Then it will get the previous execution record', () => {
@@ -225,10 +215,7 @@ describe('Given a class with a function to decorate', (classWithLambdaHandler = 
     });
 
     test('Then it will attempt to save the record to INPROGRESS', () => {
-      expect(mockSaveInProgress).toBeCalledWith(
-        inputRecord,
-        mockLambaContext.getRemainingTimeInMillis()
-      );
+      expect(mockSaveInProgress).toBeCalledWith(inputRecord, undefined);
     });
 
     test('Then it will get the previous execution record', () => {


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes
In this PR we fix the issue to pass lambda context remaining execution time to save in progress. This only applies to function wrapper for now. We need to rework the entire decorator signature to extract the context, this will be handled in a separate PR. 
<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1482 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.