### PR TITLE
chore(parameters): refactor provider constructor to init client as needed

### DIFF
--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -10,10 +10,6 @@ import type {
   AppConfigGetOptions,
   AppConfigGetOutput,
 } from '../types/AppConfigProvider';
-/* import {
-  addUserAgentMiddleware,
-  isSdkClient,
-} from '@aws-lambda-powertools/commons'; */
 
 /**
  * ## Intro

--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -10,10 +10,10 @@ import type {
   AppConfigGetOptions,
   AppConfigGetOutput,
 } from '../types/AppConfigProvider';
-import {
+/* import {
   addUserAgentMiddleware,
   isSdkClient,
-} from '@aws-lambda-powertools/commons';
+} from '@aws-lambda-powertools/commons'; */
 
 /**
  * ## Intro
@@ -185,7 +185,7 @@ import {
  * For more usage examples, see [our documentation](https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parameters/).
  */
 class AppConfigProvider extends BaseProvider {
-  public client: AppConfigDataClient;
+  public client!: AppConfigDataClient;
   protected configurationTokenStore = new Map<string, string>();
   protected valueStore = new Map<string, Uint8Array>();
   private application?: string;
@@ -197,24 +197,16 @@ class AppConfigProvider extends BaseProvider {
    * @param {AppConfigProviderOptions} options - The configuration object.
    */
   public constructor(options: AppConfigProviderOptions) {
-    super();
+    super({
+      proto: AppConfigDataClient as new (
+        config?: unknown
+      ) => AppConfigDataClient,
+      clientConfig: options.clientConfig,
+      awsSdkV3Client: options.awsSdkV3Client,
+    });
 
-    const { clientConfig, awsSdkV3Client, application, environment } = options;
-    if (awsSdkV3Client) {
-      if (!isSdkClient(awsSdkV3Client)) {
-        console.warn(
-          'awsSdkV3Client is not an AWS SDK v3 client, using default client'
-        );
-        this.client = new AppConfigDataClient(clientConfig ?? {});
-      } else {
-        this.client = awsSdkV3Client;
-      }
-    } else {
-      this.client = new AppConfigDataClient(clientConfig ?? {});
-    }
-    addUserAgentMiddleware(this.client, 'parameters');
-
-    this.application = application || this.envVarsService.getServiceName();
+    const { application, environment } = options;
+    this.application = application ?? this.envVarsService.getServiceName();
     if (!this.application || this.application.trim().length === 0) {
       throw new Error(
         'Application name is not defined or POWERTOOLS_SERVICE_NAME is not set'

--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -198,26 +198,29 @@ class AppConfigProvider extends BaseProvider {
    */
   public constructor(options: AppConfigProviderOptions) {
     super();
-    this.client = new AppConfigDataClient(options.clientConfig || {});
-    if (options?.awsSdkV3Client) {
-      if (isSdkClient(options.awsSdkV3Client)) {
-        this.client = options.awsSdkV3Client;
-      } else {
+
+    const { clientConfig, awsSdkV3Client, application, environment } = options;
+    if (awsSdkV3Client) {
+      if (!isSdkClient(awsSdkV3Client)) {
         console.warn(
           'awsSdkV3Client is not an AWS SDK v3 client, using default client'
         );
+        this.client = new AppConfigDataClient(clientConfig ?? {});
+      } else {
+        this.client = awsSdkV3Client;
       }
+    } else {
+      this.client = new AppConfigDataClient(clientConfig ?? {});
     }
     addUserAgentMiddleware(this.client, 'parameters');
 
-    this.application =
-      options?.application || this.envVarsService.getServiceName();
+    this.application = application || this.envVarsService.getServiceName();
     if (!this.application || this.application.trim().length === 0) {
       throw new Error(
         'Application name is not defined or POWERTOOLS_SERVICE_NAME is not set'
       );
     }
-    this.environment = options.environment;
+    this.environment = environment;
   }
 
   /**

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -18,10 +18,10 @@ import type {
 } from '@aws-sdk/client-dynamodb';
 import type { PaginationConfiguration } from '@aws-sdk/types';
 import type { JSONValue } from '@aws-lambda-powertools/commons';
-import {
+/* import {
   addUserAgentMiddleware,
   isSdkClient,
-} from '@aws-lambda-powertools/commons';
+} from '@aws-lambda-powertools/commons'; */
 
 /**
  * ## Intro
@@ -239,7 +239,7 @@ import {
  * For more usage examples, see [our documentation](https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parameters/).
  */
 class DynamoDBProvider extends BaseProvider {
-  public client: DynamoDBClient;
+  public client!: DynamoDBClient;
   protected keyAttr = 'id';
   protected sortAttr = 'sk';
   protected tableName: string;
@@ -251,30 +251,13 @@ class DynamoDBProvider extends BaseProvider {
    * @param {DynamoDBProviderOptions} config - The configuration object.
    */
   public constructor(config: DynamoDBProviderOptions) {
-    super();
+    super({
+      awsSdkV3Client: config.awsSdkV3Client,
+      clientConfig: config.clientConfig,
+      proto: DynamoDBClient as new (config?: unknown) => DynamoDBClient,
+    });
 
-    const {
-      clientConfig,
-      awsSdkV3Client,
-      tableName,
-      keyAttr,
-      sortAttr,
-      valueAttr,
-    } = config;
-    if (awsSdkV3Client) {
-      if (!isSdkClient(awsSdkV3Client)) {
-        console.warn(
-          'awsSdkV3Client is not an AWS SDK v3 client, using default client'
-        );
-        this.client = new DynamoDBClient(clientConfig ?? {});
-      } else {
-        this.client = awsSdkV3Client;
-      }
-    } else {
-      this.client = new DynamoDBClient(clientConfig ?? {});
-    }
-    addUserAgentMiddleware(this.client, 'parameters');
-
+    const { tableName, keyAttr, sortAttr, valueAttr } = config;
     this.tableName = tableName;
     if (keyAttr) this.keyAttr = keyAttr;
     if (sortAttr) this.sortAttr = sortAttr;

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -18,10 +18,6 @@ import type {
 } from '@aws-sdk/client-dynamodb';
 import type { PaginationConfiguration } from '@aws-sdk/types';
 import type { JSONValue } from '@aws-lambda-powertools/commons';
-/* import {
-  addUserAgentMiddleware,
-  isSdkClient,
-} from '@aws-lambda-powertools/commons'; */
 
 /**
  * ## Intro

--- a/packages/parameters/src/dynamodb/DynamoDBProvider.ts
+++ b/packages/parameters/src/dynamodb/DynamoDBProvider.ts
@@ -253,22 +253,32 @@ class DynamoDBProvider extends BaseProvider {
   public constructor(config: DynamoDBProviderOptions) {
     super();
 
-    this.client = new DynamoDBClient(config?.clientConfig || {});
-    if (config?.awsSdkV3Client) {
-      if (isSdkClient(config.awsSdkV3Client)) {
-        this.client = config.awsSdkV3Client;
-      } else {
+    const {
+      clientConfig,
+      awsSdkV3Client,
+      tableName,
+      keyAttr,
+      sortAttr,
+      valueAttr,
+    } = config;
+    if (awsSdkV3Client) {
+      if (!isSdkClient(awsSdkV3Client)) {
         console.warn(
           'awsSdkV3Client is not an AWS SDK v3 client, using default client'
         );
+        this.client = new DynamoDBClient(clientConfig ?? {});
+      } else {
+        this.client = awsSdkV3Client;
       }
+    } else {
+      this.client = new DynamoDBClient(clientConfig ?? {});
     }
     addUserAgentMiddleware(this.client, 'parameters');
 
-    this.tableName = config.tableName;
-    if (config.keyAttr) this.keyAttr = config.keyAttr;
-    if (config.sortAttr) this.sortAttr = config.sortAttr;
-    if (config.valueAttr) this.valueAttr = config.valueAttr;
+    this.tableName = tableName;
+    if (keyAttr) this.keyAttr = keyAttr;
+    if (sortAttr) this.sortAttr = sortAttr;
+    if (valueAttr) this.valueAttr = valueAttr;
   }
 
   /**

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -9,10 +9,6 @@ import type {
   SecretsGetOptions,
   SecretsGetOutput,
 } from '../types/SecretsProvider';
-import {
-  addUserAgentMiddleware,
-  isSdkClient,
-} from '@aws-lambda-powertools/commons';
 
 /**
  * ## Intro
@@ -149,7 +145,7 @@ import {
  * @see https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parameters/
  */
 class SecretsProvider extends BaseProvider {
-  public client: SecretsManagerClient;
+  public client!: SecretsManagerClient;
 
   /**
    * It initializes the SecretsProvider class.
@@ -157,22 +153,12 @@ class SecretsProvider extends BaseProvider {
    * @param {SecretsProviderOptions} config - The configuration object.
    */
   public constructor(config?: SecretsProviderOptions) {
-    super();
-
-    const { clientConfig, awsSdkV3Client } = config ?? {};
-    if (awsSdkV3Client) {
-      if (!isSdkClient(awsSdkV3Client)) {
-        console.warn(
-          'awsSdkV3Client is not an AWS SDK v3 client, using default client'
-        );
-        this.client = new SecretsManagerClient(clientConfig ?? {});
-      } else {
-        this.client = awsSdkV3Client;
-      }
-    } else {
-      this.client = new SecretsManagerClient(clientConfig ?? {});
-    }
-    addUserAgentMiddleware(this.client, 'parameters');
+    super({
+      proto: SecretsManagerClient as new (
+        config?: unknown
+      ) => SecretsManagerClient,
+      ...(config ?? {}),
+    });
   }
 
   /**

--- a/packages/parameters/src/secrets/SecretsProvider.ts
+++ b/packages/parameters/src/secrets/SecretsProvider.ts
@@ -159,15 +159,18 @@ class SecretsProvider extends BaseProvider {
   public constructor(config?: SecretsProviderOptions) {
     super();
 
-    this.client = new SecretsManagerClient(config?.clientConfig || {});
-    if (config?.awsSdkV3Client) {
-      if (isSdkClient(config.awsSdkV3Client)) {
-        this.client = config.awsSdkV3Client;
-      } else {
+    const { clientConfig, awsSdkV3Client } = config ?? {};
+    if (awsSdkV3Client) {
+      if (!isSdkClient(awsSdkV3Client)) {
         console.warn(
           'awsSdkV3Client is not an AWS SDK v3 client, using default client'
         );
+        this.client = new SecretsManagerClient(clientConfig ?? {});
+      } else {
+        this.client = awsSdkV3Client;
       }
+    } else {
+      this.client = new SecretsManagerClient(clientConfig ?? {});
     }
     addUserAgentMiddleware(this.client, 'parameters');
   }

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -27,10 +27,6 @@ import type {
   SSMGetParametersByNameFromCacheOutputType,
 } from '../types/SSMProvider';
 import type { PaginationConfiguration } from '@aws-sdk/types';
-import {
-  addUserAgentMiddleware,
-  isSdkClient,
-} from '@aws-lambda-powertools/commons';
 
 /**
  * ## Intro
@@ -266,7 +262,7 @@ import {
  * For more usage examples, see [our documentation](https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parameters/).
  */
 class SSMProvider extends BaseProvider {
-  public client: SSMClient;
+  public client!: SSMClient;
   protected errorsKey = '_errors';
   protected maxGetParametersItems = 10;
 
@@ -276,22 +272,10 @@ class SSMProvider extends BaseProvider {
    * @param {SSMProviderOptions} config - The configuration object.
    */
   public constructor(config?: SSMProviderOptions) {
-    super();
-
-    const { clientConfig, awsSdkV3Client } = config ?? {};
-    if (awsSdkV3Client) {
-      if (!isSdkClient(awsSdkV3Client)) {
-        console.warn(
-          'awsSdkV3Client is not an AWS SDK v3 client, using default client'
-        );
-        this.client = new SSMClient(clientConfig ?? {});
-      } else {
-        this.client = awsSdkV3Client;
-      }
-    } else {
-      this.client = new SSMClient(clientConfig ?? {});
-    }
-    addUserAgentMiddleware(this.client, 'parameters');
+    super({
+      proto: SSMClient as new (config?: unknown) => SSMClient,
+      ...(config ?? {}),
+    });
   }
 
   /**

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -278,15 +278,18 @@ class SSMProvider extends BaseProvider {
   public constructor(config?: SSMProviderOptions) {
     super();
 
-    this.client = new SSMClient(config?.clientConfig || {});
-    if (config?.awsSdkV3Client) {
-      if (isSdkClient(config.awsSdkV3Client)) {
-        this.client = config.awsSdkV3Client;
-      } else {
+    const { clientConfig, awsSdkV3Client } = config ?? {};
+    if (awsSdkV3Client) {
+      if (!isSdkClient(awsSdkV3Client)) {
         console.warn(
           'awsSdkV3Client is not an AWS SDK v3 client, using default client'
         );
+        this.client = new SSMClient(clientConfig ?? {});
+      } else {
+        this.client = awsSdkV3Client;
       }
+    } else {
+      this.client = new SSMClient(clientConfig ?? {});
     }
     addUserAgentMiddleware(this.client, 'parameters');
   }

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -9,6 +9,10 @@ import { GetParameterError, TransformParameterError } from '../../src/errors';
 import { toBase64 } from '@aws-sdk/util-base64-node';
 
 const encoder = new TextEncoder();
+jest.mock('@aws-lambda-powertools/commons', () => ({
+  ...jest.requireActual('@aws-lambda-powertools/commons'),
+  addUserAgentMiddleware: jest.fn(),
+}));
 
 describe('Class: BaseProvider', () => {
   afterEach(() => {
@@ -16,6 +20,12 @@ describe('Class: BaseProvider', () => {
   });
 
   class TestProvider extends BaseProvider {
+    public constructor() {
+      super({
+        proto: class {},
+      });
+    }
+
     public _add(key: string, value: ExpirableValue): void {
       this.store.set(key, value);
     }
@@ -582,6 +592,12 @@ describe('Class: BaseProvider', () => {
 
 describe('Function: clearCaches', () => {
   class TestProvider extends BaseProvider {
+    public constructor() {
+      super({
+        proto: class {},
+      });
+    }
+
     public _get(_name: string): Promise<string> {
       throw Error('Not implemented.');
     }

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -14,46 +14,46 @@ jest.mock('@aws-lambda-powertools/commons', () => ({
   addUserAgentMiddleware: jest.fn(),
 }));
 
+class TestProvider extends BaseProvider {
+  public constructor() {
+    super({
+      proto: class {
+        #name = 'TestProvider';
+
+        public hello(): string {
+          return this.#name;
+        }
+      },
+    });
+  }
+
+  public _add(key: string, value: ExpirableValue): void {
+    this.store.set(key, value);
+  }
+
+  public _get(_name: string): Promise<string> {
+    throw Error('Not implemented.');
+  }
+
+  public _getKeyTest(key: string): ExpirableValue | undefined {
+    return this.store.get(key);
+  }
+
+  public _getMultiple(
+    _path: string
+  ): Promise<Record<string, string | undefined>> {
+    throw Error('Not implemented.');
+  }
+
+  public _getStoreSize(): number {
+    return this.store.size;
+  }
+}
+
 describe('Class: BaseProvider', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-
-  class TestProvider extends BaseProvider {
-    public constructor() {
-      super({
-        proto: class {
-          #name = 'TestProvider';
-
-          public hello(): string {
-            return this.#name;
-          }
-        },
-      });
-    }
-
-    public _add(key: string, value: ExpirableValue): void {
-      this.store.set(key, value);
-    }
-
-    public _get(_name: string): Promise<string> {
-      throw Error('Not implemented.');
-    }
-
-    public _getKeyTest(key: string): ExpirableValue | undefined {
-      return this.store.get(key);
-    }
-
-    public _getMultiple(
-      _path: string
-    ): Promise<Record<string, string | undefined>> {
-      throw Error('Not implemented.');
-    }
-
-    public _getStoreSize(): number {
-      return this.store.size;
-    }
-  }
 
   describe('Method: addToCache', () => {
     test('when called with a value and maxAge equal to 0, it skips the cache entirely', () => {
@@ -597,24 +597,6 @@ describe('Class: BaseProvider', () => {
 });
 
 describe('Function: clearCaches', () => {
-  class TestProvider extends BaseProvider {
-    public constructor() {
-      super({
-        proto: class {},
-      });
-    }
-
-    public _get(_name: string): Promise<string> {
-      throw Error('Not implemented.');
-    }
-
-    public _getMultiple(
-      _path: string
-    ): Promise<Record<string, string | undefined>> {
-      throw Error('Not implemented.');
-    }
-  }
-
   test('when called, it clears all the caches', () => {
     // Prepare
     const provider1 = new TestProvider();

--- a/packages/parameters/tests/unit/BaseProvider.test.ts
+++ b/packages/parameters/tests/unit/BaseProvider.test.ts
@@ -22,7 +22,13 @@ describe('Class: BaseProvider', () => {
   class TestProvider extends BaseProvider {
     public constructor() {
       super({
-        proto: class {},
+        proto: class {
+          #name = 'TestProvider';
+
+          public hello(): string {
+            return this.#name;
+          }
+        },
       });
     }
 


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces a slight refactor to the constructor of all the Parameters providers  so that the respective AWS SDK client is instantiated only when strictly needed.

Before this PR we were instatianting a new client optimistically and then overwriting it with the customer-provided one if one was passed.

This, while simplifying the flow of the code, caused an unnecessary runtime penalty for advanced customers who were providing their own client and that now were instantiating two clients only for one to be discarded.

While doing this refactor I have also taken the opportunity to generalize the logic that creates a new client or checks the existing one, as well as the one that adds the UA to it, and move it to the `BaseProvider` class. This way I was able to shave a few kb (~9kb) from the overall final bundle.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1740

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.