### PR TITLE
chore(docs): add invisible unicode char to decorator docstrings

### DIFF
--- a/packages/idempotency/src/idempotencyDecorator.ts
+++ b/packages/idempotency/src/idempotencyDecorator.ts
@@ -14,9 +14,9 @@ import { makeIdempotent } from './makeIdempotent';
  * } from '@aws-lambda-powertools/idempotency';
  * import type { LambdaInterface } from '@aws-lambda-powertools/commons';
  *
- * class MyLambdaFunction implements LambdaInterface{
- *   @idempotent({ persistenceStore: new DynamoDBPersistenceLayer() })
- *   async handler(event: any, context: any) {
+ * class MyLambdaFunction implements LambdaInterface {
+ *   ⁣@idempotent({ persistenceStore: new DynamoDBPersistenceLayer() })
+ *   async handler(event: unknown, _context: unknown) {
  *     return "Hello World";
  *   }
  * }
@@ -28,23 +28,23 @@ import { makeIdempotent } from './makeIdempotent';
  * @example
  * ```ts
  * import {
- *  DynamoDBPersistenceLayer,
- *  idempotentFunction
- *  } from '@aws-lambda-powertools/idempotency';
- *  import type { LambdaInterface } from '@aws-lambda-powertools/commons';
+ *   DynamoDBPersistenceLayer,
+ *   idempotentFunction
+ * } from '@aws-lambda-powertools/idempotency';
+ * import type { LambdaInterface } from '@aws-lambda-powertools/commons';
  *
- *  class MyClass implements LambdaInterface {
+ * class MyClass implements LambdaInterface {
+ *   public async handler(event: unknown, _context: unknown) {
+ *     for(const record of event.records){
+ *       await this.process(record);
+ *     }
+ *   }
  *
- *  public async handler(_event: any, _context: any) {
- *    for(const record of _event.records){
- *      await this.process(record);
- *      }
- *    }
- *
- *  @idemptent({ persistenceStore: new DynamoDBPersistenceLayer() })
- *  public async process(record: Record<stiring, unknown) {
+ *   ⁣@idemptent({ persistenceStore: new DynamoDBPersistenceLayer() })
+ *   public async process(record: Record<stiring, unknown>) {
  *     // do some processing
- *  }
+ *   }
+ * }
  * ```
  * @see {@link DynamoDBPersistenceLayer}
  * @see https://www.typescriptlang.org/docs/handbook/decorators.html

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -58,7 +58,7 @@ import type {
  *
  * const logger = new Logger();
  *
- * const lambdaHandler = async (_event: any, _context: any) => {
+ * const lambdaHandler = async (_event: unknown, _context: unknown) => {
  *     logger.info('This is an INFO log with some context');
  * };
  *
@@ -77,12 +77,9 @@ import type {
  * const logger = new Logger();
  *
  * class Lambda implements LambdaInterface {
- *
- *   // FYI: Decorator might not render properly in VSCode mouse over due to https://github.com/microsoft/TypeScript/issues/47679 and might show as *@logger* instead of `@logger.injectLambdaContext`
- *
  *     // Decorate your handler class method
- *     @logger.injectLambdaContext()
- *     public async handler(_event: any, _context: any): Promise<void> {
+ *     ⁣@logger.injectLambdaContext()
+ *     public async handler(_event: unknown, _context: unknown): Promise<void> {
  *         logger.info('This is an INFO log with some context');
  *     }
  * }
@@ -358,8 +355,8 @@ class Logger extends Utility implements ClassThatLogs {
    *
    * class Lambda implements LambdaInterface {
    *     // Decorate your handler class method
-   *     @logger.injectLambdaContext()
-   *     public async handler(_event: any, _context: any): Promise<void> {
+   *     ⁣@logger.injectLambdaContext()
+   *     public async handler(_event: unknown, _context: unknown): Promise<void> {
    *         logger.info('This is an INFO log with some context');
    *     }
    * }

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -54,7 +54,7 @@ import {
  *
  * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
  *
- * const lambdaHandler = async (_event: any, _context: any) => {
+ * const lambdaHandler = async (_event: unknown, _context: unknown) => {
  *   ...
  * };
  *
@@ -77,11 +77,9 @@ import {
  * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
  *
  * class Lambda implements LambdaInterface {
- *
- *   // FYI: Decorator might not render properly in VSCode mouse over due to https://github.com/microsoft/TypeScript/issues/47679 and might show as *@metrics* instead of `@metrics.logMetrics`
- *
- *   @metrics.logMetrics({ captureColdStartMetric: true, throwOnEmptyMetrics: true })
- *   public handler(_event: any, _context: any): Promise<void> {
+ *   // Decorate your handler with the logMetrics decorator
+ *   ⁣@metrics.logMetrics({ captureColdStartMetric: true, throwOnEmptyMetrics: true })
+ *   public handler(_event: unknown, _context: unknown): Promise<void> {
  *     // ...
  *     metrics.addMetric('test-metric', MetricUnits.Count, 10);
  *     // ...
@@ -103,7 +101,7 @@ import {
  *
  * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
  *
- * export const handler = async (_event: any, _context: any): Promise<void> => {
+ * export const handler = async (_event: unknown, __context: unknown): Promise<void> => {
  *   metrics.captureColdStartMetric();
  *   metrics.addMetric('test-metric', MetricUnits.Count, 10);
  *   metrics.publishStoredMetrics();
@@ -243,7 +241,7 @@ class Metrics extends Utility implements MetricsInterface {
    *
    * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' });
    *
-   * export const handler = async (event: any, _context: any): Promise<void> => {
+   * export const handler = async (_event: unknown, __context: unknown): Promise<void> => {
    *     metrics.captureColdStartMetric();
    * };
    * ```
@@ -305,7 +303,7 @@ class Metrics extends Utility implements MetricsInterface {
    * class Lambda implements LambdaInterface {
    *
    *   @metrics.logMetrics({ captureColdStartMetric: true })
-   *   public handler(_event: any, _context: any): Promise<void> {
+   *   public handler(_event: unknown, __context: unknown): Promise<void> {
    *    // ...
    *   }
    * }
@@ -373,7 +371,7 @@ class Metrics extends Utility implements MetricsInterface {
    *
    * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName: 'orders' }); // Sets metric namespace, and service as a metric dimension
    *
-   * export const handler = async (_event: any, _context: any): Promise<void> => {
+   * export const handler = async (_event: unknown, __context: unknown): Promise<void> => {
    *   metrics.addMetric('test-metric', MetricUnits.Count, 10);
    *   metrics.publishStoredMetrics();
    * };
@@ -523,7 +521,7 @@ class Metrics extends Utility implements MetricsInterface {
    *
    * const metrics = new Metrics({ namespace: 'serverlessAirline', serviceName:'orders' });
    *
-   * export const handler = async (_event: any, _context: any): Promise<void> => {
+   * export const handler = async (_event: unknown, __context: unknown): Promise<void> => {
    *     metrics.throwOnEmptyMetrics();
    *     metrics.publishStoredMetrics(); // will throw since no metrics added.
    * };

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -51,7 +51,7 @@ import { type Segment, Subsegment } from 'aws-xray-sdk-core';
  *
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  *
- * const lambdaHandler = async (_event: any, _context: any) => {
+ * const lambdaHandler = async (_event: unknown, _context: unknown) => {
  *   ...
  * };
  *
@@ -73,11 +73,9 @@ import { type Segment, Subsegment } from 'aws-xray-sdk-core';
  *
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  *
- * // FYI: Decorator might not render properly in VSCode mouse over due to https://github.com/microsoft/TypeScript/issues/47679 and might show as *@tracer* instead of `@tracer.captureLambdaHandler`
- *
  * class Lambda implements LambdaInterface {
- *   @tracer.captureLambdaHandler()
- *   public handler(event: any, context: any) {
+ *   ⁣@tracer.captureLambdaHandler()
+ *   public handler(_event: unknown, _context: unknown) {
  *     ...
  *   }
  * }
@@ -96,7 +94,7 @@ import { type Segment, Subsegment } from 'aws-xray-sdk-core';
  *
  * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
  *
- * export const handler = async (_event: any, context: any) => {
+ * export const handler = async (_event: unknown, _context: unknown) => {
  *   const segment = tracer.getSegment(); // This is the facade segment (the one that is created by AWS Lambda)
  *   // Create subsegment for the function & set it as active
  *   const subsegment = segment.addNewSubsegment(`## ${process.env._HANDLER}`);
@@ -246,7 +244,7 @@ class Tracer extends Utility implements TracerInterface {
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    * const AWS = tracer.captureAWS(require('aws-sdk'));
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   ...
    * }
    * ```
@@ -275,7 +273,7 @@ class Tracer extends Utility implements TracerInterface {
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    * const s3 = tracer.captureAWSClient(new S3({ apiVersion: '2006-03-01' }));
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   ...
    * }
    * ```
@@ -318,7 +316,7 @@ class Tracer extends Utility implements TracerInterface {
    * const client = new S3Client({});
    * tracer.captureAWSv3Client(client);
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   ...
    * }
    * ```
@@ -352,9 +350,9 @@ class Tracer extends Utility implements TracerInterface {
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    *
    * class Lambda implements LambdaInterface {
-   *   @tracer.captureLambdaHandler()
-   *   public handler(event: any, context: any) {
-   *     ...
+   *   ⁣@tracer.captureLambdaHandler()
+   *   public handler(_event: unknown, _context: unknown) {
+   *     // ...
    *   }
    * }
    *
@@ -445,13 +443,13 @@ class Tracer extends Utility implements TracerInterface {
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    *
    * class Lambda implements LambdaInterface {
-   *   @tracer.captureMethod()
-   *   public myMethod(param: any) {
-   *     ...
+   *   ⁣@tracer.captureMethod()
+   *   public myMethod(param: string) {
+   *     // ...
    *   }
    *
-   *   public handler(event: any, context: any) {
-   *     ...
+   *   public handler(_event: unknown, _context: unknown) {
+   *     this.myMethod('foo');
    *   }
    * }
    *
@@ -567,7 +565,7 @@ class Tracer extends Utility implements TracerInterface {
    *
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   const currentSegment = tracer.getSegment();
    *   ... // Do something with segment
    * }
@@ -627,7 +625,7 @@ class Tracer extends Utility implements TracerInterface {
    *
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   tracer.putAnnotation('successfulBooking', true);
    * }
    * ```
@@ -652,7 +650,7 @@ class Tracer extends Utility implements TracerInterface {
    *
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   const res = someLogic();
    *   tracer.putMetadata('paymentResponse', res);
    * }
@@ -686,7 +684,7 @@ class Tracer extends Utility implements TracerInterface {
    *
    * const tracer = new Tracer({ serviceName: 'serverlessAirline' });
    *
-   * export const handler = async (_event: any, _context: any) => {
+   * export const handler = async (_event: unknown, _context: unknown) => {
    *   const subsegment = new Subsegment('### foo.bar');
    *   tracer.setSegment(subsegment);
    * }


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As described in the linked issue, the VSCode intellisense, aka the tooltips that show documentation when you hover a method, were not playing well with code blocks containing a decorator due to it starting with `@`.

This caused the code block for decorators to render incorrectly and disrupt the indentation for the rest of the docstring. This was purely a cosmetic issue and the content of the docstring, nor runtime behavior, were affected.

The issue is caused by TypeScript & its docstring parsing, which interpret the `@` as the beginning of a keyword (i.e. `@note`, `@link`, etc.) instead of a decorator.

We have been tracking the issue since early 2022 (microsoft/TypeScript#47679) but a fix was never implemented. A couple of days ago however another user commented under the issue sharing that inserting an empty character (U+2063) forces the decorator to display properly.

This is not an ideal solution, however we can adopt this workaround so that customers can consume the docstrings and have them rendered correctly.

I am subscribed to the upstream issue and will keep an eye on it, if a proper fix is released I'll remove the invisible character.

The PR introduces this character in front of the decorator code examples in the docstrings, as well as updating some types in the docstrings to remove usage of `any`.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #292

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [ ] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.