### PR TITLE
fix(docs/ci): change how versions and aliases are inserted into versions.json

### DIFF
--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -140,7 +140,7 @@ jobs:
         #      - we assign the input as $o and the new version/alias as $n, 
         #      - we check if the version number exists in the file already (for republishing docs)
         #      - if it's an alias (stage/latest/*) or old version, we do nothing and output $o (original input)
-        #.     - if it's a new version number, we add it at position 0 in the array.
+        #      - if it's a new version number, we add it at position 0 in the array.
         #   4. Once done, we'll upload it back to S3.
         run: |
           aws s3 cp \

--- a/.github/workflows/reusable-publish-docs.yml
+++ b/.github/workflows/reusable-publish-docs.yml
@@ -136,14 +136,18 @@ jobs:
         # Operations:
         #   1. Download the versions.json file from S3
         #   2. Find any reference to the alias and delete it from the versions file
-        #   3. We insert the new version to the versions.json file with the corresponding alias
+        #   3. This is voodoo (don't use JQ):
+        #      - we assign the input as $o and the new version/alias as $n, 
+        #      - we check if the version number exists in the file already (for republishing docs)
+        #      - if it's an alias (stage/latest/*) or old version, we do nothing and output $o (original input)
+        #.     - if it's a new version number, we add it at position 0 in the array.
         #   4. Once done, we'll upload it back to S3.
         run: |
           aws s3 cp \
             s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-typescript/versions.json \
             versions_old.json
           jq 'del(.[].aliases[] | select(. == "${{ env.ALIAS }}"))' < versions_old.json > versions_proc.json
-          jq '. += [{"version": "${{ env.VERSION }}", "title": "${{ env.VERSION }}", "aliases": ["${{ env.ALIAS }}"]}]' < versions_proc.json > versions.json
+          jq '. as $o | [{"title": "${{ env.VERSION }}", "version": ${{ env.VERSION }}, "aliases": ${{env.ALIAS}} }] as $n | $n | if .[0].title | test("[a-z]+") or any($o[].title == "${{ env.VERSION }}";.) then $o else $n + $o end' < versions_proc.json > versions.json
           aws s3 cp \
             versions.json \
             s3://${{ secrets.AWS_DOCS_BUCKET }}/lambda-typescript/versions.json


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
--

versions.json generation:

  - we assign the input as $o and the new version/alias as $n, 
  - we check if the version number exists in the file already (for republishing docs)
  - if it's an alias (stage/latest/*) or old version, we do nothing and output $o (original input)
  - if it's a new version number, we add it at position 0 in the array.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1520 

## Checklist

- [X] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [X] I have performed a *self-review* of my own code
- [X] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [X] I have made corresponding changes to the *documentation*
- [X] My changes generate *no new warnings*
- [X] I have *added tests* that prove my change is effective and works
- [X] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [X] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.