### PR TITLE
feat(batch): Support for Lambda context access in batch processing

### DIFF
--- a/packages/batch/src/BasePartialProcessor.ts
+++ b/packages/batch/src/BasePartialProcessor.ts
@@ -3,6 +3,7 @@
  */
 import {
   BaseRecord,
+  BatchProcessingOptions,
   EventSourceDataClassTypes,
   FailureResponse,
   ResultType,
@@ -15,6 +16,8 @@ abstract class BasePartialProcessor {
   public failureMessages: EventSourceDataClassTypes[];
 
   public handler: CallableFunction;
+
+  public options?: BatchProcessingOptions;
 
   public records: BaseRecord[];
 
@@ -92,10 +95,15 @@ abstract class BasePartialProcessor {
    */
   public register(
     records: BaseRecord[],
-    handler: CallableFunction
+    handler: CallableFunction,
+    options?: BatchProcessingOptions
   ): BasePartialProcessor {
     this.records = records;
     this.handler = handler;
+
+    if (options) {
+      this.options = options;
+    }
 
     return this;
   }

--- a/packages/batch/src/BatchProcessor.ts
+++ b/packages/batch/src/BatchProcessor.ts
@@ -19,7 +19,13 @@ class BatchProcessor extends BasePartialBatchProcessor {
   ): Promise<SuccessResponse | FailureResponse> {
     try {
       const data = this.toBatchType(record, this.eventType);
-      const result = await this.handler(data);
+
+      let result: unknown;
+      if (this.options) {
+        result = await this.handler(data, this.options);
+      } else {
+        result = await this.handler(data);
+      }
 
       return this.successHandler(record, result);
     } catch (e) {

--- a/packages/batch/src/BatchProcessor.ts
+++ b/packages/batch/src/BatchProcessor.ts
@@ -20,12 +20,7 @@ class BatchProcessor extends BasePartialBatchProcessor {
     try {
       const data = this.toBatchType(record, this.eventType);
 
-      let result: unknown;
-      if (this.options) {
-        result = await this.handler(data, this.options);
-      } else {
-        result = await this.handler(data);
-      }
+      const result = await this.handler(data, this.options);
 
       return this.successHandler(record, result);
     } catch (e) {

--- a/packages/batch/src/processPartialResponse.ts
+++ b/packages/batch/src/processPartialResponse.ts
@@ -28,13 +28,7 @@ const processPartialResponse = async (
     );
   }
 
-  const records = event['Records'];
-
-  if (options) {
-    processor.register(records, recordHandler, options);
-  } else {
-    processor.register(records, recordHandler);
-  }
+  processor.register(event.Records, recordHandler, options);
 
   await processor.process();
 

--- a/packages/batch/src/processPartialResponse.ts
+++ b/packages/batch/src/processPartialResponse.ts
@@ -1,6 +1,7 @@
 import {
   BasePartialBatchProcessor,
   BaseRecord,
+  BatchProcessingOptions,
   EventType,
   PartialItemFailureResponse,
 } from '.';
@@ -15,7 +16,8 @@ import {
 const processPartialResponse = async (
   event: { Records: BaseRecord[] },
   recordHandler: CallableFunction,
-  processor: BasePartialBatchProcessor
+  processor: BasePartialBatchProcessor,
+  options?: BatchProcessingOptions
 ): Promise<PartialItemFailureResponse> => {
   if (!event.Records) {
     const eventTypes: string = Object.values(EventType).toString();
@@ -28,7 +30,12 @@ const processPartialResponse = async (
 
   const records = event['Records'];
 
-  processor.register(records, recordHandler);
+  if (options) {
+    processor.register(records, recordHandler, options);
+  } else {
+    processor.register(records, recordHandler);
+  }
+
   await processor.process();
 
   return processor.response();

--- a/packages/batch/src/types.ts
+++ b/packages/batch/src/types.ts
@@ -1,9 +1,17 @@
 /**
  * Types for batch processing utility
  */
-import { DynamoDBRecord, KinesisStreamRecord, SQSRecord } from 'aws-lambda';
+import {
+  Context,
+  DynamoDBRecord,
+  KinesisStreamRecord,
+  SQSRecord,
+} from 'aws-lambda';
 
-// types from base.py
+type BatchProcessingOptions = {
+  context: Context;
+};
+
 type EventSourceDataClassTypes =
   | SQSRecord
   | KinesisStreamRecord
@@ -21,6 +29,7 @@ type PartialItemFailures = { itemIdentifier: string };
 type PartialItemFailureResponse = { batchItemFailures: PartialItemFailures[] };
 
 export type {
+  BatchProcessingOptions,
   BaseRecord,
   EventSourceDataClassTypes,
   ResultType,

--- a/packages/batch/tests/helpers/handlers.ts
+++ b/packages/batch/tests/helpers/handlers.ts
@@ -64,8 +64,13 @@ const handlerWithContext = (
   options: BatchProcessingOptions
 ): string => {
   const context = options.context;
-  if (context.getRemainingTimeInMillis() == 0) {
-    throw Error('No time remaining.');
+
+  try {
+    if (context.getRemainingTimeInMillis() == 0) {
+      throw Error('No time remaining.');
+    }
+  } catch (e) {
+    throw Error('Context possibly malformed. Displaying context:\n' + context);
   }
 
   return record.body;

--- a/packages/batch/tests/helpers/handlers.ts
+++ b/packages/batch/tests/helpers/handlers.ts
@@ -1,4 +1,5 @@
 import { DynamoDBRecord, KinesisStreamRecord, SQSRecord } from 'aws-lambda';
+import { BatchProcessingOptions } from '../../src';
 
 const sqsRecordHandler = (record: SQSRecord): string => {
   const body = record.body;
@@ -58,6 +59,18 @@ const asyncDynamodbRecordHandler = async (
   return body;
 };
 
+const handlerWithContext = (
+  record: SQSRecord,
+  options: BatchProcessingOptions
+): string => {
+  const context = options.context;
+  if (context.getRemainingTimeInMillis() == 0) {
+    throw Error('No time remaining.');
+  }
+
+  return record.body;
+};
+
 export {
   sqsRecordHandler,
   asyncSqsRecordHandler,
@@ -65,4 +78,5 @@ export {
   asyncKinesisRecordHandler,
   dynamodbRecordHandler,
   asyncDynamodbRecordHandler,
+  handlerWithContext,
 };

--- a/packages/batch/tests/unit/BatchProcessor.test.ts
+++ b/packages/batch/tests/unit/BatchProcessor.test.ts
@@ -4,7 +4,12 @@
  * @group unit/batch/class/batchprocessor
  */
 
-import { BatchProcessingError, BatchProcessor, EventType } from '../../src';
+import {
+  BatchProcessingError,
+  BatchProcessingOptions,
+  BatchProcessor,
+  EventType,
+} from '../../src';
 import {
   sqsRecordFactory,
   kinesisRecordFactory,
@@ -17,10 +22,13 @@ import {
   asyncKinesisRecordHandler,
   dynamodbRecordHandler,
   asyncDynamodbRecordHandler,
+  handlerWithContext,
 } from '../../tests/helpers/handlers';
+import { helloworldContext as dummyContext } from '../../../commons/src/samples/resources/contexts';
 
 describe('Class: BatchProcessor', () => {
   const ENVIRONMENT_VARIABLES = process.env;
+  const options: BatchProcessingOptions = { context: dummyContext };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -416,6 +424,44 @@ describe('Class: BatchProcessor', () => {
       await expect(processor.process()).rejects.toThrowError(
         BatchProcessingError
       );
+    });
+  });
+
+  describe('Batch processing with Lambda context', () => {
+    test('Batch processing when context is provided and handler accepts', async () => {
+      // Prepare
+      const firstRecord = sqsRecordFactory('success');
+      const secondRecord = sqsRecordFactory('success');
+      const records = [firstRecord, secondRecord];
+      const processor = new BatchProcessor(EventType.SQS);
+
+      // Act
+      processor.register(records, handlerWithContext, options);
+      const processedMessages = await processor.process();
+
+      // Assess
+      expect(processedMessages).toStrictEqual([
+        ['success', firstRecord.body, firstRecord],
+        ['success', secondRecord.body, secondRecord],
+      ]);
+    });
+
+    test('Batch processing when context is provided and handler does not accept', async () => {
+      // Prepare
+      const firstRecord = sqsRecordFactory('success');
+      const secondRecord = sqsRecordFactory('success');
+      const records = [firstRecord, secondRecord];
+      const processor = new BatchProcessor(EventType.SQS);
+
+      // Act
+      processor.register(records, sqsRecordHandler, options);
+      const processedMessages = await processor.process();
+
+      // Assess
+      expect(processedMessages).toStrictEqual([
+        ['success', firstRecord.body, firstRecord],
+        ['success', secondRecord.body, secondRecord],
+      ]);
     });
   });
 });

--- a/packages/batch/tests/unit/BatchProcessor.test.ts
+++ b/packages/batch/tests/unit/BatchProcessor.test.ts
@@ -25,6 +25,7 @@ import {
   handlerWithContext,
 } from '../../tests/helpers/handlers';
 import { helloworldContext as dummyContext } from '../../../commons/src/samples/resources/contexts';
+import { Context } from 'aws-lambda';
 
 describe('Class: BatchProcessor', () => {
   const ENVIRONMENT_VARIABLES = process.env;
@@ -462,6 +463,22 @@ describe('Class: BatchProcessor', () => {
         ['success', firstRecord.body, firstRecord],
         ['success', secondRecord.body, secondRecord],
       ]);
+    });
+
+    test('Batch processing when malformed context is provided and handler attempts to use', async () => {
+      // Prepare
+      const firstRecord = sqsRecordFactory('success');
+      const secondRecord = sqsRecordFactory('success');
+      const records = [firstRecord, secondRecord];
+      const processor = new BatchProcessor(EventType.SQS);
+      const badContext = { foo: 'bar' };
+      const badOptions = { context: badContext as unknown as Context };
+
+      // Act
+      processor.register(records, handlerWithContext, badOptions);
+      await expect(processor.process()).rejects.toThrowError(
+        BatchProcessingError
+      );
     });
   });
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes
- Added BatchProcessingOptions type to hold context and future configuration options
- Added optional parameters to carry `options` parameter
- Added unit tests to check use of `options` parameter
<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number: #1607** 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.