### PR TITLE
fix(ci): remove old release tag version for layer

### DIFF
--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
     inputs:
       latest_published_version:
-        description: "Latest npm published version to rebuild corresponding layer for, e.g. v1.0.2"
-        default: "v1.0.2"
+        description: "Latest npm published version to rebuild corresponding layer for, e.g. 1.0.2"
+        default: "1.0.2"
         required: true
 
   workflow_call:
@@ -40,20 +40,14 @@ jobs:
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
         with:
           node-version: "18"
-      - name: Set release notes tag
-        run: |
-          RELEASE_INPUT=${{ inputs.latest_published_version }}
-          LATEST_TAG=$(git describe --tag --abbrev=0)
-          RELEASE_TAG_VERSION=${RELEASE_INPUT:-$LATEST_TAG}
-          echo "RELEASE_TAG_VERSION=${RELEASE_TAG_VERSION:1}" >> $GITHUB_ENV
       - name: Setup dependencies
         uses: ./.github/actions/cached-node-modules
       - name: Create layer files
         run: |
-          export VERSION=$RELEASE_TAG_VERSION
+          export VERSION=${{ inputs.latest_published_version }}
           bash .github/scripts/setup_tmp_layer_files.sh
       - name: CDK build
-        run: npm run cdk -w layers -- synth --context PowertoolsPackageVersion=$RELEASE_TAG_VERSION -o cdk.out
+        run: npm run cdk -w layers -- synth --context PowertoolsPackageVersion=${{ inputs.latest_published_version }} -o cdk.out
       - name: Zip output
         run: zip -r cdk.out.zip layers/cdk.out
       - name: Archive CDK artifacts


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

We no longer need the to run the bash script to determine the version for layer build step. Now, the input passed to the layer workflow is a correct version without the `v` prefix. 

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1569 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.