### PR TITLE
chore(tracer): update warning to better format segment name

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -410,7 +410,8 @@ class Tracer extends Utility implements TracerInterface {
                 subsegment?.close();
               } catch (error) {
                 console.warn(
-                  `Failed to close or serialize segment, ${subsegment?.name}. We are catching the error but data might be lost.`,
+                  `Failed to close or serialize segment %s. We are catching the error but data might be lost.`,
+                  subsegment?.name,
                   error
                 );
               }
@@ -499,7 +500,8 @@ class Tracer extends Utility implements TracerInterface {
                 subsegment?.close();
               } catch (error) {
                 console.warn(
-                  `Failed to close or serialize segment, ${subsegment?.name}. We are catching the error but data might be lost.`,
+                  `Failed to close or serialize segment %s. We are catching the error but data might be lost.`,
+                  subsegment?.name,
                   error
                 );
               }

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -74,7 +74,8 @@ const captureLambdaHandler = (
       handlerSegment.close();
     } catch (error) {
       console.warn(
-        `Failed to close or serialize segment, ${handlerSegment.name}. We are catching the error but data might be lost.`,
+        `Failed to close or serialize segment %s. We are catching the error but data might be lost.`,
+        handlerSegment.name,
         error
       );
     }

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -22,7 +22,7 @@ type CaptureAsyncFuncMock = jest.SpyInstance<
   [
     name: string,
     fcn: (subsegment?: Subsegment) => unknown,
-    parent?: Segment | Subsegment
+    parent?: Segment | Subsegment,
   ]
 >;
 const createCaptureAsyncFuncMock = function (
@@ -953,7 +953,8 @@ describe('Class: Tracer', () => {
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(logWarningSpy).toHaveBeenNthCalledWith(
         1,
-        `Failed to close or serialize segment, ${handlerSubsegment.name}. We are catching the error but data might be lost.`,
+        `Failed to close or serialize segment %s. We are catching the error but data might be lost.`,
+        handlerSubsegment.name,
         new Error('dummy error')
       );
     });
@@ -1414,7 +1415,8 @@ describe('Class: Tracer', () => {
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect(logWarningSpy).toHaveBeenNthCalledWith(
         1,
-        `Failed to close or serialize segment, ${handlerSubsegment.name}. We are catching the error but data might be lost.`,
+        `Failed to close or serialize segment %s. We are catching the error but data might be lost.`,
+        handlerSubsegment.name,
         new Error('dummy error')
       );
     });

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -22,7 +22,7 @@ type CaptureAsyncFuncMock = jest.SpyInstance<
   [
     name: string,
     fcn: (subsegment?: Subsegment) => unknown,
-    parent?: Segment | Subsegment,
+    parent?: Segment | Subsegment
   ]
 >;
 const createCaptureAsyncFuncMock = function (

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -405,7 +405,8 @@ describe('Middy middleware', () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
     expect(logWarningSpy).toHaveBeenNthCalledWith(
       1,
-      `Failed to close or serialize segment, ${handlerSubsegment.name}. We are catching the error but data might be lost.`,
+      `Failed to close or serialize segment %s. We are catching the error but data might be lost.`,
+      handlerSubsegment.name,
       new Error('dummy error')
     );
     // Check that the segments are restored


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As discussed in the linked issue, the Tracer utility logs a warning when it can't manipulate a segment. This is done to avoid throwing an error and blocking customer code and he log includes the name of the segment that threw an error.

Prior to this PR the name of the segment is included by concatenating a string with a non-literal variable, which according to [Semgrep guidance](https://semgrep.dev/r?q=javascript.lang.security.audit.unsafe-formatstring.unsafe-formatstring) can allow an attacker to inject a format specifier in the string and forge the log message.

This PR removes the string concatenation in favor of using the format function on the console object (i.e. `console.warn('hello %s', 'Bob');`) so that the string interpolation is handled by the language.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1749

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.