### PR TITLE
chore(ci): allow dependabot PRs

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -30,6 +30,7 @@ scopes:
   - tests
   - internal
   - maintenance
+  - deps
 
 # Always validate the PR title
 # and ignore the commits to lower the entry bar for contribution


### PR DESCRIPTION
## Description of your changes

Updates Semantic PR config to allow dependabot PRs with `deps` scope.

### Related issues, RFCs

**Issue number:** #1859

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [x] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.