### PR TITLE
feat(idempotency): add idempotency decorator

### DIFF
--- a/docs/snippets/idempotency/idempotentDecoratorBase.ts
+++ b/docs/snippets/idempotency/idempotentDecoratorBase.ts
@@ -1,0 +1,28 @@
+import type { Context } from 'aws-lambda';
+import { LambdaInterface } from '@aws-lambda-powertools/commons';
+import {
+  IdempotencyConfig,
+  idempotent,
+} from '@aws-lambda-powertools/idempotency';
+import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
+import { Request, Response } from './types';
+
+const dynamoDBPersistenceLayer = new DynamoDBPersistenceLayer({
+  tableName: 'idempotencyTableName',
+});
+
+const config = new IdempotencyConfig({});
+
+class MyLambda implements LambdaInterface {
+  @idempotent({ persistenceStore: dynamoDBPersistenceLayer, config: config })
+  public async handler(_event: Request, _context: Context): Promise<Response> {
+    // ... process your event
+    return {
+      message: 'success',
+      statusCode: 200,
+    };
+  }
+}
+
+const defaultLambda = new MyLambda();
+export const handler = defaultLambda.handler.bind(defaultLambda);

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -160,6 +160,22 @@ When using `makeIdempotent` on arbitrary functions, you can tell us which argume
 
 The function this example has two arguments, note that while wrapping it with the `makeIdempotent` high-order function, we specify the `dataIndexArgument` as `1` to tell the decorator that the second argument is the one that contains the data we should use to make the function idempotent. Remember that arguments are zero-indexed, so the first argument is `0`, the second is `1`, and so on.
 
+### Idempotent Decorator
+
+You can also use the `@idempotent` decorator to make your Lambda handler idempotent, similar to the `makeIdempotent` function wrapper.
+
+=== "index.ts"
+
+    ```typescript hl_lines="17"
+    --8<-- "docs/snippets/idempotency/idempotentDecoratorBase.ts"
+    ```
+
+=== "types.ts"
+
+    ```typescript
+
+You can use the decorator on your Lambda handler or on any function that returns a response to make it idempotent. This is useful when you want to make a specific logic idempotent, for example when your Lambda handler performs multiple side effects and you only want to make a specific one idempotent.
+The configuration options for the `@idempotent` decorator are the same as the ones for the `makeIdempotent` function wrapper.
 
 ### MakeHandlerIdempotent Middy middleware
 

--- a/packages/idempotency/src/idempotencyDecorator.ts
+++ b/packages/idempotency/src/idempotencyDecorator.ts
@@ -1,102 +1,11 @@
-import type { Context, Handler } from 'aws-lambda';
-import {
-  AnyFunction,
-  IdempotencyLambdaHandlerOptions,
-  ItempotentFunctionOptions,
-} from './types';
-import { IdempotencyHandler } from './IdempotencyHandler';
-import { IdempotencyConfig } from './IdempotencyConfig';
+import { AnyFunction, ItempotentFunctionOptions } from './types';
 import { makeIdempotent } from './makeIdempotent';
-
-const isContext = (arg: unknown): arg is Context => {
-  return (
-    arg !== undefined &&
-    arg !== null &&
-    typeof arg === 'object' &&
-    'getRemainingTimeInMillis' in arg
-  );
-};
-
-const isFnHandler = (
-  fn: AnyFunction,
-  args: Parameters<AnyFunction>
-): fn is Handler => {
-  // get arguments of function
-  return (
-    fn !== undefined &&
-    fn !== null &&
-    typeof fn === 'function' &&
-    isContext(args[1])
-  );
-};
-
-const isOptionsWithDataIndexArgument = (
-  options: unknown
-): options is IdempotencyLambdaHandlerOptions & {
-  dataIndexArgument: number;
-} => {
-  return (
-    options !== undefined &&
-    options !== null &&
-    typeof options === 'object' &&
-    'dataIndexArgument' in options
-  );
-};
-
-const idempotent = function (
-  options: ItempotentFunctionOptions<Parameters<AnyFunction>>
-): (
-  target: unknown,
-  propertyKey: string,
-  descriptor: PropertyDescriptor
-) => PropertyDescriptor {
-  return function (
-    _target: unknown,
-    _propertyKey: string,
-    descriptor: PropertyDescriptor
-  ) {
-    const childFunction = descriptor.value;
-    descriptor.value = makeIdempotent(childFunction, options);
-    descriptor.value = function (...args: Parameters<AnyFunction>) {
-      const { persistenceStore, config } = options;
-      const idempotencyConfig = config ? config : new IdempotencyConfig({});
-
-      if (!idempotencyConfig.isEnabled())
-        return childFunction.apply(this, args);
-
-      let functionPayloadtoBeHashed;
-
-      if (isFnHandler(childFunction, args)) {
-        idempotencyConfig.registerLambdaContext(args[1]);
-        functionPayloadtoBeHashed = args[0];
-      } else {
-        if (isOptionsWithDataIndexArgument(options)) {
-          functionPayloadtoBeHashed = args[options.dataIndexArgument];
-        } else {
-          functionPayloadtoBeHashed = args[0];
-        }
-      }
-
-      return new IdempotencyHandler({
-        functionToMakeIdempotent: childFunction,
-        idempotencyConfig: idempotencyConfig,
-        persistenceStore: persistenceStore,
-        functionArguments: args,
-        functionPayloadToBeHashed: functionPayloadtoBeHashed,
-      }).handle();
-    };
-
-    return descriptor;
-  };
-};
 
 /**
  * Use this decorator to make your lambda handler itempotent.
  * You need to provide a peristance layer to store the idempotency information.
  * At the moment we only support `DynamodbPersistenceLayer`.
- * > **Note**:
- * > decorators are an exeperimental feature in typescript and may change in the future.
- * > To enable decoratopr support in your project, you need to enable the `experimentalDecorators` compiler option in your tsconfig.json file.
+ *
  * @example
  * ```ts
  * import {
@@ -105,7 +14,7 @@ const idempotent = function (
  * } from '@aws-lambda-powertools/idempotency'
  *
  * class MyLambdaFunction {
- *   @idempotentLambdaHandler({ persistenceStore: new DynamoDBPersistenceLayer() })
+ *   @idempotent({ persistenceStore: new DynamoDBPersistenceLayer() })
  *   async handler(event: any, context: any) {
  *     return "Hello World";
  *   }
@@ -113,21 +22,8 @@ const idempotent = function (
  * export myLambdaHandler new MyLambdaFunction();
  * export const handler = myLambdaHandler.handler.bind(myLambdaHandler);
  * ```
- * @see {@link DynamoDBPersistenceLayer}
- * @see https://www.typescriptlang.org/docs/handbook/decorators.html
- */
-// const idempotentLambdaHandler = function (
-//   options: IdempotencyLambdaHandlerOptions
-// ): (
-//   target: unknown,
-//   propertyKey: string,
-//   descriptor: PropertyDescriptor
-// ) => PropertyDescriptor {
-//   return idempotent(options);
-// };
-/**
- * Use this decorator to make any class function idempotent.
- * Similar to the `idempotentLambdaHandler` decorator, you need to provide a persistence layer to store the idempotency information.
+ *
+ * Similar to decoratoring a handler you can use the decorator on any other function.
  * @example
  * ```ts
  * import {
@@ -143,22 +39,31 @@ const idempotent = function (
  *      }
  *    }
  *
- *  @idempotentFunction({ persistenceStore: new DynamoDBPersistenceLayer() })
+ *  @idemptent({ persistenceStore: new DynamoDBPersistenceLayer() })
  *  public async process(record: Record<stiring, unknown) {
  *     // do some processing
  *  }
- *  ```
- *  @see {@link DynamoDBPersistenceLayer}
- * @param options
+ * ```
+ * @see {@link DynamoDBPersistenceLayer}
+ * @see https://www.typescriptlang.org/docs/handbook/decorators.html
  */
-// const idempotentFunction = function (
-//   options: ItempotentFunctionOptions<Parameters<AnyFunction>>
-// ): (
-//   target: unknown,
-//   propertyKey: string,
-//   descriptor: PropertyDescriptor
-// ) => PropertyDescriptor {
-//   return idempotent(options);
-// };
+const idempotent = function (
+  options: ItempotentFunctionOptions<Parameters<AnyFunction>>
+): (
+  target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor
+) => PropertyDescriptor {
+  return function (
+    _target: unknown,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const childFunction = descriptor.value;
+    descriptor.value = makeIdempotent(childFunction, options);
+
+    return descriptor;
+  };
+};
 
 export { idempotent };

--- a/packages/idempotency/src/idempotencyDecorator.ts
+++ b/packages/idempotency/src/idempotencyDecorator.ts
@@ -1,0 +1,164 @@
+import type { Context, Handler } from 'aws-lambda';
+import {
+  AnyFunction,
+  IdempotencyLambdaHandlerOptions,
+  ItempotentFunctionOptions,
+} from './types';
+import { IdempotencyHandler } from './IdempotencyHandler';
+import { IdempotencyConfig } from './IdempotencyConfig';
+import { makeIdempotent } from './makeIdempotent';
+
+const isContext = (arg: unknown): arg is Context => {
+  return (
+    arg !== undefined &&
+    arg !== null &&
+    typeof arg === 'object' &&
+    'getRemainingTimeInMillis' in arg
+  );
+};
+
+const isFnHandler = (
+  fn: AnyFunction,
+  args: Parameters<AnyFunction>
+): fn is Handler => {
+  // get arguments of function
+  return (
+    fn !== undefined &&
+    fn !== null &&
+    typeof fn === 'function' &&
+    isContext(args[1])
+  );
+};
+
+const isOptionsWithDataIndexArgument = (
+  options: unknown
+): options is IdempotencyLambdaHandlerOptions & {
+  dataIndexArgument: number;
+} => {
+  return (
+    options !== undefined &&
+    options !== null &&
+    typeof options === 'object' &&
+    'dataIndexArgument' in options
+  );
+};
+
+const idempotent = function (
+  options: ItempotentFunctionOptions<Parameters<AnyFunction>>
+): (
+  target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor
+) => PropertyDescriptor {
+  return function (
+    _target: unknown,
+    _propertyKey: string,
+    descriptor: PropertyDescriptor
+  ) {
+    const childFunction = descriptor.value;
+    descriptor.value = makeIdempotent(childFunction, options);
+    descriptor.value = function (...args: Parameters<AnyFunction>) {
+      const { persistenceStore, config } = options;
+      const idempotencyConfig = config ? config : new IdempotencyConfig({});
+
+      if (!idempotencyConfig.isEnabled())
+        return childFunction.apply(this, args);
+
+      let functionPayloadtoBeHashed;
+
+      if (isFnHandler(childFunction, args)) {
+        idempotencyConfig.registerLambdaContext(args[1]);
+        functionPayloadtoBeHashed = args[0];
+      } else {
+        if (isOptionsWithDataIndexArgument(options)) {
+          functionPayloadtoBeHashed = args[options.dataIndexArgument];
+        } else {
+          functionPayloadtoBeHashed = args[0];
+        }
+      }
+
+      return new IdempotencyHandler({
+        functionToMakeIdempotent: childFunction,
+        idempotencyConfig: idempotencyConfig,
+        persistenceStore: persistenceStore,
+        functionArguments: args,
+        functionPayloadToBeHashed: functionPayloadtoBeHashed,
+      }).handle();
+    };
+
+    return descriptor;
+  };
+};
+
+/**
+ * Use this decorator to make your lambda handler itempotent.
+ * You need to provide a peristance layer to store the idempotency information.
+ * At the moment we only support `DynamodbPersistenceLayer`.
+ * > **Note**:
+ * > decorators are an exeperimental feature in typescript and may change in the future.
+ * > To enable decoratopr support in your project, you need to enable the `experimentalDecorators` compiler option in your tsconfig.json file.
+ * @example
+ * ```ts
+ * import {
+ *   DynamoDBPersistenceLayer,
+ *   idempotentLambdaHandler
+ * } from '@aws-lambda-powertools/idempotency'
+ *
+ * class MyLambdaFunction {
+ *   @idempotentLambdaHandler({ persistenceStore: new DynamoDBPersistenceLayer() })
+ *   async handler(event: any, context: any) {
+ *     return "Hello World";
+ *   }
+ * }
+ * export myLambdaHandler new MyLambdaFunction();
+ * export const handler = myLambdaHandler.handler.bind(myLambdaHandler);
+ * ```
+ * @see {@link DynamoDBPersistenceLayer}
+ * @see https://www.typescriptlang.org/docs/handbook/decorators.html
+ */
+// const idempotentLambdaHandler = function (
+//   options: IdempotencyLambdaHandlerOptions
+// ): (
+//   target: unknown,
+//   propertyKey: string,
+//   descriptor: PropertyDescriptor
+// ) => PropertyDescriptor {
+//   return idempotent(options);
+// };
+/**
+ * Use this decorator to make any class function idempotent.
+ * Similar to the `idempotentLambdaHandler` decorator, you need to provide a persistence layer to store the idempotency information.
+ * @example
+ * ```ts
+ * import {
+ *  DynamoDBPersistenceLayer,
+ *  idempotentFunction
+ *  } from '@aws-lambda-powertools/idempotency'
+ *
+ *  class MyClass {
+ *
+ *  public async handler(_event: any, _context: any) {
+ *    for(const record of _event.records){
+ *      await this.process(record);
+ *      }
+ *    }
+ *
+ *  @idempotentFunction({ persistenceStore: new DynamoDBPersistenceLayer() })
+ *  public async process(record: Record<stiring, unknown) {
+ *     // do some processing
+ *  }
+ *  ```
+ *  @see {@link DynamoDBPersistenceLayer}
+ * @param options
+ */
+// const idempotentFunction = function (
+//   options: ItempotentFunctionOptions<Parameters<AnyFunction>>
+// ): (
+//   target: unknown,
+//   propertyKey: string,
+//   descriptor: PropertyDescriptor
+// ) => PropertyDescriptor {
+//   return idempotent(options);
+// };
+
+export { idempotent };

--- a/packages/idempotency/src/index.ts
+++ b/packages/idempotency/src/index.ts
@@ -1,4 +1,5 @@
 export * from './errors';
 export * from './IdempotencyConfig';
 export * from './makeIdempotent';
+export * from './idempotencyDecorator';
 export { IdempotencyRecordStatus } from './constants';

--- a/packages/idempotency/tests/e2e/idempotentDecorator.test.FunctionCode.ts
+++ b/packages/idempotency/tests/e2e/idempotentDecorator.test.FunctionCode.ts
@@ -1,0 +1,164 @@
+import type { Context } from 'aws-lambda';
+import { LambdaInterface } from '@aws-lambda-powertools/commons';
+import { idempotent } from '../../src';
+import { Logger } from '../../../logger';
+import { DynamoDBPersistenceLayer } from '../../src/persistence/DynamoDBPersistenceLayer';
+import { IdempotencyConfig } from '../../src/';
+
+const IDEMPOTENCY_TABLE_NAME =
+  process.env.IDEMPOTENCY_TABLE_NAME || 'table_name';
+const dynamoDBPersistenceLayer = new DynamoDBPersistenceLayer({
+  tableName: IDEMPOTENCY_TABLE_NAME,
+});
+
+const dynamoDBPersistenceLayerCustomized = new DynamoDBPersistenceLayer({
+  tableName: IDEMPOTENCY_TABLE_NAME,
+  dataAttr: 'dataAttr',
+  keyAttr: 'customId',
+  expiryAttr: 'expiryAttr',
+  statusAttr: 'statusAttr',
+  inProgressExpiryAttr: 'inProgressExpiryAttr',
+  staticPkValue: 'staticPkValue',
+  validationKeyAttr: 'validationKeyAttr',
+});
+
+const config = new IdempotencyConfig({});
+
+class DefaultLambda implements LambdaInterface {
+  @idempotent({ persistenceStore: dynamoDBPersistenceLayer })
+  public async handler(
+    _event: Record<string, unknown>,
+    _context: Context
+  ): Promise<string> {
+    logger.info(`Got test event: ${JSON.stringify(_event)}`);
+    // sleep to enforce error with parallel execution
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return 'Hello World';
+  }
+
+  @idempotent({
+    persistenceStore: dynamoDBPersistenceLayerCustomized,
+    config: config,
+  })
+  public async handlerCustomized(
+    event: { foo: string },
+    context: Context
+  ): Promise<string> {
+    config.registerLambdaContext(context);
+    logger.info('Processed event', { details: event.foo });
+
+    return event.foo;
+  }
+
+  @idempotent({
+    persistenceStore: dynamoDBPersistenceLayer,
+    config: new IdempotencyConfig({
+      useLocalCache: false,
+      expiresAfterSeconds: 1,
+      eventKeyJmesPath: 'foo',
+    }),
+  })
+  public async handlerExpired(
+    event: { foo: string; invocation: number },
+    context: Context
+  ): Promise<{ foo: string; invocation: number }> {
+    logger.addContext(context);
+
+    logger.info('Processed event', { details: event.foo });
+
+    return {
+      foo: event.foo,
+      invocation: event.invocation,
+    };
+  }
+
+  @idempotent({ persistenceStore: dynamoDBPersistenceLayer })
+  public async handlerParallel(
+    event: { foo: string },
+    context: Context
+  ): Promise<string> {
+    logger.addContext(context);
+
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+
+    logger.info('Processed event', { details: event.foo });
+
+    return event.foo;
+  }
+
+  @idempotent({
+    persistenceStore: dynamoDBPersistenceLayer,
+    config: new IdempotencyConfig({
+      eventKeyJmesPath: 'foo',
+    }),
+  })
+  public async handlerTimeout(
+    event: { foo: string; invocation: number },
+    context: Context
+  ): Promise<{ foo: string; invocation: number }> {
+    logger.addContext(context);
+
+    if (event.invocation === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 4000));
+    }
+
+    logger.info('Processed event', {
+      details: event.foo,
+    });
+
+    return {
+      foo: event.foo,
+      invocation: event.invocation,
+    };
+  }
+}
+
+const defaultLambda = new DefaultLambda();
+const handler = defaultLambda.handler.bind(defaultLambda);
+const handlerParallel = defaultLambda.handlerParallel.bind(defaultLambda);
+
+const handlerCustomized = defaultLambda.handlerCustomized.bind(defaultLambda);
+
+const handlerTimeout = defaultLambda.handlerTimeout.bind(defaultLambda);
+
+const handlerExpired = defaultLambda.handlerExpired.bind(defaultLambda);
+
+const logger = new Logger();
+
+class LambdaWithKeywordArgument implements LambdaInterface {
+  public async handler(
+    event: { id: string },
+    _context: Context
+  ): Promise<string> {
+    config.registerLambdaContext(_context);
+    await this.process(event.id, 'bar');
+
+    return 'Hello World Keyword Argument';
+  }
+
+  @idempotent({
+    persistenceStore: dynamoDBPersistenceLayer,
+    config: config,
+    dataIndexArgument: 1,
+  })
+  public async process(id: string, foo: string): Promise<string> {
+    logger.info('Got test event', { id, foo });
+
+    return 'idempotent result: ' + foo;
+  }
+}
+
+const handlerDataIndexArgument = new LambdaWithKeywordArgument();
+const handlerWithKeywordArgument = handlerDataIndexArgument.handler.bind(
+  handlerDataIndexArgument
+);
+
+export {
+  handler,
+  handlerCustomized,
+  handlerExpired,
+  handlerWithKeywordArgument,
+  handlerTimeout,
+  handlerParallel,
+};

--- a/packages/idempotency/tests/e2e/idempotentDecorator.test.ts
+++ b/packages/idempotency/tests/e2e/idempotentDecorator.test.ts
@@ -1,0 +1,474 @@
+/**
+ * Test idempotency decorator
+ *
+ * @group e2e/idempotency
+ */
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  RESOURCE_NAME_PREFIX,
+  SETUP_TIMEOUT,
+  TEARDOWN_TIMEOUT,
+  TEST_CASE_TIMEOUT,
+} from './constants';
+import { ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { createHash } from 'node:crypto';
+import {
+  invokeFunction,
+  isValidRuntimeKey,
+  TestInvocationLogs,
+  TestStack,
+} from '@aws-lambda-powertools/testing-utils';
+import { IdempotencyTestNodejsFunctionAndDynamoTable } from '../helpers/resources';
+import { join } from 'node:path';
+import { Duration } from 'aws-cdk-lib';
+import { AttributeType } from 'aws-cdk-lib/aws-dynamodb';
+
+const runtime: string = process.env.RUNTIME || 'nodejs18x';
+
+if (!isValidRuntimeKey(runtime)) {
+  throw new Error(`Invalid runtime key value: ${runtime}`);
+}
+
+const dynamoDBClient = new DynamoDBClient({});
+
+describe('Idempotency e2e test decorator, default settings', () => {
+  const testStack = new TestStack({
+    stackNameProps: {
+      stackNamePrefix: RESOURCE_NAME_PREFIX,
+      testName: 'idempotentDecorator',
+    },
+  });
+
+  const lambdaFunctionCodeFilePath = join(
+    __dirname,
+    'idempotentDecorator.test.FunctionCode.ts'
+  );
+
+  let functionNameDefault: string;
+  let tableNameDefault: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+      },
+    },
+    {
+      nameSuffix: 'default',
+    }
+  );
+
+  let functionNameDefaultParallel: string;
+  let tableNameDefaultParallel: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+        handler: 'handlerParallel',
+      },
+    },
+    {
+      nameSuffix: 'defaultParallel',
+    }
+  );
+
+  let functionNameTimeout: string;
+  let tableNameTimeout: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+        handler: 'handlerTimeout',
+        timeout: Duration.seconds(2),
+      },
+    },
+    {
+      nameSuffix: 'timeout',
+    }
+  );
+
+  let functionNameExpired: string;
+  let tableNameExpired: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+        handler: 'handlerExpired',
+        timeout: Duration.seconds(2),
+      },
+    },
+    {
+      nameSuffix: 'expired',
+    }
+  );
+
+  let functionNameDataIndex: string;
+  let tableNameDataIndex: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+        handler: 'handlerWithKeywordArgument',
+      },
+    },
+    {
+      nameSuffix: 'dataIndex',
+    }
+  );
+
+  let functionCustomConfig: string;
+  let tableNameCustomConfig: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+        handler: 'handlerCustomized',
+      },
+      table: {
+        partitionKey: {
+          name: 'customId',
+          type: AttributeType.STRING,
+        },
+      },
+    },
+    {
+      nameSuffix: 'customConfig',
+    }
+  );
+
+  beforeAll(async () => {
+    await testStack.deploy();
+
+    functionNameDefault = testStack.findAndGetStackOutputValue('defaultFn');
+    tableNameDefault = testStack.findAndGetStackOutputValue('defaultTable');
+
+    functionNameDefaultParallel =
+      testStack.findAndGetStackOutputValue('defaultParallelFn');
+    tableNameDefaultParallel = testStack.findAndGetStackOutputValue(
+      'defaultParallelTable'
+    );
+
+    functionNameTimeout = testStack.findAndGetStackOutputValue('timeoutFn');
+    tableNameTimeout = testStack.findAndGetStackOutputValue('timeoutTable');
+
+    functionNameExpired = testStack.findAndGetStackOutputValue('expiredFn');
+    tableNameExpired = testStack.findAndGetStackOutputValue('expiredTable');
+
+    functionCustomConfig =
+      testStack.findAndGetStackOutputValue('customConfigFn');
+    tableNameCustomConfig =
+      testStack.findAndGetStackOutputValue('customConfigTable');
+
+    functionNameDataIndex = testStack.findAndGetStackOutputValue('dataIndexFn');
+    tableNameDataIndex = testStack.findAndGetStackOutputValue('dataIndexTable');
+  }, SETUP_TIMEOUT);
+
+  test(
+    'when called twice with the same payload, it returns the same result and runs the handler once',
+    async () => {
+      const payload = { foo: 'bar' };
+
+      const payloadHash = createHash('md5')
+        .update(JSON.stringify(payload))
+        .digest('base64');
+
+      const logs = await invokeFunction({
+        functionName: functionNameDefault,
+        times: 2,
+        invocationMode: 'SEQUENTIAL',
+        payload: payload,
+      });
+
+      const functionLogs = logs.map((log) => log.getFunctionLogs());
+
+      const idempotencyRecord = await dynamoDBClient.send(
+        new ScanCommand({
+          TableName: tableNameDefault,
+        })
+      );
+      expect(idempotencyRecord.Items).toHaveLength(1);
+      expect(idempotencyRecord.Items?.[0].id).toEqual(
+        `${functionNameDefault}#${payloadHash}`
+      );
+      expect(idempotencyRecord.Items?.[0].data).toEqual('Hello World');
+      expect(idempotencyRecord.Items?.[0].status).toEqual('COMPLETED');
+      // During the first invocation the handler should be called, so the logs should contain 1 log
+      expect(functionLogs[0]).toHaveLength(1);
+      // We test the content of the log as well as the presence of fields from the context, this
+      // ensures that the all the arguments are passed to the handler when made idempotent
+      expect(TestInvocationLogs.parseFunctionLog(functionLogs[0][0])).toEqual(
+        expect.objectContaining({
+          message: 'Got test event: {"foo":"bar"}',
+        })
+      );
+    },
+    TEST_CASE_TIMEOUT
+  );
+
+  test(
+    'when called twice in parallel, the handler is called only once',
+    async () => {
+      const payload = { foo: 'bar' };
+      const payloadHash = createHash('md5')
+        .update(JSON.stringify(payload))
+        .digest('base64');
+      const logs = await invokeFunction({
+        functionName: functionNameDefaultParallel,
+        times: 2,
+        invocationMode: 'PARALLEL',
+        payload: payload,
+      });
+
+      const functionLogs = logs.map((log) => log.getFunctionLogs());
+
+      const idempotencyRecords = await dynamoDBClient.send(
+        new ScanCommand({
+          TableName: tableNameDefaultParallel,
+        })
+      );
+      expect(idempotencyRecords.Items).toHaveLength(1);
+      expect(idempotencyRecords.Items?.[0].id).toEqual(
+        `${functionNameDefaultParallel}#${payloadHash}`
+      );
+      expect(idempotencyRecords.Items?.[0].data).toEqual('bar');
+      expect(idempotencyRecords.Items?.[0].status).toEqual('COMPLETED');
+      expect(idempotencyRecords?.Items?.[0].expiration).toBeGreaterThan(
+        Date.now() / 1000
+      );
+      const successfulInvocationLogs = functionLogs.find(
+        (functionLog) =>
+          functionLog.toString().includes('Processed event') !== undefined
+      );
+
+      const failedInvocationLogs = functionLogs.find(
+        (functionLog) =>
+          functionLog
+            .toString()
+            .includes('There is already an execution in progres') !== undefined
+      );
+
+      expect(successfulInvocationLogs).toBeDefined();
+      expect(failedInvocationLogs).toBeDefined();
+    },
+    TEST_CASE_TIMEOUT
+  );
+
+  test(
+    'when the function times out, the second request is processed correctly by the handler',
+    async () => {
+      const payload = { foo: 'bar' };
+      const payloadHash = createHash('md5')
+        .update(JSON.stringify(payload.foo))
+        .digest('base64');
+
+      const logs = await invokeFunction({
+        functionName: functionNameTimeout,
+        times: 2,
+        invocationMode: 'SEQUENTIAL',
+        payload: Array.from({ length: 2 }, (_, index) => ({
+          ...payload,
+          invocation: index,
+        })),
+      });
+      const functionLogs = logs.map((log) => log.getFunctionLogs());
+      const idempotencyRecord = await dynamoDBClient.send(
+        new ScanCommand({
+          TableName: tableNameTimeout,
+        })
+      );
+      expect(idempotencyRecord.Items).toHaveLength(1);
+      expect(idempotencyRecord.Items?.[0].id).toEqual(
+        `${functionNameTimeout}#${payloadHash}`
+      );
+      expect(idempotencyRecord.Items?.[0].data).toEqual({
+        ...payload,
+        invocation: 1,
+      });
+      expect(idempotencyRecord.Items?.[0].status).toEqual('COMPLETED');
+
+      // During the first invocation the handler should be called, so the logs should contain 1 log
+      expect(functionLogs[0]).toHaveLength(2);
+      expect(functionLogs[0][0]).toContain('Task timed out after');
+
+      expect(functionLogs[1]).toHaveLength(1);
+      expect(TestInvocationLogs.parseFunctionLog(functionLogs[1][0])).toEqual(
+        expect.objectContaining({
+          message: 'Processed event',
+          details: 'bar',
+          function_name: functionNameTimeout,
+        })
+      );
+    },
+    TEST_CASE_TIMEOUT
+  );
+
+  test(
+    'when the idempotency record is expired, the second request is processed correctly by the handler',
+    async () => {
+      const payload = {
+        foo: 'baz',
+      };
+      const payloadHash = createHash('md5')
+        .update(JSON.stringify(payload.foo))
+        .digest('base64');
+
+      // Act
+      const logs = [
+        (
+          await invokeFunction({
+            functionName: functionNameExpired,
+            times: 1,
+            invocationMode: 'SEQUENTIAL',
+            payload: { ...payload, invocation: 0 },
+          })
+        )[0],
+      ];
+      // Wait for the idempotency record to expire
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      logs.push(
+        (
+          await invokeFunction({
+            functionName: functionNameExpired,
+            times: 1,
+            invocationMode: 'SEQUENTIAL',
+            payload: { ...payload, invocation: 1 },
+          })
+        )[0]
+      );
+      const functionLogs = logs.map((log) => log.getFunctionLogs());
+
+      // Assess
+      const idempotencyRecords = await dynamoDBClient.send(
+        new ScanCommand({
+          TableName: tableNameExpired,
+        })
+      );
+      expect(idempotencyRecords.Items).toHaveLength(1);
+      expect(idempotencyRecords.Items?.[0].id).toEqual(
+        `${functionNameExpired}#${payloadHash}`
+      );
+      expect(idempotencyRecords.Items?.[0].data).toEqual({
+        ...payload,
+        invocation: 1,
+      });
+      expect(idempotencyRecords.Items?.[0].status).toEqual('COMPLETED');
+
+      // Both invocations should be successful and the logs should contain 1 log each
+      expect(functionLogs[0]).toHaveLength(1);
+      expect(TestInvocationLogs.parseFunctionLog(functionLogs[1][0])).toEqual(
+        expect.objectContaining({
+          message: 'Processed event',
+          details: 'baz',
+          function_name: functionNameExpired,
+        })
+      );
+      // During the second invocation the handler should be called and complete, so the logs should
+      // contain 1 log
+      expect(functionLogs[1]).toHaveLength(1);
+      expect(TestInvocationLogs.parseFunctionLog(functionLogs[1][0])).toEqual(
+        expect.objectContaining({
+          message: 'Processed event',
+          details: 'baz',
+          function_name: functionNameExpired,
+        })
+      );
+    },
+    TEST_CASE_TIMEOUT
+  );
+
+  test(
+    'when called with customized function wrapper, it creates ddb entry with custom attributes',
+    async () => {
+      const payload = { foo: 'bar' };
+      const payloadHash = createHash('md5')
+        .update(JSON.stringify(payload))
+        .digest('base64');
+      const logs = await invokeFunction({
+        functionName: functionCustomConfig,
+        times: 1,
+        invocationMode: 'SEQUENTIAL',
+        payload: payload,
+      });
+
+      const functionLogs = logs.map((log) => log.getFunctionLogs());
+
+      const idempotencyRecord = await dynamoDBClient.send(
+        new ScanCommand({
+          TableName: tableNameCustomConfig,
+        })
+      );
+      expect(idempotencyRecord.Items?.[0]).toStrictEqual({
+        customId: `${functionCustomConfig}#${payloadHash}`,
+        dataAttr: 'bar',
+        statusAttr: 'COMPLETED',
+        expiryAttr: expect.any(Number),
+        inProgressExpiryAttr: expect.any(Number),
+      });
+
+      expect(functionLogs[0]).toHaveLength(1);
+      expect(TestInvocationLogs.parseFunctionLog(functionLogs[0][0])).toEqual(
+        expect.objectContaining({
+          message: 'Processed event',
+          details: 'bar',
+        })
+      );
+    },
+    TEST_CASE_TIMEOUT
+  );
+
+  test(
+    'when called twice for with different payload using data index arugment, it returns the same result and runs the handler once',
+    async () => {
+      const payload = [{ id: '1234' }, { id: '5678' }];
+      const payloadHash = createHash('md5')
+        .update(JSON.stringify('bar'))
+        .digest('base64');
+
+      const logs = await invokeFunction({
+        functionName: functionNameDataIndex,
+        times: 2,
+        invocationMode: 'SEQUENTIAL',
+        payload: payload,
+      });
+
+      const functionLogs = logs.map((log) => log.getFunctionLogs());
+
+      const idempotencyRecord = await dynamoDBClient.send(
+        new ScanCommand({
+          TableName: tableNameDataIndex,
+        })
+      );
+      expect(idempotencyRecord.Items).toHaveLength(1);
+      expect(idempotencyRecord.Items?.[0].id).toEqual(
+        `${functionNameDataIndex}#${payloadHash}`
+      );
+      expect(idempotencyRecord.Items?.[0].data).toEqual(
+        'idempotent result: bar'
+      );
+      expect(idempotencyRecord.Items?.[0].status).toEqual('COMPLETED');
+      // During the first invocation the handler should be called, so the logs should contain 1 log
+      expect(functionLogs[0]).toHaveLength(1);
+      // We test the content of the log as well as the presence of fields from the context, this
+      // ensures that the all the arguments are passed to the handler when made idempotent
+      expect(TestInvocationLogs.parseFunctionLog(functionLogs[0][0])).toEqual(
+        expect.objectContaining({
+          message: 'Got test event',
+          id: '1234',
+          foo: 'bar',
+        })
+      );
+    },
+    TEST_CASE_TIMEOUT
+  );
+
+  afterAll(async () => {
+    if (!process.env.DISABLE_TEARDOWN) {
+      await testStack.destroy();
+    }
+  }, TEARDOWN_TIMEOUT);
+});

--- a/packages/idempotency/tests/unit/idempotencyDecorator.test.ts
+++ b/packages/idempotency/tests/unit/idempotencyDecorator.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Test Function Wrapper
+ *
+ * @group unit/idempotency/decorator
+ */
+
+import { BasePersistenceLayer, IdempotencyRecord } from '../../src/persistence';
+import { idempotent } from '../../src/';
+import type { IdempotencyRecordOptions } from '../../src/types';
+import {
+  IdempotencyAlreadyInProgressError,
+  IdempotencyInconsistentStateError,
+  IdempotencyItemAlreadyExistsError,
+  IdempotencyPersistenceLayerError,
+} from '../../src/errors';
+import { IdempotencyConfig } from '../../src';
+import { Context } from 'aws-lambda';
+import { helloworldContext } from '@aws-lambda-powertools/commons/lib/samples/resources/contexts';
+import { IdempotencyRecordStatus } from '../../src/constants';
+
+const mockSaveInProgress = jest
+  .spyOn(BasePersistenceLayer.prototype, 'saveInProgress')
+  .mockImplementation();
+const mockSaveSuccess = jest
+  .spyOn(BasePersistenceLayer.prototype, 'saveSuccess')
+  .mockImplementation();
+const mockGetRecord = jest
+  .spyOn(BasePersistenceLayer.prototype, 'getRecord')
+  .mockImplementation();
+
+const dummyContext = helloworldContext;
+
+const mockConfig: IdempotencyConfig = new IdempotencyConfig({});
+
+class PersistenceLayerTestClass extends BasePersistenceLayer {
+  protected _deleteRecord = jest.fn();
+  protected _getRecord = jest.fn();
+  protected _putRecord = jest.fn();
+  protected _updateRecord = jest.fn();
+}
+
+const functionalityToDecorate = jest.fn();
+
+class TestinClassWithLambdaHandler {
+  @idempotent({
+    persistenceStore: new PersistenceLayerTestClass(),
+  })
+  public testing(record: Record<string, unknown>, _context: Context): string {
+    functionalityToDecorate(record);
+
+    return 'Hi';
+  }
+}
+
+class TestingClassWithFunctionDecorator {
+  public handler(record: Record<string, unknown>, context: Context): string {
+    mockConfig.registerLambdaContext(context);
+
+    return this.proccessRecord(record, 'bar');
+  }
+
+  @idempotent({
+    persistenceStore: new PersistenceLayerTestClass(),
+    config: mockConfig,
+    dataIndexArgument: 0,
+  })
+  public proccessRecord(record: Record<string, unknown>, _foo: string): string {
+    functionalityToDecorate(record);
+
+    return 'Processed Record';
+  }
+}
+
+describe('Given a class with a function to decorate', (classWithLambdaHandler = new TestinClassWithLambdaHandler(), classWithFunctionDecorator = new TestingClassWithFunctionDecorator()) => {
+  const keyValueToBeSaved = 'thisWillBeSaved';
+  const inputRecord = {
+    testingKey: keyValueToBeSaved,
+    otherKey: 'thisWillNot',
+  };
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('When wrapping a function with no previous executions', () => {
+    beforeEach(async () => {
+      await classWithFunctionDecorator.handler(inputRecord, dummyContext);
+    });
+
+    test('Then it will save the record to INPROGRESS', () => {
+      expect(mockSaveInProgress).toBeCalledWith(
+        inputRecord,
+        dummyContext.getRemainingTimeInMillis()
+      );
+    });
+
+    test('Then it will call the function that was decorated', () => {
+      expect(functionalityToDecorate).toBeCalledWith(inputRecord);
+    });
+
+    test('Then it will save the record to COMPLETED with function return value', () => {
+      expect(mockSaveSuccess).toBeCalledWith(inputRecord, 'Processed Record');
+    });
+  });
+  describe('When wrapping a handler function with no previous executions', () => {
+    beforeEach(async () => {
+      await classWithLambdaHandler.testing(inputRecord, dummyContext);
+    });
+
+    test('Then it will save the record to INPROGRESS', () => {
+      expect(mockSaveInProgress).toBeCalledWith(
+        inputRecord,
+        dummyContext.getRemainingTimeInMillis()
+      );
+    });
+
+    test('Then it will call the function that was decorated', () => {
+      expect(functionalityToDecorate).toBeCalledWith(inputRecord);
+    });
+
+    test('Then it will save the record to COMPLETED with function return value', () => {
+      expect(mockSaveSuccess).toBeCalledWith(inputRecord, 'Hi');
+    });
+  });
+
+  describe('When decorating a function with previous execution that is INPROGRESS', () => {
+    let resultingError: Error;
+    beforeEach(async () => {
+      mockSaveInProgress.mockRejectedValue(
+        new IdempotencyItemAlreadyExistsError()
+      );
+      const idempotencyOptions: IdempotencyRecordOptions = {
+        idempotencyKey: 'key',
+        status: IdempotencyRecordStatus.INPROGRESS,
+      };
+      mockGetRecord.mockResolvedValue(
+        new IdempotencyRecord(idempotencyOptions)
+      );
+      try {
+        await classWithLambdaHandler.testing(inputRecord, dummyContext);
+      } catch (e) {
+        resultingError = e as Error;
+      }
+    });
+
+    test('Then it will attempt to save the record to INPROGRESS', () => {
+      expect(mockSaveInProgress).toBeCalledWith(
+        inputRecord,
+        dummyContext.getRemainingTimeInMillis()
+      );
+    });
+
+    test('Then it will get the previous execution record', () => {
+      expect(mockGetRecord).toBeCalledWith(inputRecord);
+    });
+
+    test('Then it will not call the function that was decorated', () => {
+      expect(functionalityToDecorate).not.toBeCalled();
+    });
+
+    test('Then an IdempotencyAlreadyInProgressError is thrown', () => {
+      expect(resultingError).toBeInstanceOf(IdempotencyAlreadyInProgressError);
+    });
+  });
+
+  describe('When decorating a function with previous execution that is EXPIRED', () => {
+    let resultingError: Error;
+    beforeEach(async () => {
+      mockSaveInProgress.mockRejectedValue(
+        new IdempotencyItemAlreadyExistsError()
+      );
+      const idempotencyOptions: IdempotencyRecordOptions = {
+        idempotencyKey: 'key',
+        status: IdempotencyRecordStatus.EXPIRED,
+      };
+      mockGetRecord.mockResolvedValue(
+        new IdempotencyRecord(idempotencyOptions)
+      );
+      try {
+        await classWithLambdaHandler.testing(inputRecord, dummyContext);
+      } catch (e) {
+        resultingError = e as Error;
+      }
+    });
+
+    test('Then it will attempt to save the record to INPROGRESS', () => {
+      expect(mockSaveInProgress).toBeCalledWith(
+        inputRecord,
+        dummyContext.getRemainingTimeInMillis()
+      );
+    });
+
+    test('Then it will get the previous execution record', () => {
+      expect(mockGetRecord).toBeCalledWith(inputRecord);
+    });
+
+    test('Then it will not call the function that was decorated', () => {
+      expect(functionalityToDecorate).not.toBeCalled();
+    });
+
+    test('Then an IdempotencyInconsistentStateError is thrown', () => {
+      expect(resultingError).toBeInstanceOf(IdempotencyInconsistentStateError);
+    });
+  });
+
+  describe('When wrapping a function with previous execution that is COMPLETED', () => {
+    beforeEach(async () => {
+      mockSaveInProgress.mockRejectedValue(
+        new IdempotencyItemAlreadyExistsError()
+      );
+      const idempotencyOptions: IdempotencyRecordOptions = {
+        idempotencyKey: 'key',
+        status: IdempotencyRecordStatus.COMPLETED,
+        responseData: 'Hi',
+      };
+
+      mockGetRecord.mockResolvedValue(
+        new IdempotencyRecord(idempotencyOptions)
+      );
+      await classWithLambdaHandler.testing(inputRecord, dummyContext);
+    });
+
+    test('Then it will attempt to save the record to INPROGRESS', () => {
+      expect(mockSaveInProgress).toBeCalledWith(
+        inputRecord,
+        dummyContext.getRemainingTimeInMillis()
+      );
+    });
+
+    test('Then it will get the previous execution record', () => {
+      expect(mockGetRecord).toBeCalledWith(inputRecord);
+    });
+
+    test('Then it will not call decorated functionality', () => {
+      expect(functionalityToDecorate).not.toBeCalledWith(inputRecord);
+    });
+  });
+
+  describe('When wrapping a function with issues saving the record', () => {
+    class TestinClassWithLambdaHandlerWithConfig {
+      @idempotent({
+        persistenceStore: new PersistenceLayerTestClass(),
+        config: new IdempotencyConfig({ lambdaContext: dummyContext }),
+      })
+      public testing(record: Record<string, unknown>): string {
+        functionalityToDecorate(record);
+
+        return 'Hi';
+      }
+    }
+
+    let resultingError: Error;
+    beforeEach(async () => {
+      mockSaveInProgress.mockRejectedValue(new Error('RandomError'));
+      const classWithLambdaHandlerWithConfig =
+        new TestinClassWithLambdaHandlerWithConfig();
+      try {
+        await classWithLambdaHandlerWithConfig.testing(inputRecord);
+      } catch (e) {
+        resultingError = e as Error;
+      }
+    });
+
+    test('Then it will attempt to save the record to INPROGRESS', () => {
+      expect(mockSaveInProgress).toBeCalledWith(
+        inputRecord,
+        dummyContext.getRemainingTimeInMillis()
+      );
+    });
+
+    test('Then an IdempotencyPersistenceLayerError is thrown', () => {
+      expect(resultingError).toBeInstanceOf(IdempotencyPersistenceLayerError);
+    });
+  });
+
+  describe('When idempotency is disabled', () => {
+    beforeAll(async () => {
+      process.env.POWERTOOLS_IDEMPOTENCY_DISABLED = 'true';
+      class TestingClassWithIdempotencyDisabled {
+        @idempotent({
+          persistenceStore: new PersistenceLayerTestClass(),
+          config: new IdempotencyConfig({ lambdaContext: dummyContext }),
+        })
+        public testing(
+          record: Record<string, unknown>,
+          _context: Context
+        ): string {
+          functionalityToDecorate(record);
+
+          return 'Hi';
+        }
+      }
+      const classWithoutIdempotencyDisabled =
+        new TestingClassWithIdempotencyDisabled();
+      await classWithoutIdempotencyDisabled.testing(inputRecord, dummyContext);
+    });
+
+    test('Then it will skip ipdemotency', async () => {
+      expect(mockSaveInProgress).not.toBeCalled();
+      expect(mockSaveSuccess).not.toBeCalled();
+    });
+
+    afterAll(() => {
+      delete process.env.POWERTOOLS_IDEMPOTENCY_DISABLED;
+    });
+  });
+});


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

This PR adds `@idempotent` decorator to the utility. We initially implemented it, but removed later due to uncertainty about decorator interface with TypeScript 5.x upgrade. Now we can restore and simplify the old implementation, by internally calling `makeIdempotent`, making it syntactic sugar for this functionality. This also means that most of e2e tests are very similar to the `makeIdempotent` tests, but we still need to make sure that it works when wrapping around decorator.

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #1700 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda-typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.