### PR TITLE
improv(commons): add number key type to JSONObject type

### DIFF
--- a/packages/commons/src/types/utils.ts
+++ b/packages/commons/src/types/utils.ts
@@ -53,7 +53,7 @@ export { isRecord, isString, isTruthy, isNullOrUndefined };
 
 type JSONPrimitive = string | number | boolean | null | undefined;
 type JSONValue = JSONPrimitive | JSONObject | JSONArray;
-type JSONObject = { [key: string]: JSONValue };
+type JSONObject = { [key: number | string]: JSONValue };
 type JSONArray = Array<JSONValue>;
 
 export type { JSONPrimitive, JSONValue, JSONObject, JSONArray };


### PR DESCRIPTION
Fixes #1689

<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Fixes #1689
-->

### Related issues, RFCs

<!--- 
Fixes issue #1689-->
**Issue number**: closes #1689

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.