### PR TITLE
chore(maintenance): enable `isolatedModules` and isolate cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,4 @@ site
 tmp
 
 # TS build files
-tsconfig.tsbuildinfo
-tsconfig.esm.tsbuildinfo
+*.tsbuildinfo

--- a/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
+++ b/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
@@ -81,11 +81,22 @@ const getVersionFromModule = async (moduleName: string): Promise<string> => {
 
 export const handler = async (): Promise<void> => {
   // Check that the packages version matches the expected one
-  for (const moduleName of ['commons', 'logger', 'metrics', 'tracer']) {
+  for (const moduleName of [
+    'commons',
+    'logger',
+    'metrics',
+    'tracer',
+    'parameters',
+    'idempotency',
+    'batch',
+  ]) {
     const moduleVersion = await getVersionFromModule(moduleName);
-    if (moduleVersion != expectedVersion) {
+    // TODO: remove this check once v2 becomes GA
+    // if (moduleVersion != expectedVersion) {
+    if (!moduleVersion.startsWith(expectedVersion)) {
       throw new Error(
-        `Package version mismatch (${moduleName}): ${moduleVersion} != ${expectedVersion}`
+        // `Package version mismatch (${moduleName}): ${moduleVersion} != ${expectedVersion}`
+        `Package version mismatch (${moduleName}): ${moduleVersion} does not start with ${expectedVersion}`
       );
     }
   }

--- a/packages/batch/package.json
+++ b/packages/batch/package.json
@@ -17,13 +17,12 @@
     "test:e2e:nodejs18x": "echo 'Not Implemented'",
     "test:e2e": "echo 'Not Implemented'",
     "watch": "jest --watch",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/batch/tsconfig.esm.json
+++ b/packages/batch/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/batch/tsconfig.json
+++ b/packages/batch/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs/",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -16,12 +16,12 @@
     "test:e2e": "echo 'Not Applicable'",
     "watch": "jest --watch",
     "generateVersionFile": "echo \"// this file is auto generated, do not modify\nexport const PT_VERSION = '$(jq -r '.version' package.json)';\" > src/version.ts",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/commons/src/types/LambdaInterface.ts
+++ b/packages/commons/src/types/LambdaInterface.ts
@@ -1,12 +1,12 @@
 import type { Handler } from 'aws-lambda';
 
-export type SyncHandler<T extends Handler> = (
+type SyncHandler<T extends Handler> = (
   event: Parameters<T>[0],
   context: Parameters<T>[1],
   callback: Parameters<T>[2]
 ) => void;
 
-export type AsyncHandler<T extends Handler> = (
+type AsyncHandler<T extends Handler> = (
   event: Parameters<T>[0],
   context: Parameters<T>[1]
 ) => Promise<NonNullable<Parameters<Parameters<T>[2]>[1]>>;
@@ -23,4 +23,9 @@ type HandlerMethodDecorator = (
     | TypedPropertyDescriptor<AsyncHandler<Handler>>
 ) => void;
 
-export { LambdaInterface, HandlerMethodDecorator };
+export type {
+  AsyncHandler,
+  SyncHandler,
+  LambdaInterface,
+  HandlerMethodDecorator,
+};

--- a/packages/commons/src/types/awsSdk.ts
+++ b/packages/commons/src/types/awsSdk.ts
@@ -19,4 +19,4 @@ interface SdkClient {
  */
 type MiddlewareArgsLike = { request: { headers: { [key: string]: string } } };
 
-export { SdkClient, MiddlewareArgsLike };
+export type { SdkClient, MiddlewareArgsLike };

--- a/packages/commons/src/types/index.ts
+++ b/packages/commons/src/types/index.ts
@@ -1,11 +1,16 @@
-export {
+export type {
   MiddlewareLikeObj,
   MiddyLikeRequest,
   CleanupFunction,
 } from './middy.js';
-export { SdkClient, MiddlewareArgsLike } from './awsSdk.js';
-export { JSONPrimitive, JSONValue, JSONObject, JSONArray } from './json.js';
-export {
+export type { SdkClient, MiddlewareArgsLike } from './awsSdk.js';
+export type {
+  JSONPrimitive,
+  JSONValue,
+  JSONObject,
+  JSONArray,
+} from './json.js';
+export type {
   SyncHandler,
   AsyncHandler,
   LambdaInterface,

--- a/packages/commons/src/types/middy.ts
+++ b/packages/commons/src/types/middy.ts
@@ -57,4 +57,4 @@ type MiddyLikeRequest = {
  */
 type CleanupFunction = (request: MiddyLikeRequest) => Promise<void>;
 
-export { MiddlewareLikeObj, MiddyLikeRequest, CleanupFunction };
+export type { MiddlewareLikeObj, MiddyLikeRequest, CleanupFunction };

--- a/packages/commons/tsconfig.esm.json
+++ b/packages/commons/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/commons/tsconfig.json
+++ b/packages/commons/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs/",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -17,13 +17,12 @@
     "test:e2e:nodejs18x": "RUNTIME=nodejs18x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --watch",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/idempotency/src/types/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/types/BasePersistenceLayer.ts
@@ -15,4 +15,4 @@ interface BasePersistenceLayerInterface {
   getRecord(data: unknown): Promise<IdempotencyRecord>;
 }
 
-export { BasePersistenceLayerOptions, BasePersistenceLayerInterface };
+export type { BasePersistenceLayerOptions, BasePersistenceLayerInterface };

--- a/packages/idempotency/src/types/ConfigServiceInterface.ts
+++ b/packages/idempotency/src/types/ConfigServiceInterface.ts
@@ -8,4 +8,4 @@ interface ConfigServiceInterface {
   getIdempotencyEnabled(): boolean;
 }
 
-export { ConfigServiceInterface };
+export type { ConfigServiceInterface };

--- a/packages/idempotency/src/types/IdempotencyOptions.ts
+++ b/packages/idempotency/src/types/IdempotencyOptions.ts
@@ -179,7 +179,7 @@ type IdempotencyConfigOptions = {
   lambdaContext?: Context;
 };
 
-export {
+export type {
   AnyFunction,
   IdempotencyConfigOptions,
   ItempotentFunctionOptions,

--- a/packages/idempotency/src/types/IdempotencyRecord.ts
+++ b/packages/idempotency/src/types/IdempotencyRecord.ts
@@ -13,4 +13,4 @@ type IdempotencyRecordOptions = {
   payloadHash?: string;
 };
 
-export { IdempotencyRecordStatusValue, IdempotencyRecordOptions };
+export type { IdempotencyRecordStatusValue, IdempotencyRecordOptions };

--- a/packages/idempotency/src/types/LRUCache.ts
+++ b/packages/idempotency/src/types/LRUCache.ts
@@ -5,4 +5,4 @@ type LRUCacheOptions = {
   maxSize: number;
 };
 
-export { LRUCacheOptions };
+export type { LRUCacheOptions };

--- a/packages/idempotency/src/types/index.ts
+++ b/packages/idempotency/src/types/index.ts
@@ -1,12 +1,12 @@
-export {
+export type {
   IdempotencyRecordOptions,
   IdempotencyRecordStatusValue,
 } from './IdempotencyRecord.js';
-export {
+export type {
   BasePersistenceLayerInterface,
   BasePersistenceLayerOptions,
 } from './BasePersistenceLayer.js';
-export {
+export type {
   IdempotencyConfigOptions,
   IdempotencyLambdaHandlerOptions,
   IdempotencyHandlerOptions,

--- a/packages/idempotency/tsconfig.esm.json
+++ b/packages/idempotency/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/idempotency/tsconfig.json
+++ b/packages/idempotency/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -17,13 +17,12 @@
     "test:e2e:nodejs18x": "RUNTIME=nodejs18x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --watch --group=unit",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/logger/src/types/ConfigServiceInterface.ts
+++ b/packages/logger/src/types/ConfigServiceInterface.ts
@@ -65,4 +65,4 @@ interface ConfigServiceInterface {
   isValueTrue(value: string): boolean;
 }
 
-export { ConfigServiceInterface };
+export type { ConfigServiceInterface };

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -86,7 +86,7 @@ type LoggerInterface = {
   warn(input: LogItemMessage, ...extraInput: LogItemExtraInput): void;
 };
 
-export {
+export type {
   LogFunction,
   LoggerInterface,
   LogItemMessage,

--- a/packages/logger/src/types/index.ts
+++ b/packages/logger/src/types/index.ts
@@ -6,7 +6,6 @@ export type {
   LogAttributes,
   LogLevel,
 } from './Log.js';
-
 export type {
   LogItemMessage,
   LogItemExtraInput,

--- a/packages/logger/tsconfig.esm.json
+++ b/packages/logger/tsconfig.esm.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
-  "include": ["./src/**/*"]
+  "include": [
+    "./src/**/*"
+  ]
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./lib/cjs/",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
   },
-  "include": ["./src/**/*"]
+  "include": [
+    "./src/**/*"
+  ]
 }

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -17,13 +17,12 @@
     "test:e2e:nodejs18x": "RUNTIME=nodejs18x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --group=unit --watch ",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/metrics/src/types/ConfigServiceInterface.ts
+++ b/packages/metrics/src/types/ConfigServiceInterface.ts
@@ -4,4 +4,4 @@ interface ConfigServiceInterface {
   getServiceName(): string;
 }
 
-export { ConfigServiceInterface };
+export type { ConfigServiceInterface };

--- a/packages/metrics/src/types/Metrics.ts
+++ b/packages/metrics/src/types/Metrics.ts
@@ -68,7 +68,7 @@ type MetricDefinition = {
   StorageResolution?: MetricResolution;
 };
 
-export {
+export type {
   MetricsOptions,
   Dimensions,
   EmfOutput,

--- a/packages/metrics/src/types/MetricsInterface.ts
+++ b/packages/metrics/src/types/MetricsInterface.ts
@@ -29,4 +29,4 @@ interface MetricsInterface {
   singleMetric(): Metrics;
 }
 
-export { MetricsInterface };
+export type { MetricsInterface };

--- a/packages/metrics/src/types/index.ts
+++ b/packages/metrics/src/types/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   MetricsOptions,
   Dimensions,
   EmfOutput,
@@ -9,5 +9,5 @@ export {
   MetricResolution,
   MetricUnit,
 } from './Metrics.js';
-export { ConfigServiceInterface } from './ConfigServiceInterface.js';
-export { MetricsInterface } from './MetricsInterface.js';
+export type { ConfigServiceInterface } from './ConfigServiceInterface.js';
+export type { MetricsInterface } from './MetricsInterface.js';

--- a/packages/metrics/tsconfig.esm.json
+++ b/packages/metrics/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/metrics/tsconfig.json
+++ b/packages/metrics/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -17,13 +17,12 @@
     "test:e2e:nodejs18x": "RUNTIME=nodejs18x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --watch",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/parameters/src/types/ConfigServiceInterface.ts
+++ b/packages/parameters/src/types/ConfigServiceInterface.ts
@@ -8,4 +8,4 @@ interface ConfigServiceInterface {
   getSSMDecrypt(): string;
 }
 
-export { ConfigServiceInterface };
+export type { ConfigServiceInterface };

--- a/packages/parameters/tsconfig.esm.json
+++ b/packages/parameters/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/parameters/tsconfig.json
+++ b/packages/parameters/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs/",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,13 +13,12 @@
     "jest": "jest --detectOpenHandles --verbose",
     "test:e2e": "echo 'Not implemented'",
     "watch": "jest --watch",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -76,7 +76,7 @@ interface TestStackProps {
   stack?: Stack;
 }
 
-export {
+export type {
   ExtraTestProps,
   TestDynamodbTableProps,
   TestNodejsFunctionProps,

--- a/packages/testing/tsconfig.esm.json
+++ b/packages/testing/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/testing/tsconfig.json
+++ b/packages/testing/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -17,13 +17,12 @@
     "test:e2e:nodejs18x": "RUNTIME=nodejs18x jest --group=e2e",
     "test:e2e": "jest --group=e2e",
     "watch": "jest --watch",
-    "build:cjs": "tsc --build --force && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
-    "build:esm": "tsc --project tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
+    "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
     "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "prebuild": "rimraf ./lib",
-    "prepack": "rimraf ./lib/*.tsbuildinfo && node ../../.github/scripts/release_patch_package_json.js ."
+    "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "lint-staged": {
     "*.{js,ts}": "npm run lint-fix"

--- a/packages/tracer/src/types/ConfigServiceInterface.ts
+++ b/packages/tracer/src/types/ConfigServiceInterface.ts
@@ -12,4 +12,4 @@ interface ConfigServiceInterface {
   getTracingCaptureError(): string;
 }
 
-export { ConfigServiceInterface };
+export type { ConfigServiceInterface };

--- a/packages/tracer/src/types/ProviderServiceInterface.ts
+++ b/packages/tracer/src/types/ProviderServiceInterface.ts
@@ -45,4 +45,4 @@ interface ProviderServiceInterface {
   putMetadata(key: string, value: unknown, namespace?: string): void;
 }
 
-export { ProviderServiceInterface, ContextMissingStrategy };
+export type { ProviderServiceInterface, ContextMissingStrategy };

--- a/packages/tracer/src/types/Tracer.ts
+++ b/packages/tracer/src/types/Tracer.ts
@@ -134,7 +134,7 @@ interface TracerInterface {
   setSegment(segment: Segment | Subsegment): void;
 }
 
-export {
+export type {
   TracerOptions,
   CaptureLambdaHandlerOptions,
   CaptureMethodOptions,

--- a/packages/tracer/src/types/index.ts
+++ b/packages/tracer/src/types/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   TracerOptions,
   CaptureLambdaHandlerOptions,
   CaptureMethodOptions,

--- a/packages/tracer/tsconfig.esm.json
+++ b/packages/tracer/tsconfig.esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./lib/esm",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
   "include": [
     "./src/**/*"

--- a/packages/tracer/tsconfig.json
+++ b/packages/tracer/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "./lib/cjs",
         "rootDir": "./src",
+        "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
     },
     "include": [
         "./src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2022", // Node.js 16
     "experimentalDecorators": true,
     "module": "commonjs",
-    "moduleResolution": "node", // TODO: experiment with bundler & esnext
+    "moduleResolution": "node",
     "baseUrl": ".",
     // "traceResolution": true, // Enable this to debug module resolution issues
     "declaration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,12 +10,7 @@
     // "traceResolution": true, // Enable this to debug module resolution issues
     "declaration": true,
     "removeComments": false,
-    // TODO: experiment with this & move to tslib in v2
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // TODO: see if this can introduced in v2 (requires breaking changes in exports)
-    // "isolatedModules": true, /* Ensure that each file can be safely transpiled without relying on other imports. */
+    "isolatedModules": true,
     "declarationMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces two changes related to the TypeScript config for the project. The first one enabled the `isolatedModules` compiler option at the project level, while the second specifies paths for the `tsBuildInfoFile` at the workspace level.

The `isolatedModules` [compiler option](https://www.typescriptlang.org/tsconfig#isolatedModules) sets additional constraints that ultimately allow to be more strict in our intent when exporting something. The change doesn't have any runtime impact but a more strict compilation increases the chances of being compatible with a wider range of compilers & bundlers that our customers might be using. This PR enables the option and makes changes needed to ensure that all the exported types use the `export type` notation.

Several weeks ago we enabled the `incremental` [compiler option](https://www.typescriptlang.org/tsconfig#incremental) in the project. This option tells TypeScript to store a cache for the project's tree which ultimately speeds up builds. Before this PR the files were generated in the output folder (`lib`) and then were removed before packaging so that they would not end up in the published tarball. In doing so however we were inadvertently invalidating the cache for subsequent builds.

In this PR we specify a path dedicated to these files and outside of the output folder (`.tsbuildinfo`) so that they can be kept around during and after packaging. The change has been made in the `tsconfig.*.json` file overrides at the package level, since [the paths are relative](https://www.typescriptlang.org/tsconfig#tsBuildInfoFile). This opens the door to cache these files in the CI, which I will look into soon.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1764

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.