### PR TITLE
chore(logger): set default UTC timezone

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -965,8 +965,8 @@ class Logger extends Utility implements LoggerInterface {
       environment,
     } = options;
 
+    // order is important, EnvVarsService() is used by other methods
     this.setEnvVarsService();
-    // order is important, it uses EnvVarsService()
     this.setConsole();
     this.setCustomConfigService(customConfigService);
     this.setInitialLogLevel(logLevel);
@@ -975,7 +975,6 @@ class Logger extends Utility implements LoggerInterface {
     this.setInitialSampleRate(sampleRateValue);
     this.setLogEvent();
     this.setLogIndentation();
-
     this.addPersistentLogAttributes(persistentLogAttributes);
 
     return this;

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -930,7 +930,9 @@ class Logger extends Utility implements LoggerInterface {
    * @returns {void}
    */
   private setLogFormatter(logFormatter?: LogFormatterInterface): void {
-    this.logFormatter = logFormatter ?? new PowertoolsLogFormatter();
+    this.logFormatter =
+      logFormatter ??
+      new PowertoolsLogFormatter({ envVarsService: this.getEnvVarsService() });
   }
 
   /**

--- a/packages/logger/src/config/EnvironmentVariablesService.ts
+++ b/packages/logger/src/config/EnvironmentVariablesService.ts
@@ -29,6 +29,7 @@ class EnvironmentVariablesService
   private logLevelVariable = 'LOG_LEVEL';
   private memoryLimitInMBVariable = 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE';
   private sampleRateValueVariable = 'POWERTOOLS_LOGGER_SAMPLE_RATE';
+  private tzVariable = 'TZ';
 
   /**
    * It returns the value of the AWS_REGION environment variable.
@@ -106,6 +107,17 @@ class EnvironmentVariablesService
     const value = this.get(this.sampleRateValueVariable);
 
     return value && value.length > 0 ? Number(value) : undefined;
+  }
+
+  /**
+   * It returns the value of the `TZ` environment variable or `UTC` if it is not set.
+   *
+   * @returns {string}
+   */
+  public getTimezone(): string {
+    const value = this.get(this.tzVariable);
+
+    return value.length > 0 ? value : 'UTC';
   }
 
   /**

--- a/packages/logger/src/formatter/LogFormatter.ts
+++ b/packages/logger/src/formatter/LogFormatter.ts
@@ -1,4 +1,8 @@
-import type { LogAttributes, LogFormatterInterface } from '../types/Log.js';
+import type {
+  LogAttributes,
+  LogFormatterInterface,
+  LogFormatterOptions,
+} from '../types/Log.js';
 import type { UnformattedAttributes } from '../types/Logger.js';
 import { LogItem } from './LogItem.js';
 
@@ -10,6 +14,16 @@ import { LogItem } from './LogItem.js';
  * @implements {LogFormatterInterface}
  */
 abstract class LogFormatter implements LogFormatterInterface {
+  /**
+   * Timezone used for formatting timestamps.
+   * @default 'UTC'
+   */
+  protected timezone: string;
+
+  public constructor(options?: LogFormatterOptions) {
+    this.timezone = options?.timezone ?? 'UTC';
+  }
+
   /**
    * It formats key-value pairs of log attributes.
    *

--- a/packages/logger/src/formatter/LogFormatter.ts
+++ b/packages/logger/src/formatter/LogFormatter.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentVariablesService } from '../config/EnvironmentVariablesService.js';
 import type {
   LogAttributes,
   LogFormatterInterface,
@@ -15,13 +16,13 @@ import { LogItem } from './LogItem.js';
  */
 abstract class LogFormatter implements LogFormatterInterface {
   /**
-   * Timezone used for formatting timestamps.
-   * @default 'UTC'
+   * EnvironmentVariablesService instance.
+   * If set, it allows to access environment variables.
    */
-  protected timezone: string;
+  protected envVarsService?: EnvironmentVariablesService;
 
   public constructor(options?: LogFormatterOptions) {
-    this.timezone = options?.timezone ?? 'UTC';
+    this.envVarsService = options?.envVarsService;
   }
 
   /**

--- a/packages/logger/src/types/Log.ts
+++ b/packages/logger/src/types/Log.ts
@@ -125,6 +125,13 @@ interface LogItemInterface {
   setAttributes(attributes: LogAttributes): void;
 }
 
+type LogFormatterOptions = {
+  /**
+   * Timezone to use when formatting timestamps.
+   */
+  timezone?: string;
+};
+
 /**
  * @interface
  */
@@ -175,5 +182,6 @@ export type {
   LogLevel,
   PowertoolsLog,
   LogItemInterface,
+  LogFormatterOptions,
   LogFormatterInterface,
 };

--- a/packages/logger/src/types/Log.ts
+++ b/packages/logger/src/types/Log.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentVariablesService } from '../config/EnvironmentVariablesService.js';
 import type { LogItem } from '../formatter/LogItem.js';
 import type { UnformattedAttributes } from './Logger.js';
 
@@ -127,9 +128,10 @@ interface LogItemInterface {
 
 type LogFormatterOptions = {
   /**
-   * Timezone to use when formatting timestamps.
+   * EnvironmentVariablesService instance.
+   * If set, it gives the LogFormatter access to environment variables.
    */
-  timezone?: string;
+  envVarsService?: EnvironmentVariablesService;
 };
 
 /**

--- a/packages/logger/tests/unit/EnvironmentVariablesService.test.ts
+++ b/packages/logger/tests/unit/EnvironmentVariablesService.test.ts
@@ -153,6 +153,31 @@ describe('Class: EnvironmentVariablesService', () => {
     });
   });
 
+  describe('Method: getTimezone', () => {
+    it('returns the value of the TZ environment variable when set', () => {
+      // Prepare
+      process.env.TZ = 'Europe/London';
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getTimezone();
+
+      // Assess
+      expect(value).toEqual('Europe/London');
+    });
+
+    it('returns the default UTC value when no TZ is set', () => {
+      // Prepare
+      const service = new EnvironmentVariablesService();
+
+      // Act
+      const value = service.getTimezone();
+
+      // Assess
+      expect(value).toEqual('UTC');
+    });
+  });
+
   describe('Method: isDevMode', () => {
     test('it returns true if the environment variable POWERTOOLS_DEV is "true"', () => {
       // Prepare

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -222,7 +222,7 @@ describe('Class: Logger', () => {
           envVarsService: expect.any(EnvironmentVariablesService),
           customConfigService: undefined,
           logLevel: 8,
-          logFormatter: {},
+          logFormatter: expect.any(PowertoolsLogFormatter),
         })
       );
     });
@@ -344,7 +344,7 @@ describe('Class: Logger', () => {
           envVarsService: expect.any(EnvironmentVariablesService),
           customConfigService: undefined,
           logLevel: 8,
-          logFormatter: {},
+          logFormatter: expect.any(PowertoolsLogFormatter),
         })
       );
     });
@@ -398,7 +398,7 @@ describe('Class: Logger', () => {
           envVarsService: expect.any(EnvironmentVariablesService),
           customConfigService: configService,
           logLevel: 12,
-          logFormatter: {},
+          logFormatter: expect.any(PowertoolsLogFormatter),
         })
       );
     });
@@ -440,7 +440,7 @@ describe('Class: Logger', () => {
           envVarsService: expect.any(EnvironmentVariablesService),
           customConfigService: undefined,
           logLevel: 8,
-          logFormatter: {},
+          logFormatter: expect.any(PowertoolsLogFormatter),
         })
       );
     });
@@ -468,7 +468,7 @@ describe('Class: Logger', () => {
           envVarsService: expect.any(EnvironmentVariablesService),
           customConfigService: undefined,
           logLevel: 8,
-          logFormatter: {},
+          logFormatter: expect.any(PowertoolsLogFormatter),
         })
       );
     });

--- a/packages/tracer/tests/helpers/tracesUtils.ts
+++ b/packages/tracer/tests/helpers/tracesUtils.ts
@@ -314,8 +314,8 @@ export {
   getInvocationSubsegment,
   splitSegmentsByName,
   invokeAllTestCases,
-  ParsedDocument,
-  ParsedSegment,
-  ParsedTrace,
-  AssertAnnotationParams,
+  type ParsedDocument,
+  type ParsedSegment,
+  type ParsedTrace,
+  type AssertAnnotationParams,
 };


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

By default the AWS Lambda execution environment has the `TZ` variable set to `UTC` ([source](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)). Likewise, the Logger utility emits logs with timestamps formatted as UTC.

**This PR does not change the behavior of the Logger utility** but only:
- Adds a method to the `EnvironmentVariablesService` so that the `TZ` value can be fetched, with fallback on the `UTC` value
- Adds an `envVarsService` property and constructor option to the `LogFormatter` class so that I can accept a reference to an instance of `EnvironmentVariablesService` when instantiated. This property is optional.

At the moment the none of the additions is used by the Logger directly as the default behaviors in both Lambda and the Logger are aligned, however this small change will allow us to add the ability to format time zone-aware timestamps in the future without making a breaking change (see linked issue).

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1774

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.