### PR TITLE
feat(tracer): add try/catch logic to decorator and middleware close

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -406,7 +406,14 @@ class Tracer extends Utility implements TracerInterface {
               tracerRef.addErrorAsMetadata(error as Error);
               throw error;
             } finally {
-              subsegment?.close();
+              try {
+                subsegment?.close();
+              } catch (error) {
+                console.warn(
+                  `Failed to close or serialize segment, ${subsegment?.name}. We are catching the error but data might be lost.`,
+                  error
+                );
+              }
               subsegment?.flush();
             }
 
@@ -489,7 +496,14 @@ class Tracer extends Utility implements TracerInterface {
 
               throw error;
             } finally {
-              subsegment?.close();
+              try {
+                subsegment?.close();
+              } catch (error) {
+                console.warn(
+                  `Failed to close or serialize segment, ${subsegment?.name}. We are catching the error but data might be lost.`,
+                  error
+                );
+              }
               subsegment?.flush();
             }
 

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -414,7 +414,6 @@ class Tracer extends Utility implements TracerInterface {
                   error
                 );
               }
-              subsegment?.flush();
             }
 
             return result;
@@ -504,7 +503,6 @@ class Tracer extends Utility implements TracerInterface {
                   error
                 );
               }
-              subsegment?.flush();
             }
 
             return result;

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -70,7 +70,14 @@ const captureLambdaHandler = (
     if (handlerSegment === undefined || lambdaSegment === null) {
       return;
     }
-    handlerSegment.close();
+    try {
+      handlerSegment.close();
+    } catch (error) {
+      console.warn(
+        `Failed to close or serialize segment, ${handlerSegment.name}. We are catching the error but data might be lost.`,
+        error
+      );
+    }
     target.setSegment(lambdaSegment);
   };
 

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -103,7 +103,15 @@ class ProviderService implements ProviderServiceInterface {
 
       return;
     }
-    segment.addMetadata(key, value, namespace);
+
+    try {
+      segment.addMetadata(key, value, namespace);
+    } catch (error) {
+      console.warn(
+        'Failed to add metadata to segment, catching the error to avoid stopping the execution',
+        error
+      );
+    }
   }
 
   public setContextMissingStrategy(strategy: unknown): void {

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -104,14 +104,7 @@ class ProviderService implements ProviderServiceInterface {
       return;
     }
 
-    try {
-      segment.addMetadata(key, value, namespace);
-    } catch (error) {
-      console.warn(
-        'Failed to add metadata to segment, catching the error to avoid stopping the execution',
-        error
-      );
-    }
+    segment.addMetadata(key, value, namespace);
   }
 
   public setContextMissingStrategy(strategy: unknown): void {

--- a/packages/tracer/tests/unit/ProviderService.test.ts
+++ b/packages/tracer/tests/unit/ProviderService.test.ts
@@ -358,29 +358,5 @@ describe('Class: ProviderService', () => {
       expect(segmentSpy).toHaveBeenCalledTimes(1);
       expect(segmentSpy).toHaveBeenCalledWith('foo', 'bar', 'baz');
     });
-
-    test('when the underlying SDK throws an error, it catches it and logs a warning', () => {
-      // Prepare
-      const provider: ProviderService = new ProviderService();
-      const segment = new Subsegment('## dummySegment');
-      jest.spyOn(provider, 'getSegment').mockImplementation(() => segment);
-      const segmentSpy = jest
-        .spyOn(segment, 'addMetadata')
-        .mockImplementation(() => {
-          throw new Error('dummy error');
-        });
-      const logWarningSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-      // Act
-      expect(() => provider.putMetadata('foo', 'bar', 'baz')).not.toThrow();
-
-      // Assess
-      expect(segmentSpy).toHaveBeenCalledTimes(1);
-      expect(logWarningSpy).toHaveBeenNthCalledWith(
-        1,
-        'Failed to add metadata to segment, catching the error to avoid stopping the execution',
-        new Error('dummy error')
-      );
-    });
   });
 });

--- a/packages/tracer/tests/unit/ProviderService.test.ts
+++ b/packages/tracer/tests/unit/ProviderService.test.ts
@@ -358,5 +358,29 @@ describe('Class: ProviderService', () => {
       expect(segmentSpy).toHaveBeenCalledTimes(1);
       expect(segmentSpy).toHaveBeenCalledWith('foo', 'bar', 'baz');
     });
+
+    test('when the underlying SDK throws an error, it catches it and logs a warning', () => {
+      // Prepare
+      const provider: ProviderService = new ProviderService();
+      const segment = new Subsegment('## dummySegment');
+      jest.spyOn(provider, 'getSegment').mockImplementation(() => segment);
+      const segmentSpy = jest
+        .spyOn(segment, 'addMetadata')
+        .mockImplementation(() => {
+          throw new Error('dummy error');
+        });
+      const logWarningSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      // Act
+      expect(() => provider.putMetadata('foo', 'bar', 'baz')).not.toThrow();
+
+      // Assess
+      expect(segmentSpy).toHaveBeenCalledTimes(1);
+      expect(logWarningSpy).toHaveBeenNthCalledWith(
+        1,
+        'Failed to add metadata to segment, catching the error to avoid stopping the execution',
+        new Error('dummy error')
+      );
+    });
   });
 });

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -402,8 +402,6 @@ describe('Middy middleware', () => {
     await handler({ idx: 0 }, context);
 
     // Assess
-    // Check that the subsegments are closed
-    // expect(handlerSubsegment.close()).toHaveBeenCalled();
     expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(logWarningSpy).toHaveBeenNthCalledWith(
       1,

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -215,157 +215,202 @@ describe('Middy middleware', () => {
 
       delete process.env.POWERTOOLS_TRACER_CAPTURE_ERROR;
     });
+
+    test('when used with standard config, it captures the exception correctly', async () => {
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
+        '## index.handler'
+      );
+      const setSegmentSpy = jest
+        .spyOn(tracer.provider, 'setSegment')
+        .mockImplementation();
+      jest
+        .spyOn(tracer.provider, 'getSegment')
+        .mockImplementation(() => newSubsegment);
+      setContextMissingStrategy(() => null);
+      const addErrorSpy = jest.spyOn(newSubsegment, 'addError');
+      const lambdaHandler: Handler = async (
+        _event: unknown,
+        _context: Context
+      ) => {
+        throw new Error('Exception thrown!');
+      };
+      const handler = middy(lambdaHandler).use(captureLambdaHandler(tracer));
+
+      // Act & Assess
+      await expect(
+        handler({}, context, () => console.log('Lambda invoked!'))
+      ).rejects.toThrowError(Error);
+      expect(setSegmentSpy).toHaveBeenCalledTimes(2);
+      expect('cause' in newSubsegment).toBe(true);
+      expect(addErrorSpy).toHaveBeenCalledTimes(1);
+      expect(addErrorSpy).toHaveBeenCalledWith(
+        new Error('Exception thrown!'),
+        false
+      );
+      expect.assertions(5);
+    });
+
+    test('when used with standard config, it annotates ColdStart correctly', async () => {
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      jest.spyOn(tracer.provider, 'setSegment').mockImplementation(() => ({}));
+      jest
+        .spyOn(tracer.provider, 'getSegment')
+        .mockImplementationOnce(() => new Segment('facade'))
+        .mockImplementationOnce(() => new Subsegment('## index.handler'))
+        .mockImplementationOnce(() => new Segment('facade'))
+        .mockImplementation(() => new Subsegment('## index.handler'));
+      const putAnnotationSpy = jest.spyOn(tracer, 'putAnnotation');
+
+      const handler = middy(async (_event: unknown, _context: Context) => ({
+        foo: 'bar',
+      })).use(captureLambdaHandler(tracer));
+
+      // Act
+      await handler({}, context);
+      await handler({}, context);
+
+      // Assess
+      // 2x Cold Start + 2x Service
+      expect(putAnnotationSpy).toHaveBeenCalledTimes(4);
+      expect(putAnnotationSpy).toHaveBeenNthCalledWith(1, 'ColdStart', true);
+      expect(putAnnotationSpy).toHaveBeenNthCalledWith(3, 'ColdStart', false);
+    });
+
+    test('when used with standard config, it annotates Service correctly', async () => {
+      // Prepare
+      const tracer: Tracer = new Tracer();
+      jest.spyOn(tracer.provider, 'setSegment').mockImplementation(() => ({}));
+      jest
+        .spyOn(tracer.provider, 'getSegment')
+        .mockImplementationOnce(() => new Segment('facade'))
+        .mockImplementation(() => new Subsegment('## index.handler'));
+      const putAnnotationSpy = jest.spyOn(tracer, 'putAnnotation');
+
+      const handler = middy(async (_event: unknown, _context: Context) => ({
+        foo: 'bar',
+      })).use(captureLambdaHandler(tracer));
+
+      // Act
+      await handler({}, context);
+
+      // Assess
+      // The first call is for the Cold Start annotation
+      expect(putAnnotationSpy).toHaveBeenCalledTimes(2);
+      expect(putAnnotationSpy).toHaveBeenNthCalledWith(
+        2,
+        'Service',
+        'hello-world'
+      );
+    });
+
+    test('when enabled, and another middleware returns early, it still closes and restores the segments correctly', async () => {
+      // Prepare
+      const tracer = new Tracer();
+      const setSegmentSpy = jest
+        .spyOn(tracer.provider, 'setSegment')
+        .mockImplementation(() => ({}));
+      jest.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
+      jest
+        .spyOn(tracer, 'addServiceNameAnnotation')
+        .mockImplementation(() => ({}));
+      const facadeSegment1 = new Segment('facade');
+      const handlerSubsegment1 = new Subsegment('## index.handlerA');
+      jest
+        .spyOn(facadeSegment1, 'addNewSubsegment')
+        .mockImplementation(() => handlerSubsegment1);
+      const facadeSegment2 = new Segment('facade');
+      const handlerSubsegment2 = new Subsegment('## index.handlerB');
+      jest
+        .spyOn(facadeSegment2, 'addNewSubsegment')
+        .mockImplementation(() => handlerSubsegment2);
+      jest
+        .spyOn(tracer.provider, 'getSegment')
+        .mockImplementationOnce(() => facadeSegment1)
+        .mockImplementationOnce(() => facadeSegment2);
+      const myCustomMiddleware = (): middy.MiddlewareObj => {
+        const before = async (
+          request: middy.Request
+        ): Promise<undefined | string> => {
+          // Return early on the second invocation
+          if (request.event.idx === 1) {
+            // Cleanup Powertools resources
+            await cleanupMiddlewares(request);
+
+            // Then return early
+            return 'foo';
+          }
+        };
+
+        return {
+          before,
+        };
+      };
+      const handler = middy((): void => {
+        console.log('Hello world!');
+      })
+        .use(captureLambdaHandler(tracer, { captureResponse: false }))
+        .use(myCustomMiddleware());
+
+      // Act
+      await handler({ idx: 0 }, context);
+      await handler({ idx: 1 }, context);
+
+      // Assess
+      // Check that the subsegments are closed
+      expect(handlerSubsegment1.isClosed()).toBe(true);
+      expect(handlerSubsegment2.isClosed()).toBe(true);
+      // Check that the segments are restored
+      expect(setSegmentSpy).toHaveBeenCalledTimes(4);
+      expect(setSegmentSpy).toHaveBeenNthCalledWith(2, facadeSegment1);
+      expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegment2);
+    });
   });
 
-  test('when used with standard config, it captures the exception correctly', async () => {
-    // Prepare
-    const tracer: Tracer = new Tracer();
-    const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-      '## index.handler'
-    );
-    const setSegmentSpy = jest
-      .spyOn(tracer.provider, 'setSegment')
-      .mockImplementation();
-    jest
-      .spyOn(tracer.provider, 'getSegment')
-      .mockImplementation(() => newSubsegment);
-    setContextMissingStrategy(() => null);
-    const addErrorSpy = jest.spyOn(newSubsegment, 'addError');
-    const lambdaHandler: Handler = async (
-      _event: unknown,
-      _context: Context
-    ) => {
-      throw new Error('Exception thrown!');
-    };
-    const handler = middy(lambdaHandler).use(captureLambdaHandler(tracer));
-
-    // Act & Assess
-    await expect(
-      handler({}, context, () => console.log('Lambda invoked!'))
-    ).rejects.toThrowError(Error);
-    expect(setSegmentSpy).toHaveBeenCalledTimes(2);
-    expect('cause' in newSubsegment).toBe(true);
-    expect(addErrorSpy).toHaveBeenCalledTimes(1);
-    expect(addErrorSpy).toHaveBeenCalledWith(
-      new Error('Exception thrown!'),
-      false
-    );
-    expect.assertions(5);
-  });
-
-  test('when used with standard config, it annotates ColdStart correctly', async () => {
-    // Prepare
-    const tracer: Tracer = new Tracer();
-    jest.spyOn(tracer.provider, 'setSegment').mockImplementation(() => ({}));
-    jest
-      .spyOn(tracer.provider, 'getSegment')
-      .mockImplementationOnce(() => new Segment('facade'))
-      .mockImplementationOnce(() => new Subsegment('## index.handler'))
-      .mockImplementationOnce(() => new Segment('facade'))
-      .mockImplementation(() => new Subsegment('## index.handler'));
-    const putAnnotationSpy = jest.spyOn(tracer, 'putAnnotation');
-
-    const handler = middy(async (_event: unknown, _context: Context) => ({
-      foo: 'bar',
-    })).use(captureLambdaHandler(tracer));
-
-    // Act
-    await handler({}, context);
-    await handler({}, context);
-
-    // Assess
-    // 2x Cold Start + 2x Service
-    expect(putAnnotationSpy).toHaveBeenCalledTimes(4);
-    expect(putAnnotationSpy).toHaveBeenNthCalledWith(1, 'ColdStart', true);
-    expect(putAnnotationSpy).toHaveBeenNthCalledWith(3, 'ColdStart', false);
-  });
-
-  test('when used with standard config, it annotates Service correctly', async () => {
-    // Prepare
-    const tracer: Tracer = new Tracer();
-    jest.spyOn(tracer.provider, 'setSegment').mockImplementation(() => ({}));
-    jest
-      .spyOn(tracer.provider, 'getSegment')
-      .mockImplementationOnce(() => new Segment('facade'))
-      .mockImplementation(() => new Subsegment('## index.handler'));
-    const putAnnotationSpy = jest.spyOn(tracer, 'putAnnotation');
-
-    const handler = middy(async (_event: unknown, _context: Context) => ({
-      foo: 'bar',
-    })).use(captureLambdaHandler(tracer));
-
-    // Act
-    await handler({}, context);
-
-    // Assess
-    // The first call is for the Cold Start annotation
-    expect(putAnnotationSpy).toHaveBeenCalledTimes(2);
-    expect(putAnnotationSpy).toHaveBeenNthCalledWith(
-      2,
-      'Service',
-      'hello-world'
-    );
-  });
-
-  test('when enabled, and another middleware returns early, it still closes and restores the segments correctly', async () => {
+  it('catches the error and logs a warning when the segment closing/serialization fails upon closing the segment', async () => {
     // Prepare
     const tracer = new Tracer();
-    const setSegmentSpy = jest
-      .spyOn(tracer.provider, 'setSegment')
-      .mockImplementation(() => ({}));
+    const facadeSegment = new Segment('facade');
+    const handlerSubsegment = new Subsegment('## index.handler');
+    jest
+      .spyOn(tracer.provider, 'getSegment')
+      .mockImplementationOnce(() => facadeSegment)
+      .mockImplementationOnce(() => handlerSubsegment);
     jest.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
     jest
       .spyOn(tracer, 'addServiceNameAnnotation')
       .mockImplementation(() => ({}));
-    const facadeSegment1 = new Segment('facade');
-    const handlerSubsegment1 = new Subsegment('## index.handlerA');
+    const setSegmentSpy = jest
+      .spyOn(tracer.provider, 'setSegment')
+      .mockImplementation(() => ({}));
     jest
-      .spyOn(facadeSegment1, 'addNewSubsegment')
-      .mockImplementation(() => handlerSubsegment1);
-    const facadeSegment2 = new Segment('facade');
-    const handlerSubsegment2 = new Subsegment('## index.handlerB');
-    jest
-      .spyOn(facadeSegment2, 'addNewSubsegment')
-      .mockImplementation(() => handlerSubsegment2);
-    jest
-      .spyOn(tracer.provider, 'getSegment')
-      .mockImplementationOnce(() => facadeSegment1)
-      .mockImplementationOnce(() => facadeSegment2);
-    const myCustomMiddleware = (): middy.MiddlewareObj => {
-      const before = async (
-        request: middy.Request
-      ): Promise<undefined | string> => {
-        // Return early on the second invocation
-        if (request.event.idx === 1) {
-          // Cleanup Powertools resources
-          await cleanupMiddlewares(request);
-
-          // Then return early
-          return 'foo';
-        }
-      };
-
-      return {
-        before,
-      };
-    };
+      .spyOn(facadeSegment, 'addNewSubsegment')
+      .mockImplementation(() => handlerSubsegment);
     const handler = middy((): void => {
       console.log('Hello world!');
-    })
-      .use(captureLambdaHandler(tracer, { captureResponse: false }))
-      .use(myCustomMiddleware());
+    }).use(captureLambdaHandler(tracer));
+    const logWarningSpy = jest.spyOn(console, 'warn');
+    const closeSpy = jest
+      .spyOn(handlerSubsegment, 'close')
+      .mockImplementation(() => {
+        throw new Error('dummy error');
+      });
 
     // Act
     await handler({ idx: 0 }, context);
-    await handler({ idx: 1 }, context);
 
     // Assess
     // Check that the subsegments are closed
-    expect(handlerSubsegment1.isClosed()).toBe(true);
-    expect(handlerSubsegment2.isClosed()).toBe(true);
+    // expect(handlerSubsegment.close()).toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(logWarningSpy).toHaveBeenNthCalledWith(
+      1,
+      `Failed to close or serialize segment, ${handlerSubsegment.name}. We are catching the error but data might be lost.`,
+      new Error('dummy error')
+    );
     // Check that the segments are restored
-    expect(setSegmentSpy).toHaveBeenCalledTimes(4);
-    expect(setSegmentSpy).toHaveBeenNthCalledWith(2, facadeSegment1);
-    expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegment2);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(2, facadeSegment);
   });
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces some `try/catch` logic to the parts of the code that are in charge of closing a subsegment in decorators and middleware usage.

As reported in the linked issue, if the segment contains metadata that cannot be serialized calling the `subsegment.close()` (or `subsegment.flush()`) method will throw an error.

This happens because the segment is serialized using `JSON.stringify()` twice right before being emitted and so if the stringify method encounters an entity that doesn't know how to serialize, it'll throw an error.

Even though the linked issue propsosed to add this `try/catch` logic to the `tracer.putMetdata()` method, this would be useless as the serialization is done just-in-time before emitting the segment.

For this reason we must guard against runtime errors when closing the segment that we (Powertools) opened. In this case, we are now catching the error and logging a warning.

Customers can use this warning to:
- detect potential issues in the data being emitted using the provided stack trace
- be warned about potential data loss 

It's important to note that this fix only safeguards against runtime errors for segments that Tracer opens under the hood. If customers try to call `segment.close()` directly on a segment the error will still be thrown.

We are attempting to work with the X-Ray team to provide a more permanent fix.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1713

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.