### PR TITLE
chore(ci): create v2 alpha release workflow

### DIFF
--- a/.github/workflows/make-v2-release.yml
+++ b/.github/workflows/make-v2-release.yml
@@ -1,0 +1,77 @@
+name: Make Release v2 (pre-release)
+on:
+  workflow_dispatch: {}
+concurrency:
+  group: on-release-publish
+jobs:
+  run-unit-tests:
+    uses: ./.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+  publish-npm:
+    needs: run-unit-tests
+    # Needed as recommended by npm docs on publishing with provenance https://docs.npmjs.com/generating-provenance-statements
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_VERSION: ${{ steps.set-release-version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Setup NodeJS
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - name: Setup auth tokens
+        run: |
+          npm set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
+      - name: Setup dependencies
+        uses: ./.github/actions/cached-node-modules
+      - name: Version
+        run: |
+          # Version all packages to next major version (2.0.0) without pushing to git, generating changelog or running commit hooks
+          # Since the version stored in the lerna.json will always be a 1.x.x version, we manually set the version to 2.0.0
+          npx lerna version major --force-publish --no-push --no-git-tag-version --no-commit-hooks --no-changelog --yes
+      - name: Set alpha iteration
+        run: |
+          # Get the current alpha version from npm i.e 2.0.0-alpha.0 -> 0, 2.0.0-alpha.1 -> 1 (default to -1 if no alpha versions exist = first pre-release)
+          ITERATION=$(npm show @aws-lambda-powertools/commons time --json | jq -r 'to_entries | map(select(.key | startswith("2.0.0-alpha"))) | sort_by(.key) | last | .key // "-1"')
+          # Write the new version to the file
+          echo "{ \"iteration\": $((ITERATION + 1)) }" > v2.json
+      - name: Increment version in UA
+        run: |
+          # Increment the version in the UA
+          echo "// this file is auto generated, do not modify\nexport const PT_VERSION = '2.0.0-alpha.$(jq -r '.iteration' v2.json)';" > packages/commons/src/version.ts
+      - name: Build
+        run: |
+          npm run build:prod -w packages/batch \
+            -w packages/commons \
+            -w packages/idempotency \
+            -w packages/logger \
+            -w packages/metrics \
+            -w packages/parameters \
+            -w packages/tracer
+      - name: Pack packages
+        run: |
+          npm pack -w packages/batch \
+            -w packages/commons \
+            -w packages/idempotency \
+            -w packages/logger \
+            -w packages/metrics \
+            -w packages/parameters \
+            -w packages/tracer
+      - name: Publish to npm
+        run: |
+          npm publish aws-lambda-powertools-batch-*.tgz --tag next --provenance
+          npm publish aws-lambda-powertools-commons-*.tgz --tag next --provenance
+          npm publish aws-lambda-powertools-idempotency-*.tgz --tag next --provenance
+          npm publish aws-lambda-powertools-logger-*.tgz --tag next --provenance
+          npm publish aws-lambda-powertools-metrics-*.tgz --tag next --provenance
+          npm publish aws-lambda-powertools-parameters-*.tgz --tag next --provenance
+          npm publish aws-lambda-powertools-tracer-*.tgz --tag next --provenance
+      - name: Set release version
+        id: set-release-version
+        run: |
+          VERSION="2.0.0-alpha.$(cat v2.json | jq .iteration -r)"
+          echo RELEASE_VERSION="$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces a new workflow that allows to publish pre-releases of our Powertools utilities to the npm registry.

The workflow is expected to last for the duration of the pre-release period and for this reason it takes some important shortcuts that make it deviate from the original release workflow. Contrary to most of the PRs related to v2 this one must be merged to `main` otherwise GitHub won't show the workflow as available.

Nevertheless, the workflow is expected to run always using the `feat/v2` branch and never on `main`.

#### No persistence

The workflow doesn't generate git tags, change logs, nor version increment commit.

Since the workflow is expected to run on the v2 branch, which might have been rebased with `main` more or less recently, it always assumes that the version present in the `lerna.json` file or any of the `package.json` files is the current one.

From this assumption it always creates a major version which will always default to `2.0.0`. Once that's done it'll query the npm registry and check the version of the latest pre-release available (i.e. `2.0.0-alpha.0`) and will use that number to determine the next increment (i.e. `2.0.0-alpha.0` -> `2.0.0-alpha.1`).

It will then add this suffix out of band right before publishing the packages to npm.

#### Automatic UA string increment

This is a change that technically speaking was not essential nor necessary, however given the lower stakes a pre-release I opted for sneaking in this behavior so that we can test it and eventually back-port it to `main`.

The workflow will use the release version determined in the previous step to update the contents of the `packages/commons/src/version.ts` file so that the full release won't require any manual intervention.

#### Build

The workflow uses a new method of building that will be introduced in a future PR and that allows us to generate double builds for CJS/ESM. 

At the moment it will call a placeholder script (`build:prod`), the actual script will be implemented in each utility in dedicated PRs.

#### Pack & Publish

The workflow then packs the utility (aka creates tarballs for each one of them) and then publishes them under the `next` tag. 

Using the `next` tag will allow customers to 

#### Others

As part of the versioning process the workflow will also run a script that injects a `postinstall` script in each utility. This script will log a warning every time a utility is installed informing customers that the version they're using is a prerelease and should not be used in production.

The script **is not part of this PR** but can be [found here](https://github.com/aws-powertools/powertools-lambda-typescript/blob/59a9b33645f8fb7386345f08b7e4b8aefbdf5f43/.github/scripts/release_patch_package_json.js#L87-L90). We want the script to be on the v2 branch instead of this one (`main`) so that it's run only when publishing pre-releases.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1717

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.