### PR TITLE
chore(docs): improve idempotency documentation

### DIFF
--- a/docs/snippets/idempotency/makeIdempotentJmes.ts
+++ b/docs/snippets/idempotency/makeIdempotentJmes.ts
@@ -24,7 +24,7 @@ const createSubscriptionPayment = async (
 
 // Extract the idempotency key from the request headers
 const config = new IdempotencyConfig({
-  eventKeyJmesPath: 'headers."X-Idempotency-Key"',
+  eventKeyJmesPath: 'body',
 });
 
 export const handler = makeIdempotent(


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes
This PR brings minor improvements of the idempotency documentation. Here is the list of all the changes to make the review a bit easier:


## 

- add requirements to install the `@aws-sdk/client-dynamodb` package
- add autonumber to sequence diagrams
- remove “New to idempotency callout”
- `expiration` should not be broken in the table
- **MakeIdempotent function wrapper:** move callouts under the example to improve the reader flow
- change Types tab to `types.ts` to make it consistent with the code
- Choosing a payload subset for idempotency:
    - change deserialising callout to warning (it’s not a tip)
    - Don’t start with the callout, add it to text
    - Payment scenario is not a quote
    - the header example does not match the text (userid and product)
- Lambda timeouts
    - clean up call outs and merge into text

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1654 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.