### PR TITLE
chore(tests): address integration test flakiness

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        package: [logger, metrics, tracer, parameters, idempotency]
+        package: [layers, packages/logger, packages/metrics, packages/tracer, packages/parameters, packages/idempotency]
         version: [14, 16, 18]
       fail-fast: false
     steps:
@@ -55,56 +55,14 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
           aws-region: eu-west-1
           mask-aws-account-id: true
-      - name: Run integration tests on utils
-        run: |
-          RUNTIME=nodejs${{ matrix.version }}x npm run test:e2e -w packages/${{ matrix.package }}
-  layer-e2e-tests:
-    runs-on: ubuntu-latest
-    env:
-      NODE_ENV: dev
-      PR_NUMBER: ${{ inputs.prNumber }}
-    permissions:
-      id-token: write # needed to interact with GitHub's OIDC Token endpoint.
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        version: [14, 16, 18]
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
-      # If we pass a PR Number when triggering the workflow we will retrieve the PR info and get its headSHA
-      - name: Extract PR details
-        id: extract_PR_details
-        if: ${{ inputs.prNumber != '' }}
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-        with:
-          script: |
-            const script = require('.github/scripts/get_pr_info.js');
-            await script({github, context, core});
-      # Only if a PR Number was passed and the headSHA of the PR extracted,
-      # we checkout the PR at that point in time
-      - name: Checkout PR code
-        if: ${{ inputs.prNumber != '' }}
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
-        with:
-          ref: ${{ steps.extract_PR_details.outputs.headSHA }}
-      - name: Setup NodeJS
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          # Always use version 18
-          node-version: 18
-      - name: Setup dependencies
-        uses: ./.github/actions/cached-node-modules
-      - name: "Configure AWS credentials"
-        uses: aws-actions/configure-aws-credentials@04b98b3f9e85f563fb061be8751a0352327246b0 # v3.0.1
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_TO_ASSUME }}
-          aws-region: eu-west-1
-          mask-aws-account-id: true
       - name: Create layer files
+        if: ${{ matrix.package == 'layers' }}
         run: |
           export VERSION=latest
           bash .github/scripts/setup_tmp_layer_files.sh
-      - name: Run integration test on layers
-        run: RUNTIME=nodejs${{ matrix.version }}x npm run test:e2e -w layers
+      - name: Run integration tests on utils
+        env:
+          RUNTIME: nodejs${{ matrix.version }}x
+          CI: true
+          JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: true
+        run: npm run test:e2e -w ${{ matrix.package }}

--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -13,7 +13,6 @@ export interface LayerPublisherStackProps extends StackProps {
   readonly layerName?: string;
   readonly powertoolsPackageVersion?: string;
   readonly ssmParameterLayerArn: string;
-  readonly removeLayerVersion?: boolean;
 }
 
 export class LayerPublisherStack extends Stack {

--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -25,7 +25,7 @@ export class LayerPublisherStack extends Stack {
   ) {
     super(scope, id, props);
 
-    const { layerName, powertoolsPackageVersion, removeLayerVersion } = props;
+    const { layerName, powertoolsPackageVersion } = props;
 
     console.log(
       `publishing layer ${layerName} version : ${powertoolsPackageVersion}`
@@ -43,10 +43,6 @@ export class LayerPublisherStack extends Stack {
       // This is needed because the following regions do not support the compatibleArchitectures property #1400
       // ...(![ 'eu-south-2', 'eu-central-2', 'ap-southeast-4' ].includes(Stack.of(this).region) ? { compatibleArchitectures: [Architecture.X86_64] } : {}),
       code: Code.fromAsset(resolve(__dirname, '..', '..', 'tmp')),
-      removalPolicy:
-        removeLayerVersion === true
-          ? RemovalPolicy.DESTROY
-          : RemovalPolicy.RETAIN,
     });
 
     const layerPermission = new CfnLayerVersionPermission(

--- a/layers/tests/e2e/layerPublisher.test.ts
+++ b/layers/tests/e2e/layerPublisher.test.ts
@@ -61,7 +61,6 @@ describe(`Layers E2E tests, publisher stack`, () => {
     layerName: layerId,
     powertoolsPackageVersion: powerToolsPackageVersion,
     ssmParameterLayerArn: ssmParameterLayerName,
-    removeLayerVersion: true,
   });
   const testLayerStack = new TestStack({
     stackNameProps: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18608,7 +18608,6 @@
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
         "@aws-sdk/client-dynamodb": "^3.360.0",
-        "@aws-sdk/client-sts": "^3.360.0",
         "@aws-sdk/client-xray": "^3.360.0",
         "@types/promise-retry": "^1.1.3",
         "aws-sdk": "^2.1354.0",

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -25,7 +25,7 @@ describe(`Logger E2E tests, basic functionalities middy usage`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'AllFeatures-Decorator',
+      testName: 'Basic-Middy',
     },
   });
 

--- a/packages/parameters/tests/e2e/dynamoDBProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/dynamoDBProvider.class.test.ts
@@ -99,7 +99,7 @@ describe(`Parameters E2E tests, dynamoDB provider`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'DynamoDBProvider',
+      testName: 'DynamoDB',
     },
   });
 

--- a/packages/parameters/tests/e2e/secretsProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/secretsProvider.class.test.ts
@@ -40,7 +40,7 @@ describe(`Parameters E2E tests, Secrets Manager provider`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'SecretsProvider',
+      testName: 'Secrets',
     },
   });
 

--- a/packages/parameters/tests/e2e/ssmProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/ssmProvider.class.test.ts
@@ -74,7 +74,7 @@ describe(`Parameters E2E tests, SSM provider`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'SSMProvider',
+      testName: 'SSM',
     },
   });
 

--- a/packages/parameters/tests/e2e/ssmProvider.class.test.ts
+++ b/packages/parameters/tests/e2e/ssmProvider.class.test.ts
@@ -74,7 +74,7 @@ describe(`Parameters E2E tests, SSM provider`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'AppConfig',
+      testName: 'SSMProvider',
     },
   });
 

--- a/packages/parameters/tests/helpers/resources.ts
+++ b/packages/parameters/tests/helpers/resources.ts
@@ -58,7 +58,7 @@ class TestSecureStringParameter extends Construct {
 
     const { value } = props;
 
-    const name = `/secure/${getRuntimeKey}-${randomUUID()}`;
+    const name = `/secure/${getRuntimeKey()}/${randomUUID()}`;
 
     const secureStringCreator = new AwsCustomResource(
       testStack.stack,
@@ -203,6 +203,7 @@ class TestDynamodbTableWithItems extends TestDynamodbTable {
       policy: AwsCustomResourcePolicy.fromSdkCalls({
         resources: [this.tableArn],
       }),
+      installLatestAwsSdk: false,
     });
   }
 }

--- a/packages/parameters/tests/helpers/resources.ts
+++ b/packages/parameters/tests/helpers/resources.ts
@@ -5,6 +5,7 @@ import type {
 } from '@aws-lambda-powertools/testing-utils';
 import {
   concatenateResourceName,
+  getRuntimeKey,
   TestDynamodbTable,
   TestNodejsFunction,
 } from '@aws-lambda-powertools/testing-utils';
@@ -57,7 +58,7 @@ class TestSecureStringParameter extends Construct {
 
     const { value } = props;
 
-    const name = `/secure/${randomUUID()}`;
+    const name = `/secure/${getRuntimeKey}-${randomUUID()}`;
 
     const secureStringCreator = new AwsCustomResource(
       testStack.stack,

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@aws-lambda-powertools/testing-utils": "file:../testing",
     "@aws-sdk/client-dynamodb": "^3.360.0",
-    "@aws-sdk/client-sts": "^3.360.0",
     "@aws-sdk/client-xray": "^3.360.0",
     "@types/promise-retry": "^1.1.3",
     "aws-sdk": "^2.1354.0",

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.ts
@@ -41,7 +41,7 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'AllFeatures-Decorator',
+      testName: 'AllFeatures-Middy',
     },
   });
 

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.ts
@@ -7,7 +7,6 @@ import {
   TestStack,
   TestDynamodbTable,
 } from '@aws-lambda-powertools/testing-utils';
-import { XRayClient } from '@aws-sdk/client-xray';
 import { join } from 'node:path';
 import { TracerTestNodejsFunction } from '../helpers/resources';
 import {
@@ -16,7 +15,6 @@ import {
 } from '../helpers/traceAssertions';
 import {
   getFirstSubsegment,
-  getFunctionArn,
   getInvocationSubsegment,
   getTraces,
   invokeAllTestCases,
@@ -141,7 +139,6 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
   );
   testTable.grantWriteData(fnCaptureResponseOff);
 
-  const xrayClient = new XRayClient({});
   const invocationCount = 3;
 
   beforeAll(async () => {
@@ -178,28 +175,23 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
       const { EXPECTED_CUSTOM_ERROR_MESSAGE: expectedCustomErrorMessage } =
         commonEnvironmentVars;
 
-      const tracesWhenAllFlagsEnabled = await getTraces(
-        xrayClient,
+      /**
+       * Expect the trace to have 4 segments:
+       * 1. Lambda Context (AWS::Lambda)
+       * 2. Lambda Function (AWS::Lambda::Function)
+       * 3. DynamoDB Table (AWS::DynamoDB::Table)
+       * 4. Remote call (docs.powertools.aws.dev)
+       */
+      const tracesWhenAllFlagsEnabled = await getTraces({
         startTime,
-        await getFunctionArn(fnNameAllFlagsEnabled),
-        invocationCount,
-        4
-      );
-
-      expect(tracesWhenAllFlagsEnabled.length).toBe(invocationCount);
+        resourceName: fnNameAllFlagsEnabled,
+        expectedTracesCount: invocationCount,
+        expectedSegmentsCount: 4,
+      });
 
       // Assess
       for (let i = 0; i < invocationCount; i++) {
         const trace = tracesWhenAllFlagsEnabled[i];
-
-        /**
-         * Expect the trace to have 4 segments:
-         * 1. Lambda Context (AWS::Lambda)
-         * 2. Lambda Function (AWS::Lambda::Function)
-         * 3. DynamoDB Table (AWS::DynamoDB::Table)
-         * 4. Remote call (docs.powertools.aws.dev)
-         */
-        expect(trace.Segments.length).toBe(4);
         const invocationSubsegment = getInvocationSubsegment(trace);
 
         /**
@@ -243,13 +235,12 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
         EXPECTED_CUSTOM_RESPONSE_VALUE: expectedCustomResponseValue,
       } = commonEnvironmentVars;
 
-      const tracesWhenAllFlagsEnabled = await getTraces(
-        xrayClient,
+      const tracesWhenAllFlagsEnabled = await getTraces({
         startTime,
-        await getFunctionArn(fnNameAllFlagsEnabled),
-        invocationCount,
-        4
-      );
+        resourceName: fnNameAllFlagsEnabled,
+        expectedTracesCount: invocationCount,
+        expectedSegmentsCount: 4,
+      });
 
       for (let i = 0; i < invocationCount; i++) {
         const trace = tracesWhenAllFlagsEnabled[i];
@@ -288,30 +279,23 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
   it(
     'should not capture error nor response when the flags are false',
     async () => {
-      const tracesWithNoCaptureErrorOrResponse = await getTraces(
-        xrayClient,
+      /**
+       * Expect the trace to have 4 segments:
+       * 1. Lambda Context (AWS::Lambda)
+       * 2. Lambda Function (AWS::Lambda::Function)
+       * 3. DynamoDB Table (AWS::DynamoDB::Table)
+       * 4. Remote call (docs.powertools.aws.dev)
+       */
+      const tracesWithNoCaptureErrorOrResponse = await getTraces({
         startTime,
-        await getFunctionArn(fnNameNoCaptureErrorOrResponse),
-        invocationCount,
-        4
-      );
-
-      expect(tracesWithNoCaptureErrorOrResponse.length).toBe(invocationCount);
-
+        resourceName: fnNameNoCaptureErrorOrResponse,
+        expectedTracesCount: invocationCount,
+        expectedSegmentsCount: 4,
+      });
       // Assess
       for (let i = 0; i < invocationCount; i++) {
         const trace = tracesWithNoCaptureErrorOrResponse[i];
-
-        /**
-         * Expect the trace to have 4 segments:
-         * 1. Lambda Context (AWS::Lambda)
-         * 2. Lambda Function (AWS::Lambda::Function)
-         * 3. DynamoDB Table (AWS::DynamoDB::Table)
-         * 4. Remote call (docs.powertools.aws.dev)
-         */
-        expect(trace.Segments.length).toBe(4);
         const invocationSubsegment = getInvocationSubsegment(trace);
-
         /**
          * Invocation subsegment should have a subsegment '## index.handler' (default behavior for Tracer)
          * '## index.handler' subsegment should have 2 subsegments
@@ -352,30 +336,24 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
       const { EXPECTED_CUSTOM_ERROR_MESSAGE: expectedCustomErrorMessage } =
         commonEnvironmentVars;
 
-      const tracesWithNoCaptureResponse = await getTraces(
-        xrayClient,
+      /**
+       * Expect the trace to have 4 segments:
+       * 1. Lambda Context (AWS::Lambda)
+       * 2. Lambda Function (AWS::Lambda::Function)
+       * 3. DynamoDB Table (AWS::DynamoDB::Table)
+       * 4. Remote call (docs.powertools.aws.dev)
+       */
+      const tracesWithNoCaptureResponse = await getTraces({
         startTime,
-        await getFunctionArn(fnNameCaptureResponseOff),
-        invocationCount,
-        4
-      );
-
-      expect(tracesWithNoCaptureResponse.length).toBe(invocationCount);
+        resourceName: fnNameCaptureResponseOff,
+        expectedTracesCount: invocationCount,
+        expectedSegmentsCount: 4,
+      });
 
       // Assess
       for (let i = 0; i < invocationCount; i++) {
         const trace = tracesWithNoCaptureResponse[i];
-
-        /**
-         * Expect the trace to have 4 segments:
-         * 1. Lambda Context (AWS::Lambda)
-         * 2. Lambda Function (AWS::Lambda::Function)
-         * 3. DynamoDB Table (AWS::DynamoDB::Table)
-         * 4. Remote call (docs.powertools.aws.dev)
-         */
-        expect(trace.Segments.length).toBe(4);
         const invocationSubsegment = getInvocationSubsegment(trace);
-
         /**
          * Invocation subsegment should have a subsegment '## index.handlerWithNoCaptureResponseViaMiddlewareOption' (default behavior for Tracer)
          * '## index.handlerWithNoCaptureResponseViaMiddlewareOption' subsegment should have 2 subsegments
@@ -413,22 +391,15 @@ describe(`Tracer E2E tests, all features with middy instantiation`, () => {
   it(
     'should not capture any custom traces when disabled',
     async () => {
-      const expectedNoOfTraces = 2;
-      const tracesWithTracerDisabled = await getTraces(
-        xrayClient,
+      const tracesWithTracerDisabled = await getTraces({
         startTime,
-        await getFunctionArn(fnNameTracerDisabled),
-        invocationCount,
-        expectedNoOfTraces
-      );
-
-      expect(tracesWithTracerDisabled.length).toBe(invocationCount);
-
+        resourceName: fnNameTracerDisabled,
+        expectedTracesCount: invocationCount,
+        expectedSegmentsCount: 2,
+      });
       // Assess
       for (let i = 0; i < invocationCount; i++) {
         const trace = tracesWithTracerDisabled[i];
-        expect(trace.Segments.length).toBe(2);
-
         /**
          * Expect no subsegment in the invocation
          */

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
@@ -7,7 +7,6 @@ import {
   TestStack,
   TestDynamodbTable,
 } from '@aws-lambda-powertools/testing-utils';
-import { XRayClient } from '@aws-sdk/client-xray';
 import { join } from 'node:path';
 import { TracerTestNodejsFunction } from '../helpers/resources';
 import {
@@ -16,7 +15,6 @@ import {
 } from '../helpers/traceAssertions';
 import {
   getFirstSubsegment,
-  getFunctionArn,
   getInvocationSubsegment,
   getTraces,
   invokeAllTestCases,
@@ -93,7 +91,6 @@ describe(`Tracer E2E tests, async handler with decorator instantiation`, () => {
   );
   testTable.grantWriteData(fnCustomSubsegmentName);
 
-  const xrayClient = new XRayClient({});
   const invocationsCount = 3;
 
   beforeAll(async () => {
@@ -125,28 +122,23 @@ describe(`Tracer E2E tests, async handler with decorator instantiation`, () => {
       const { EXPECTED_CUSTOM_ERROR_MESSAGE: expectedCustomErrorMessage } =
         commonEnvironmentVars;
 
-      const tracesWhenAllFlagsEnabled = await getTraces(
-        xrayClient,
+      /**
+       * Expect the trace to have 4 segments:
+       * 1. Lambda Context (AWS::Lambda)
+       * 2. Lambda Function (AWS::Lambda::Function)
+       * 3. DynamoDB Table (AWS::DynamoDB::Table)
+       * 4. Remote call (docs.powertools.aws.dev)
+       */
+      const tracesWhenAllFlagsEnabled = await getTraces({
         startTime,
-        await getFunctionArn(fnNameAllFlagsEnabled),
-        invocationsCount,
-        4
-      );
-
-      expect(tracesWhenAllFlagsEnabled.length).toBe(invocationsCount);
+        resourceName: fnNameAllFlagsEnabled,
+        expectedTracesCount: invocationsCount,
+        expectedSegmentsCount: 4,
+      });
 
       // Assess
       for (let i = 0; i < invocationsCount; i++) {
         const trace = tracesWhenAllFlagsEnabled[i];
-
-        /**
-         * Expect the trace to have 4 segments:
-         * 1. Lambda Context (AWS::Lambda)
-         * 2. Lambda Function (AWS::Lambda::Function)
-         * 3. DynamoDB Table (AWS::DynamoDB::Table)
-         * 4. Remote call (docs.powertools.aws.dev)
-         */
-        expect(trace.Segments.length).toBe(4);
         const invocationSubsegment = getInvocationSubsegment(trace);
 
         /**
@@ -193,13 +185,12 @@ describe(`Tracer E2E tests, async handler with decorator instantiation`, () => {
         EXPECTED_CUSTOM_RESPONSE_VALUE: expectedCustomResponseValue,
       } = commonEnvironmentVars;
 
-      const traces = await getTraces(
-        xrayClient,
+      const traces = await getTraces({
         startTime,
-        await getFunctionArn(fnNameAllFlagsEnabled),
-        invocationsCount,
-        4
-      );
+        resourceName: fnNameAllFlagsEnabled,
+        expectedTracesCount: invocationsCount,
+        expectedSegmentsCount: 4,
+      });
 
       for (let i = 0; i < invocationsCount; i++) {
         const trace = traces[i];
@@ -243,30 +234,23 @@ describe(`Tracer E2E tests, async handler with decorator instantiation`, () => {
         EXPECTED_CUSTOM_SUBSEGMENT_NAME: expectedCustomSubSegmentName,
       } = commonEnvironmentVars;
 
-      const tracesWhenCustomSubsegmentNameInMethod = await getTraces(
-        xrayClient,
+      /**
+       * Expect the trace to have 4 segments:
+       * 1. Lambda Context (AWS::Lambda)
+       * 2. Lambda Function (AWS::Lambda::Function)
+       * 3. DynamoDB Table (AWS::DynamoDB::Table)
+       * 4. Remote call (docs.powertools.aws.dev)
+       */
+      const tracesWhenCustomSubsegmentNameInMethod = await getTraces({
         startTime,
-        await getFunctionArn(fnNameCustomSubsegment),
-        invocationsCount,
-        4
-      );
-
-      expect(tracesWhenCustomSubsegmentNameInMethod.length).toBe(
-        invocationsCount
-      );
+        resourceName: fnNameCustomSubsegment,
+        expectedTracesCount: invocationsCount,
+        expectedSegmentsCount: 4,
+      });
 
       // Assess
       for (let i = 0; i < invocationsCount; i++) {
         const trace = tracesWhenCustomSubsegmentNameInMethod[i];
-
-        /**
-         * Expect the trace to have 4 segments:
-         * 1. Lambda Context (AWS::Lambda)
-         * 2. Lambda Function (AWS::Lambda::Function)
-         * 3. DynamoDB Table (AWS::DynamoDB::Table)
-         * 4. Remote call (docs.powertools.aws.dev)
-         */
-        expect(trace.Segments.length).toBe(4);
         const invocationSubsegment = getInvocationSubsegment(trace);
 
         /**

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.ts
@@ -32,7 +32,7 @@ describe(`Tracer E2E tests, async handler with decorator instantiation`, () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'AllFeatures-Decorator',
+      testName: 'AllFeatures-AsyncDecorator',
     },
   });
 

--- a/packages/tracer/tests/helpers/tracesUtils.ts
+++ b/packages/tracer/tests/helpers/tracesUtils.ts
@@ -1,11 +1,9 @@
 import promiseRetry from 'promise-retry';
-import type { XRayClient } from '@aws-sdk/client-xray';
 import {
+  XRayClient,
   BatchGetTracesCommand,
   GetTraceSummariesCommand,
 } from '@aws-sdk/client-xray';
-import { STSClient } from '@aws-sdk/client-sts';
-import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { invokeFunction } from '@aws-lambda-powertools/testing-utils';
 import { FunctionSegmentNotDefinedError } from './FunctionSegmentNotDefinedError';
 import type {
@@ -14,41 +12,49 @@ import type {
   ParsedTrace,
 } from './traceUtils.types';
 
-const getTraces = async (
-  xrayClient: XRayClient,
-  startTime: Date,
-  resourceArn: string,
-  expectedTraces: number,
-  expectedSegments: number
-): Promise<ParsedTrace[]> => {
-  const retryOptions = {
-    retries: 20,
-    minTimeout: 5_000,
-    maxTimeout: 10_000,
-    factor: 1.25,
-  };
+type GetTracesOptions = {
+  startTime: Date;
+  resourceName: string;
+  expectedTracesCount: number;
+  expectedSegmentsCount: number;
+};
+
+const retryOptions = {
+  retries: 10,
+  minTimeout: 5_000,
+  maxTimeout: 10_000,
+  factor: 1.75,
+};
+const xrayClient = new XRayClient({});
+
+const getTraces = async ({
+  startTime,
+  resourceName,
+  expectedTracesCount,
+  expectedSegmentsCount,
+}: GetTracesOptions): Promise<ParsedTrace[]> => {
   const endTime = new Date();
+  console.log(
+    `Manual query: aws xray get-trace-summaries --start-time ${Math.floor(
+      startTime.getTime() / 1000
+    )} --end-time ${Math.floor(
+      endTime.getTime() / 1000
+    )} --filter-expression 'resource.arn ENDSWITH ":function:${resourceName}"'`
+  );
 
   return promiseRetry(async (retry: (err?: Error) => never, _: number) => {
-    console.log(
-      `Manual query: aws xray get-trace-summaries --start-time ${Math.floor(
-        startTime.getTime() / 1000
-      )} --end-time ${Math.floor(
-        endTime.getTime() / 1000
-      )} --filter-expression 'resource.arn = "${resourceArn}"'`
-    );
     const traces = await xrayClient.send(
       new GetTraceSummariesCommand({
         StartTime: startTime,
         EndTime: endTime,
-        FilterExpression: `resource.arn = "${resourceArn}"`,
+        FilterExpression: `resource.arn ENDSWITH ":function:${resourceName}"`,
       })
     );
 
-    if (traces.TraceSummaries?.length !== expectedTraces) {
+    if (traces.TraceSummaries?.length !== expectedTracesCount) {
       retry(
         new Error(
-          `Expected ${expectedTraces} traces, got ${traces.TraceSummaries?.length} for ${resourceArn}`
+          `Expected ${expectedTracesCount} traces, got ${traces.TraceSummaries?.length} for ${resourceName}`
         )
       );
     }
@@ -59,7 +65,7 @@ const getTraces = async (
     if (!traceIds.every((traceId) => traceId !== undefined)) {
       retry(
         new Error(
-          `Expected all trace summaries to have an ID, got ${traceIds} for ${resourceArn}`
+          `Expected all trace summaries to have an ID, got ${traceIds} for ${resourceName}`
         )
       );
     }
@@ -70,10 +76,10 @@ const getTraces = async (
       })
     );
 
-    if (traceDetails.Traces?.length !== expectedTraces) {
+    if (traceDetails.Traces?.length !== expectedTracesCount) {
       retry(
         new Error(
-          `Expected ${expectedTraces} trace summaries, got ${traceDetails.Traces?.length} for ${resourceArn}`
+          `Expected ${expectedTracesCount} trace summaries, got ${traceDetails.Traces?.length} for ${resourceName}`
         )
       );
     }
@@ -126,20 +132,20 @@ const getTraces = async (
     }
 
     if (sortedTraces === undefined) {
-      throw new Error(`Traces are undefined for ${resourceArn}`);
+      throw new Error(`Traces are undefined for ${resourceName}`);
     }
 
-    if (sortedTraces.length !== expectedTraces) {
+    if (sortedTraces.length !== expectedTracesCount) {
       throw new Error(
-        `Expected ${expectedTraces} sorted traces, but got ${sortedTraces.length} for ${resourceArn}`
+        `Expected ${expectedTracesCount} sorted traces, but got ${sortedTraces.length} for ${resourceName}`
       );
     }
 
     sortedTraces.forEach((trace) => {
-      if (trace.Segments?.length != expectedSegments) {
+      if (trace.Segments?.length != expectedSegmentsCount) {
         retry(
           new Error(
-            `Expected ${expectedSegments} segments, got ${trace.Segments?.length} for trace id ${trace.Id}`
+            `Expected ${expectedSegmentsCount} segments, got ${trace.Segments?.length} for trace id ${trace.Id}`
           )
         );
       }
@@ -237,18 +243,6 @@ const invokeAllTestCases = async (
   });
 };
 
-let account: string | undefined;
-const getFunctionArn = async (functionName: string): Promise<string> => {
-  const region = process.env.AWS_REGION;
-  if (!account) {
-    const stsClient = new STSClient({});
-    const identity = await stsClient.send(new GetCallerIdentityCommand({}));
-    account = identity.Account;
-  }
-
-  return `arn:aws:lambda:${region}:${account}:function:${functionName}`;
-};
-
 export {
   getTraces,
   getFunctionSegment,
@@ -256,5 +250,4 @@ export {
   getInvocationSubsegment,
   splitSegmentsByName,
   invokeAllTestCases,
-  getFunctionArn,
 };

--- a/packages/tracer/tests/helpers/tracesUtils.ts
+++ b/packages/tracer/tests/helpers/tracesUtils.ts
@@ -20,10 +20,10 @@ type GetTracesOptions = {
 };
 
 const retryOptions = {
-  retries: 10,
+  retries: 20,
   minTimeout: 5_000,
   maxTimeout: 10_000,
-  factor: 1.75,
+  factor: 1.25,
 };
 const xrayClient = new XRayClient({});
 


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

In #1661 we have made changes to the integration test and as a result we inadvertently introduced some flakiness. This PR addresses this by applying the following fixes:
- reviewed & made unique all the test suffix across utilities
- introduce runtime key in SSM secret string name/path
- revisited X-Ray trace retrieval and moved to using function name instead of ARN
- unified workflow to use single job

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** 

## Checklist

- [ ] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [ ] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [ ] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [ ] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.