### PR TITLE
tests(tracer): update docs url for e2e tests

### DIFF
--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -52,7 +52,7 @@ export class MyFunctionBase {
           Item: { id: `${serviceName}-${event.invocation}-sdkv2` },
         })
         .promise(),
-      axios.get('https://docs.powertools.aws.dev/lambda-typescript/latest/', {
+      axios.get('https://docs.powertools.aws.dev/lambda/typescript/latest/', {
         timeout: 5000,
       }),
       new Promise((resolve, reject) => {

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
@@ -56,7 +56,7 @@ export const handler = async (
       })
       .promise();
     await axios.get(
-      'https://docs.powertools.aws.dev/lambda-typescript/latest/',
+      'https://docs.powertools.aws.dev/lambda/typescript/latest/',
       { timeout: 5000 }
     );
 

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
@@ -46,7 +46,7 @@ const testHandler = async (
       })
     );
     await axios.get(
-      'https://docs.powertools.aws.dev/lambda-typescript/latest/',
+      'https://docs.powertools.aws.dev/lambda/typescript/latest/',
       { timeout: 5000 }
     );
 

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -56,7 +56,7 @@ export class MyFunctionBase {
         })
       );
       await axios.get(
-        'https://docs.powertools.aws.dev/lambda-typescript/latest/',
+        'https://docs.powertools.aws.dev/lambda/typescript/latest/',
         { timeout: 5000 }
       );
 
@@ -82,9 +82,8 @@ class MyFunctionWithDecorator extends MyFunctionBase {
   // @ts-ignore
   public async handler(
     event: CustomEvent,
-    _context: Context,
-    _callback: Callback<unknown>
-  ): void | Promise<unknown> {
+    _context: Context
+  ): Promise<unknown> {
     return super.handler(event, _context);
   }
 
@@ -105,9 +104,8 @@ export class MyFunctionWithDecoratorAndCustomNamedSubSegmentForMethod extends My
   // @ts-ignore
   public async handler(
     event: CustomEvent,
-    _context: Context,
-    _callback: Callback<unknown>
-  ): void | Promise<unknown> {
+    _context: Context
+  ): Promise<unknown> {
     return super.handler(event, _context);
   }
 


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR changes the url used to make outbound HTTP calls in the integration tests for the Tracer utility. The new url represents the latest homepage for our docs.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1557

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.