### PR TITLE
chore(ci): pin npm 9.x in workflows

### DIFF
--- a/.github/actions/cached-node-modules/action.yml
+++ b/.github/actions/cached-node-modules/action.yml
@@ -12,9 +12,8 @@ runs:
   using: "composite"
   steps:
     - name: Install npm
-      if: ${{ inputs.nodeVersion != '18' }}
-      shell: bash
       run: npm i -g npm@next-9
+      shell: bash
     - name: Cache node modules
       id: cache-node-modules
       uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6

--- a/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           node-version: ${{ matrix.version }}
           cache: "npm"
-      - name: Setup npm
-        run: npm i -g npm@latest
       - name: Setup dependencies
         uses: ./.github/actions/cached-node-modules
         with:


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As discussed in the linked issue, npm recently reached version 10 which drops support for Node.js 14 and 16.

In order to continue running our CI, this PR pins the npm version to 9.x for all runtimes.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1665

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.