### PR TITLE
fix(parameters): return type when options without transform is used

### DIFF
--- a/packages/parameters/src/types/AppConfigProvider.ts
+++ b/packages/parameters/src/types/AppConfigProvider.ts
@@ -108,6 +108,8 @@ type AppConfigGetOutput<
 > = undefined extends ExplicitUserProvidedType
   ? undefined extends InferredFromOptionsType | AppConfigGetOptionsTransformNone
     ? Uint8Array
+    : InferredFromOptionsType extends AppConfigGetOptionsTransformNone
+    ? Uint8Array
     : InferredFromOptionsType extends AppConfigGetOptionsTransformBinary
     ? string
     : InferredFromOptionsType extends AppConfigGetOptionsTransformJson

--- a/packages/parameters/src/types/SecretsProvider.ts
+++ b/packages/parameters/src/types/SecretsProvider.ts
@@ -85,7 +85,9 @@ type SecretsGetOutput<
   ExplicitUserProvidedType = undefined,
   InferredFromOptionsType = undefined
 > = undefined extends ExplicitUserProvidedType
-  ? undefined extends InferredFromOptionsType | SecretsGetOptionsTransformNone
+  ? undefined extends InferredFromOptionsType
+    ? string | Uint8Array
+    : InferredFromOptionsType extends SecretsGetOptionsTransformNone
     ? string | Uint8Array
     : InferredFromOptionsType extends SecretsGetOptionsTransformBinary
     ? string


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As discussed in the linked issue, when using the Parameters providers to retrieve values from Secrets Manager or DynamoDB and passing an options object with no `transform` setting, the return type of the value was mistakenly assigned to `undefined` rather than the default return type for that provider.

This PR fixes the issue by accounting for this case.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1670

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.