### PR TITLE
docs(logger): remove logEvent from required settings

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -173,7 +173,7 @@ When debugging in non-production environments, you can instruct Logger to log th
     1. Binding your handler method allows your handler to access `this` within the class methods.
 
 Logging incoming events only works with middy or decorator by using `injectLambdaContext`.  
-Only setting `POWEETOOLS_LOGGER_LOG_EVENT` to `true` will not log the incoming event.
+Only setting `POWERTOOLS_LOGGER_LOG_EVENT` to `true` will not log the incoming event.
 
 ### Appending persistent additional log keys and values
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -50,8 +50,6 @@ These settings will be used across all logs emitted:
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------- | ------------------------------------------------------ | ------------------- | --------------------- |
 | **Service name**       | Sets the name of service of which the Lambda function is part of, that will be present across all log statements | `POWERTOOLS_SERVICE_NAME`       | `service_undefined` | Any string                                             | `serverlessAirline` | `serviceName`         |
 | **Logging level**      | Sets how verbose Logger should be, from the most verbose to the least verbose (no logs)                          | `POWERTOOLS_LOG_LEVEL`          | `INFO`              | `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `SILENT` | `ERROR`             | `logLevel`            |
-| **Log incoming event** | Whether to log or not the incoming event when using the decorator or middleware                                  | `POWERTOOLS_LOGGER_LOG_EVENT`   | `false`             | `true`, `false`                                        | `false`             | `logEvent`            |
-| **Debug log sampling** | Probability that a Lambda invocation will print all the log items regardless of the log level setting            | `POWERTOOLS_LOGGER_SAMPLE_RATE` | `0`                 | `0.0` to `1`                                           | `0.5`               | `sampleRateValue`     |
 
 #### Example using AWS Serverless Application Model (SAM)
 
@@ -153,7 +151,7 @@ In each case, the printed log will look like this:
     }
     ```
 
-#### Log incoming event
+### Log incoming event
 
 When debugging in non-production environments, you can instruct Logger to log the incoming event with the middleware/decorator parameter `logEvent` or via `POWERTOOLS_LOGGER_LOG_EVENT` env var set to `true`.
 
@@ -173,6 +171,9 @@ When debugging in non-production environments, you can instruct Logger to log th
     ```
 
     1. Binding your handler method allows your handler to access `this` within the class methods.
+
+Logging incoming events only works with middy or decorator by using `injectLambdaContext`.  
+Only setting `POWEETOOLS_LOGGER_LOG_EVENT` to `true` will not log the incoming event.
 
 ### Appending persistent additional log keys and values
 
@@ -388,6 +389,18 @@ The error will be logged with default key name `error`, but you can also pass yo
 
 !!! tip "Logging errors and log level"
     You can also log errors using the `warn`, `info`, and `debug` methods. Be aware of the log level though, you might miss those  errors when analyzing the log later depending on the log level configuration.
+
+### Environment variables
+
+The following environment variables are available to configure Logger at a global scope:
+
+
+| Setting                | Description                                                                                                     | Environment variable            | Default Value       | Allowed Values                                         | Example Value       | Constructor parameter |
+| ---------------------- |-----------------------------------------------------------------------------------------------------------------| ------------------------------- | ------------------- | ------------------------------------------------------ | ------------------- | --------------------- |
+| **Service name**       | Sets the name of service of which the Lambda function is part of, that will be present across all log statements | `POWERTOOLS_SERVICE_NAME`       | `service_undefined` | Any string                                             | `serverlessAirline` | `serviceName`         |
+| **Logging level**      | Sets how verbose Logger should be, from the most verbose to the least verbose (no logs)                         | `POWERTOOLS_LOG_LEVEL`          | `INFO`              | `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `SILENT` | `ERROR`             | `logLevel`            |
+| **Log event**          | Whether to log or not the incoming event when using the decorator or middleware                                 | `POWERTOOLS_LOGGER_LOG_EVENT`   | `false`             | `true`, `false`                                        | `true`              | `logEvent`            |
+| **Sample rate**        | Probability that a Lambda invocation will print all the log items regardless of the log level setting           | `POWERTOOLS_LOGGER_SAMPLE_RATE` | `0`                 | `0.0` to `1.0`                                         | `0.1`               | `sampleRateValue`     |
 
 
 ## Advanced

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -41,8 +41,7 @@ The `Logger` utility must always be instantiated outside the Lambda handler. By 
     ```
 
 ### Utility settings
-
-The library requires two settings. You can set them as environment variables, or pass them in the constructor.
+The library has three optional settings, which can be set via environment variables or passed in the constructor.
 
 These settings will be used across all logs emitted:
 
@@ -50,6 +49,10 @@ These settings will be used across all logs emitted:
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------- | ------------------- | ------------------------------------------------------ | ------------------- | --------------------- |
 | **Service name**       | Sets the name of service of which the Lambda function is part of, that will be present across all log statements | `POWERTOOLS_SERVICE_NAME`       | `service_undefined` | Any string                                             | `serverlessAirline` | `serviceName`         |
 | **Logging level**      | Sets how verbose Logger should be, from the most verbose to the least verbose (no logs)                          | `POWERTOOLS_LOG_LEVEL`          | `INFO`              | `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `SILENT` | `ERROR`             | `logLevel`            |
+| **Sample rate**        | Probability that a Lambda invocation will print all the log items regardless of the log level setting           | `POWERTOOLS_LOGGER_SAMPLE_RATE` | `0`                 | `0.0` to `1.0`                                         | `0.1`               | `sampleRateValue`     |
+
+See all enivronment variables in the [Environment variables](../index.md/#environment-variables) section.
+Check API docs to learn more about [Logger constructor options](https://docs.powertools.aws.dev/lambda/typescript/latest/api/types/_aws_lambda_powertools_logger.types.ConstructorOptions.html){target="_blank"}.
 
 #### Example using AWS Serverless Application Model (SAM)
 
@@ -389,19 +392,6 @@ The error will be logged with default key name `error`, but you can also pass yo
 
 !!! tip "Logging errors and log level"
     You can also log errors using the `warn`, `info`, and `debug` methods. Be aware of the log level though, you might miss those  errors when analyzing the log later depending on the log level configuration.
-
-### Environment variables
-
-The following environment variables are available to configure Logger at a global scope:
-
-
-| Setting                | Description                                                                                                     | Environment variable            | Default Value       | Allowed Values                                         | Example Value       | Constructor parameter |
-| ---------------------- |-----------------------------------------------------------------------------------------------------------------| ------------------------------- | ------------------- | ------------------------------------------------------ | ------------------- | --------------------- |
-| **Service name**       | Sets the name of service of which the Lambda function is part of, that will be present across all log statements | `POWERTOOLS_SERVICE_NAME`       | `service_undefined` | Any string                                             | `serverlessAirline` | `serviceName`         |
-| **Logging level**      | Sets how verbose Logger should be, from the most verbose to the least verbose (no logs)                         | `POWERTOOLS_LOG_LEVEL`          | `INFO`              | `DEBUG`, `INFO`, `WARN`, `ERROR`, `CRITICAL`, `SILENT` | `ERROR`             | `logLevel`            |
-| **Log event**          | Whether to log or not the incoming event when using the decorator or middleware                                 | `POWERTOOLS_LOGGER_LOG_EVENT`   | `false`             | `true`, `false`                                        | `true`              | `logEvent`            |
-| **Sample rate**        | Probability that a Lambda invocation will print all the log items regardless of the log level setting           | `POWERTOOLS_LOGGER_SAMPLE_RATE` | `0`                 | `0.0` to `1.0`                                         | `0.1`               | `sampleRateValue`     |
-
 
 ## Advanced
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -156,7 +156,7 @@ In each case, the printed log will look like this:
 
 ### Log incoming event
 
-When debugging in non-production environments, you can instruct Logger to log the incoming event with the middleware/decorator parameter `logEvent` or via `POWERTOOLS_LOGGER_LOG_EVENT` env var set to `true`.
+When debugging in non-production environments, you can instruct Logger to log the incoming event with the middleware/decorator parameter `logEvent`.
 
 ???+ warning
 	This is disabled by default to prevent sensitive info being logged
@@ -175,8 +175,7 @@ When debugging in non-production environments, you can instruct Logger to log th
 
     1. Binding your handler method allows your handler to access `this` within the class methods.
 
-Logging incoming events only works with middy or decorator by using `injectLambdaContext`.  
-Only setting `POWERTOOLS_LOGGER_LOG_EVENT` to `true` will not log the incoming event.
+Use `POWERTOOLS_LOGGER_LOG_EVENT` environment variable to enable or disable (`true`/`false`) this feature.
 
 ### Appending persistent additional log keys and values
 


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

This PR removes the `logEvent` and `sampleRateValue` values from the sections of required parameters. I have introduced a new section **Environment variables** to collect all the option in one place. In addition, I added a small clarification that `POWERTOOLS_LOGGER_LOG_EVENT` only works with `injectLambdaContext` to avoid misunderstanding. 

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:**  closes #1814

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [ ] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.