### PR TITLE
feat(tracer): close & restore segments when other middlewares return

### DIFF
--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -356,8 +356,8 @@ describe('Middy middleware', () => {
       .use(myCustomMiddleware());
 
     // Act
-    await handler({}, context);
-    await handler({}, context);
+    await handler({ idx: 0 }, context);
+    await handler({ idx: 1 }, context);
 
     // Assess
     // Check that the subsegments are closed

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -3,7 +3,6 @@
  *
  * @group unit/tracer/all
  */
-
 import { captureLambdaHandler } from '../../src/middleware/middy';
 import middy from '@middy/core';
 import { Tracer } from './../../src';
@@ -13,6 +12,7 @@ import {
   setContextMissingStrategy,
   Subsegment,
 } from 'aws-xray-sdk-core';
+import { cleanupMiddlewares } from '@aws-lambda-powertools/commons/lib/middleware';
 
 jest.spyOn(console, 'debug').mockImplementation(() => null);
 jest.spyOn(console, 'warn').mockImplementation(() => null);
@@ -305,5 +305,67 @@ describe('Middy middleware', () => {
       'Service',
       'hello-world'
     );
+  });
+
+  test('when enabled, and another middleware returns early, it still closes and restores the segments correctly', async () => {
+    // Prepare
+    const tracer = new Tracer();
+    const setSegmentSpy = jest
+      .spyOn(tracer.provider, 'setSegment')
+      .mockImplementation(() => ({}));
+    jest.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
+    jest
+      .spyOn(tracer, 'addServiceNameAnnotation')
+      .mockImplementation(() => ({}));
+    const facadeSegment1 = new Segment('facade');
+    const handlerSubsegment1 = new Subsegment('## index.handlerA');
+    jest
+      .spyOn(facadeSegment1, 'addNewSubsegment')
+      .mockImplementation(() => handlerSubsegment1);
+    const facadeSegment2 = new Segment('facade');
+    const handlerSubsegment2 = new Subsegment('## index.handlerB');
+    jest
+      .spyOn(facadeSegment2, 'addNewSubsegment')
+      .mockImplementation(() => handlerSubsegment2);
+    jest
+      .spyOn(tracer.provider, 'getSegment')
+      .mockImplementationOnce(() => facadeSegment1)
+      .mockImplementationOnce(() => facadeSegment2);
+    const myCustomMiddleware = (): middy.MiddlewareObj => {
+      const before = async (
+        request: middy.Request
+      ): Promise<undefined | string> => {
+        // Return early on the second invocation
+        if (request.event.idx === 1) {
+          // Cleanup Powertools resources
+          await cleanupMiddlewares(request);
+
+          // Then return early
+          return 'foo';
+        }
+      };
+
+      return {
+        before,
+      };
+    };
+    const handler = middy((): void => {
+      console.log('Hello world!');
+    })
+      .use(captureLambdaHandler(tracer, { captureResponse: false }))
+      .use(myCustomMiddleware());
+
+    // Act
+    await handler({}, context);
+    await handler({}, context);
+
+    // Assess
+    // Check that the subsegments are closed
+    expect(handlerSubsegment1.isClosed()).toBe(true);
+    expect(handlerSubsegment2.isClosed()).toBe(true);
+    // Check that the segments are restored
+    expect(setSegmentSpy).toHaveBeenCalledTimes(4);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(2, facadeSegment1);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegment2);
   });
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces new logic to the `captureLambdaHandler()` Middy middleware offered by Tracer to allow it to close and restore any open segments whenever another middleware down in the stack returns early.

This is made possible by the `cleanupMiddlewares` function shipped in `commons` in the previous release. The new logic sets a reference to a cleanup function in the Middy internal storage using a scoped key. This way, Middy middlewares that want to return early can call the `cleanupMiddlewares` function which will execute all the cleanup functions available. This is useful for those middlewares like Idempotency, that want to return a result bypassing the Lambda handler and the normal Middy request lifecycle.

I have also added a unit test case to verify that the cleanup logic is executed.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1536

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.