### PR TITLE
fix(metrics): flush metrics when data points array reaches max size

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -7,6 +7,7 @@ import {
   MAX_METRICS_SIZE,
   DEFAULT_NAMESPACE,
   COLD_START_METRIC,
+  MAX_METRIC_VALUES_SIZE,
 } from './constants';
 import {
   MetricsOptions,
@@ -662,7 +663,10 @@ class Metrics extends Utility implements MetricsInterface {
   }
 
   /**
-   * Stores a metric in the buffer
+   * Stores a metric in the buffer.
+   *
+   * If the buffer is full, or the metric reaches the maximum number of values,
+   * the buffer is published to stdout.
    *
    * @param name The name of the metric to store
    * @param unit The unit of the metric to store
@@ -692,6 +696,9 @@ class Metrics extends Utility implements MetricsInterface {
         storedMetric.value = [storedMetric.value];
       }
       storedMetric.value.push(value);
+      if (storedMetric.value.length === MAX_METRIC_VALUES_SIZE) {
+        this.publishStoredMetrics();
+      }
     }
   }
 }

--- a/packages/metrics/src/constants.ts
+++ b/packages/metrics/src/constants.ts
@@ -1,4 +1,13 @@
-export const COLD_START_METRIC = 'ColdStart';
-export const DEFAULT_NAMESPACE = 'default_namespace';
-export const MAX_METRICS_SIZE = 100;
-export const MAX_DIMENSION_COUNT = 29;
+const COLD_START_METRIC = 'ColdStart';
+const DEFAULT_NAMESPACE = 'default_namespace';
+const MAX_METRICS_SIZE = 100;
+const MAX_METRIC_VALUES_SIZE = 100;
+const MAX_DIMENSION_COUNT = 29;
+
+export {
+  COLD_START_METRIC,
+  DEFAULT_NAMESPACE,
+  MAX_METRICS_SIZE,
+  MAX_METRIC_VALUES_SIZE,
+  MAX_DIMENSION_COUNT,
+};

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -16,6 +16,7 @@ import {
   DEFAULT_NAMESPACE,
   MAX_DIMENSION_COUNT,
   MAX_METRICS_SIZE,
+  MAX_METRIC_VALUES_SIZE,
 } from '../../src/constants';
 import { setupDecoratorLambdaHandler } from '../helpers/metricsUtils';
 import {
@@ -708,7 +709,7 @@ describe('Class: Metrics', () => {
       const metricName = 'test-metric';
 
       // Act
-      for (let i = 0; i <= MAX_METRICS_SIZE; i++) {
+      for (let i = 0; i <= MAX_METRIC_VALUES_SIZE; i++) {
         metrics.addMetric(`${metricName}`, MetricUnits.Count, i);
       }
       metrics.publishStoredMetrics();
@@ -723,8 +724,10 @@ describe('Class: Metrics', () => {
         consoleSpy.mock.calls[1][0]
       ) as EmfOutput;
 
-      expect(firstMetricsJson[metricName]).toHaveLength(MAX_METRICS_SIZE);
-      expect(secondMetricsJson[metricName]).toHaveLength(1);
+      // The first batch of values should be an array of size MAX_METRIC_VALUES_SIZE
+      expect(firstMetricsJson[metricName]).toHaveLength(MAX_METRIC_VALUES_SIZE);
+      // The second should be a single value (the last value added, which is 100 given we start from 0)
+      expect(secondMetricsJson[metricName]).toEqual(100);
     });
 
     test('it should not publish metrics if stored metrics count has not reached max metric size threshold', () => {

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -701,6 +701,32 @@ describe('Class: Metrics', () => {
       );
     });
 
+    test('it should publish metrics when the array of values reaches the maximum size', () => {
+      // Prepare
+      const metrics: Metrics = new Metrics({ namespace: TEST_NAMESPACE });
+      const consoleSpy = jest.spyOn(console, 'log');
+      const metricName = 'test-metric';
+
+      // Act
+      for (let i = 0; i <= MAX_METRICS_SIZE; i++) {
+        metrics.addMetric(`${metricName}`, MetricUnits.Count, i);
+      }
+      metrics.publishStoredMetrics();
+
+      // Assess
+      // 2 calls to console.log: 1 for the first batch of metrics, 1 for the second batch (explicit call)
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      const firstMetricsJson = JSON.parse(
+        consoleSpy.mock.calls[0][0]
+      ) as EmfOutput;
+      const secondMetricsJson = JSON.parse(
+        consoleSpy.mock.calls[1][0]
+      ) as EmfOutput;
+
+      expect(firstMetricsJson[metricName]).toHaveLength(MAX_METRICS_SIZE);
+      expect(secondMetricsJson[metricName]).toHaveLength(1);
+    });
+
     test('it should not publish metrics if stored metrics count has not reached max metric size threshold', () => {
       // Prepare
       const metrics: Metrics = new Metrics({ namespace: TEST_NAMESPACE });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As reported in the linked issue prior to this PR the Metrics utility allowed to add a number of data points greater than the current 100 limit set by the EMF specification. This PR fixes the issue by ensuring that when a new data point is added and the limit is reached, all the stored metrics are flushed right away.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** fixes #1529

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.