### PR TITLE
feat(logger): improve default log formatter ordering

### DIFF
--- a/packages/logger/src/formatter/PowertoolLogFormatter.ts
+++ b/packages/logger/src/formatter/PowertoolLogFormatter.ts
@@ -4,7 +4,9 @@ import { PowertoolLog } from '../types/formats';
 
 /**
  * This class is used to transform a set of log key-value pairs
- * in the AWS Lambda Powertools' default structure log format.
+ * in the AWS Lambda Powertools' default structure log format. It orders
+ * attribute keys in a way that should be useful when visually scanning logs in
+ * a UI such as the Cloudwatch console.
  *
  * @class
  * @extends {LogFormatter}
@@ -18,17 +20,17 @@ class PowertoolLogFormatter extends LogFormatter {
    */
   public formatAttributes(attributes: UnformattedAttributes): PowertoolLog {
     return {
-      cold_start: attributes.lambdaContext?.coldStart,
-      function_arn: attributes.lambdaContext?.invokedFunctionArn,
-      function_memory_size: attributes.lambdaContext?.memoryLimitInMB,
-      function_name: attributes.lambdaContext?.functionName,
-      function_request_id: attributes.lambdaContext?.awsRequestId,
       level: attributes.logLevel,
       message: attributes.message,
-      sampling_rate: attributes.sampleRateValue,
-      service: attributes.serviceName,
-      timestamp: this.formatTimestamp(attributes.timestamp),
+      function_request_id: attributes.lambdaContext?.awsRequestId,
       xray_trace_id: attributes.xRayTraceId,
+      cold_start: attributes.lambdaContext?.coldStart,
+      function_memory_size: attributes.lambdaContext?.memoryLimitInMB,
+      service: attributes.serviceName,
+      sampling_rate: attributes.sampleRateValue,
+      function_arn: attributes.lambdaContext?.invokedFunctionArn,
+      function_name: attributes.lambdaContext?.functionName,
+      timestamp: this.formatTimestamp(attributes.timestamp),
     };
   }
 }


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

This resolves #1568. The problem raised in that issue is that the log formatter outputs log lines with keys written in alphabetical order. In practice, that means they start off with the cold start flag, the `function_arn`, `function_name`, `function_memory_size`, and a whole bunch of other stuff that is not usually of interest. The actual log level and message are buried and need log lines expanded to be seen. Even when expanded, they're hard to visually spot at a glance. When viewing a log group in Cloudwatch or some other UI that truncates log lines, you effectively see no useful information at all.

This screenshot shows what the experience is like:

<img width="1465" alt="Screenshot 2023-06-29 at 6 58 58 AM" src="https://github.com/aws-powertools/powertools-lambda-typescript/assets/707147/d75c920b-943d-41f5-b049-5e7a0245cea6">

This change addresses the problem by surfacing log properties in order of usefulness. This is a subjective decision, and opinions may vary, but the order submitted in this PR should be preferable for the vast majority of users. The "at-a-glance" view of logs should now be actionable and help with log-diving and debugging. The actual information recorded is unchanged and log insight queries should still work as before.

The serialization order is well-defined in modern ECMAScript engines:

Serialization From the MDN docs on `JSON.stringify`:

> Only enumerable own properties are visited. This means `Map`, `Set`,
> etc. will become `"{}"`. You can use the replacer parameter to
> serialize them to something more useful. Properties are visited using
> the same algorithm as `Object.keys()`, which has a well-defined order
> and is stable across implementations. For example, `JSON.stringify` on
> the same object will always produce the same string, and
> `JSON.parse(JSON.stringify(obj))` would produce an object with the
> same key ordering as the original (assuming the object is completely
> JSON-serializable).
>
> Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#description

And the note about what that order is:

> The traversal order, as of modern ECMAScript specification, is
> well-defined and consistent across implementations. Within each
> component of the prototype chain, all non-negative integer keys (those
> that can be array indices) will be traversed first in ascending order
> by value, then other string keys in ascending chronological order of
> property creation.
>
> Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in



### Related issues, RFCs

**Issue number:** #1568 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [ ] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.