### PR TITLE
feat(logger): add `cause` field to formatted error

### DIFF
--- a/packages/logger/tests/unit/formatter/PowertoolLogFormatter.test.ts
+++ b/packages/logger/tests/unit/formatter/PowertoolLogFormatter.test.ts
@@ -307,6 +307,71 @@ describe('Class: PowertoolLogFormatter', () => {
 
       expect(shouldThrow).toThrowError(expect.any(URIError));
     });
+
+    test('when an error with cause of type Error is formatted, the cause key is included and formatted', () => {
+      // Prepare
+      const formatter = new PowertoolLogFormatter();
+      class ErrorWithCause extends Error {
+        public cause?: Error;
+        public constructor(message: string, options?: { cause: Error }) {
+          super(message);
+          this.cause = options?.cause;
+        }
+      }
+
+      // Act
+      const formattedURIError = formatter.formatError(
+        new ErrorWithCause('foo', { cause: new Error('bar') })
+      );
+
+      // Assess
+      expect(formattedURIError).toEqual({
+        location: expect.stringMatching(/PowertoolLogFormatter.test.ts:[0-9]+/),
+        message: 'foo',
+        name: 'Error',
+        stack: expect.stringMatching(
+          /PowertoolLogFormatter.test.ts:[0-9]+:[0-9]+/
+        ),
+        cause: {
+          location: expect.stringMatching(
+            /PowertoolLogFormatter.test.ts:[0-9]+/
+          ),
+          message: 'bar',
+          name: 'Error',
+          stack: expect.stringMatching(
+            /PowertoolLogFormatter.test.ts:[0-9]+:[0-9]+/
+          ),
+        },
+      });
+    });
+
+    test('when an error with cause of type other than Error is formatted, the cause key is included as-is', () => {
+      // Prepare
+      const formatter = new PowertoolLogFormatter();
+      class ErrorWithCause extends Error {
+        public cause?: unknown;
+        public constructor(message: string, options?: { cause: unknown }) {
+          super(message);
+          this.cause = options?.cause;
+        }
+      }
+
+      // Act
+      const formattedURIError = formatter.formatError(
+        new ErrorWithCause('foo', { cause: 'bar' })
+      );
+
+      // Assess
+      expect(formattedURIError).toEqual({
+        location: expect.stringMatching(/PowertoolLogFormatter.test.ts:[0-9]+/),
+        message: 'foo',
+        name: 'Error',
+        stack: expect.stringMatching(
+          /PowertoolLogFormatter.test.ts:[0-9]+:[0-9]+/
+        ),
+        cause: 'bar',
+      });
+    });
   });
 
   describe('Method: formatTimestamp', () => {


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->
This PR introduces new logic to the `LogFormatter` class to allow the Logger utility to include the `cause` field to logs, when emitting a log that contains an `Error`. The `cause` field was added in Node.js 16 so we need to use a conditional logic to check if the `Error` passed in to the logger has the field or not before attempting to format it and include it in a log entry.

This logic is meant to be temporary and will be removed once we drop support for Node.js 14. This is documented in the docstrings of the new code.

Once this PR is merged, customers can pass an `Error` with a `cause` to the logger, which will format it like so:
```ts
logger.error(
  "something went wrong",
  new Error("boom", { cause: new Error("foo") })
);
// prints
{
    "level": "ERROR",
    "message": "something went wrong",
    "service": "service_undefined",
    "timestamp": "2023-07-14T11:53:06.944Z",
    "error": {
        "name": "Error",
        "location": "/Users/aamorosi/Codes/error-cause/index.ts:8",
        "message": "boom",
        "stack": "Error: boom\n    at Object.<anonymous> (/Users/aamorosi/Codes/error-cause/index.ts:8:3)\n    at Module._compile (node:internal/modules/cjs/loader:1159:14)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)\n    at Module.load (node:internal/modules/cjs/loader:1037:32)\n    at Module._load (node:internal/modules/cjs/loader:878:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at node:internal/main/run_main_module:23:47",
        "cause": {
            "name": "Error",
            "location": "/Users/aamorosi/Codes/error-cause/index.ts:8",
            "message": "foo",
            "stack": "Error: foo\n    at Object.<anonymous> (/Users/aamorosi/Codes/error-cause/index.ts:8:30)\n    at Module._compile (node:internal/modules/cjs/loader:1159:14)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)\n    at Module.load (node:internal/modules/cjs/loader:1037:32)\n    at Module._load (node:internal/modules/cjs/loader:878:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at node:internal/main/run_main_module:23:47"
        }
    }
}
```

Note that in JS it's possible to `throw` more objects than just `Error`, for this reason the logic also includes a check `instanceof Error` before attempting to format the `cause`. If the object is not an error it will be included as value of the `cause` key as-is:

```ts
logger.error("something went wrong", new Error("boom", { cause: "something" }));
// prints
{
    "level": "ERROR",
    "message": "something went wrong",
    "service": "service_undefined",
    "timestamp": "2023-07-14T11:53:06.959Z",
    "error": {
        "name": "Error",
        "location": "/Users/aamorosi/Codes/error-cause/index.ts:13",
        "message": "boom",
        "stack": "Error: boom\n    at Object.<anonymous> (/Users/aamorosi/Codes/error-cause/index.ts:13:38)\n    at Module._compile (node:internal/modules/cjs/loader:1159:14)\n    at Module._extensions..js (node:internal/modules/cjs/loader:1213:10)\n    at Module.load (node:internal/modules/cjs/loader:1037:32)\n    at Module._load (node:internal/modules/cjs/loader:878:12)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)\n    at node:internal/main/run_main_module:23:47",
        "cause": "something"
    }
}
```

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1361

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.