### PR TITLE
fix(parameters): refresh AppConfig session token after 24 hrs

### DIFF
--- a/packages/parameters/src/appconfig/AppConfigProvider.ts
+++ b/packages/parameters/src/appconfig/AppConfigProvider.ts
@@ -10,6 +10,7 @@ import type {
   AppConfigGetOptions,
   AppConfigGetOutput,
 } from '../types/AppConfigProvider';
+import { APPCONFIG_TOKEN_EXPIRATION } from '../constants';
 
 /**
  * ## Intro
@@ -182,7 +183,10 @@ import type {
  */
 class AppConfigProvider extends BaseProvider {
   public client!: AppConfigDataClient;
-  protected configurationTokenStore = new Map<string, string>();
+  protected configurationTokenStore = new Map<
+    string,
+    { value: string; expiration: number }
+  >();
   protected valueStore = new Map<string, Uint8Array>();
   private application?: string;
   private environment: string;
@@ -270,6 +274,15 @@ class AppConfigProvider extends BaseProvider {
   /**
    * Retrieve a configuration from AWS AppConfig.
    *
+   * First we start the session and after that we retrieve the configuration from AppSync.
+   * When starting a session, the service returns a token that can be used to poll for changes
+   * for up to 24hrs, so we cache it for later use together with the expiration date.
+   *
+   * The value of the configuration is also cached internally because AppConfig returns an empty
+   * value if the configuration has not changed since the last poll. This way even if your code
+   * polls the configuration multiple times, we return the most recent value by returning the cached
+   * one if an empty response is returned by AppConfig.
+   *
    * @param {string} name - Name of the configuration or its ID
    * @param {AppConfigGetOptions} options - SDK options to propagate to `StartConfigurationSession` API call
    */
@@ -277,16 +290,10 @@ class AppConfigProvider extends BaseProvider {
     name: string,
     options?: AppConfigGetOptions
   ): Promise<Uint8Array | undefined> {
-    /**
-     * The new AppConfig APIs require two API calls to return the configuration
-     * First we start the session and after that we retrieve the configuration
-     * We need to store { name: token } pairs to use in the next execution
-     * We also need to store { name : value } pairs because AppConfig returns
-     * an empty value if the session already has the latest configuration
-     * but, we don't want to return an empty value to our callers.
-     * {@link https://docs.aws.amazon.com/appconfig/latest/userguide/appconfig-retrieving-the-configuration.html}
-     **/
-    if (!this.configurationTokenStore.has(name)) {
+    if (
+      !this.configurationTokenStore.has(name) ||
+      this.configurationTokenStore.get(name)!.expiration <= Date.now()
+    ) {
       const sessionOptions: StartConfigurationSessionCommandInput = {
         ...(options?.sdkOptions || {}),
         ApplicationIdentifier: this.application,
@@ -303,20 +310,23 @@ class AppConfigProvider extends BaseProvider {
       if (!session.InitialConfigurationToken)
         throw new Error('Unable to retrieve the configuration token');
 
-      this.configurationTokenStore.set(name, session.InitialConfigurationToken);
+      this.configurationTokenStore.set(name, {
+        value: session.InitialConfigurationToken,
+        expiration: Date.now() + APPCONFIG_TOKEN_EXPIRATION,
+      });
     }
 
     const getConfigurationCommand = new GetLatestConfigurationCommand({
-      ConfigurationToken: this.configurationTokenStore.get(name),
+      ConfigurationToken: this.configurationTokenStore.get(name)?.value,
     });
 
     const response = await this.client.send(getConfigurationCommand);
 
     if (response.NextPollConfigurationToken) {
-      this.configurationTokenStore.set(
-        name,
-        response.NextPollConfigurationToken
-      );
+      this.configurationTokenStore.set(name, {
+        value: response.NextPollConfigurationToken,
+        expiration: Date.now() + APPCONFIG_TOKEN_EXPIRATION,
+      });
     } else {
       this.configurationTokenStore.delete(name);
     }

--- a/packages/parameters/src/constants.ts
+++ b/packages/parameters/src/constants.ts
@@ -2,6 +2,7 @@ const DEFAULT_MAX_AGE_SECS = 5;
 const TRANSFORM_METHOD_JSON = 'json';
 const TRANSFORM_METHOD_BINARY = 'binary';
 const TRANSFORM_METHOD_AUTO = 'auto';
+const APPCONFIG_TOKEN_EXPIRATION = 23 * 60 * 60 * 1000 + 45 * 60 * 1000; // 23 hrs 45 min
 
 /**
  * Transform methods for values retrieved by parameter providers.
@@ -22,6 +23,7 @@ const Transform = {
 } as const;
 
 export {
+  APPCONFIG_TOKEN_EXPIRATION,
   DEFAULT_MAX_AGE_SECS,
   TRANSFORM_METHOD_JSON,
   TRANSFORM_METHOD_BINARY,

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -26,9 +26,12 @@ jest.useFakeTimers();
 describe('Class: AppConfigProvider', () => {
   const client = mockClient(AppConfigDataClient);
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   afterEach(() => {
     client.reset();
-    jest.clearAllMocks();
   });
 
   describe('Method: constructor', () => {

--- a/packages/parameters/tests/unit/AppConfigProvider.test.ts
+++ b/packages/parameters/tests/unit/AppConfigProvider.test.ts
@@ -15,21 +15,20 @@ import { Uint8ArrayBlobAdapter } from '@smithy/util-stream';
 import { mockClient } from 'aws-sdk-client-mock';
 import { addUserAgentMiddleware } from '@aws-lambda-powertools/commons';
 import 'aws-sdk-client-mock-jest';
+import { APPCONFIG_TOKEN_EXPIRATION } from '../../src/constants';
 
 jest.mock('@aws-lambda-powertools/commons', () => ({
   ...jest.requireActual('@aws-lambda-powertools/commons'),
   addUserAgentMiddleware: jest.fn(),
 }));
+jest.useFakeTimers();
 
 describe('Class: AppConfigProvider', () => {
   const client = mockClient(AppConfigDataClient);
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   afterEach(() => {
     client.reset();
+    jest.clearAllMocks();
   });
 
   describe('Method: constructor', () => {
@@ -201,7 +200,10 @@ describe('Class: AppConfigProvider', () => {
       // Prepare
       class AppConfigProviderMock extends AppConfigProvider {
         public _addToStore(key: string, value: string): void {
-          this.configurationTokenStore.set(key, value);
+          this.configurationTokenStore.set(key, {
+            value,
+            expiration: Date.now() + APPCONFIG_TOKEN_EXPIRATION,
+          });
         }
 
         public _storeHas(key: string): boolean {
@@ -288,6 +290,56 @@ describe('Class: AppConfigProvider', () => {
       // Assess
       expect(result1).toBe(mockData);
       expect(result2).toBe(mockData);
+    });
+
+    test('when the session token has expired, it starts a new session and retrieves the token', async () => {
+      // Prepare
+      const options: AppConfigProviderOptions = {
+        application: 'MyApp',
+        environment: 'MyAppProdEnv',
+      };
+      const provider = new AppConfigProvider(options);
+      const name = 'MyAppFeatureFlag';
+
+      const fakeInitialToken = 'aW5pdGlhbFRva2Vu';
+      const fakeSecondToken = 'bZ6pdGlhbFRva3Wk';
+      const fakeNextToken1 = 'bmV4dFRva2Vu';
+      const mockData = Uint8ArrayBlobAdapter.fromString('foo');
+      const mockData2 = Uint8ArrayBlobAdapter.fromString('bar');
+
+      client
+        .on(StartConfigurationSessionCommand)
+        .resolvesOnce({
+          InitialConfigurationToken: fakeInitialToken,
+        })
+        .resolvesOnce({
+          InitialConfigurationToken: fakeSecondToken,
+        })
+        .on(GetLatestConfigurationCommand, {
+          ConfigurationToken: fakeInitialToken,
+        })
+        .resolves({
+          Configuration: mockData,
+          NextPollConfigurationToken: fakeNextToken1,
+        })
+        .on(GetLatestConfigurationCommand, {
+          ConfigurationToken: fakeSecondToken,
+        })
+        .resolves({
+          Configuration: mockData2,
+          NextPollConfigurationToken: fakeNextToken1,
+        });
+      jest.setSystemTime(new Date('2022-03-10'));
+
+      // Act
+      const result1 = await provider.get(name, { forceFetch: true });
+      // Mock time skip of 24hrs
+      jest.setSystemTime(new Date('2022-03-11'));
+      const result2 = await provider.get(name, { forceFetch: true });
+
+      // Assess
+      expect(result1).toBe(mockData);
+      expect(result2).toBe(mockData2);
     });
   });
 


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

As discussed in the linked issue, the AppConfig provider in the Parameters utility stores a session token returned by the service that should be used for the subsequent call. By default the token has a [duration of up to 24hrs](https://docs.aws.amazon.com/appconfig/2019-10-09/APIReference/API_appconfigdata_StartConfigurationSession.html#API_appconfigdata_StartConfigurationSession_ResponseElements) and if the provider attempts to retrieve a configuration using an expired token it'll result in a bad request exception.

For most Lambda-based workloads this is not an issue since the execution environment is likely to have been recycled before the token has the chance to expire. For those customers who use provisioned concurrency or who decide to use the Parameters utility outside of Lambda (i.e. containers or others) this is an issue.

This PR improves the session token handling by storing the expiration timestamp together with the token. The timestamp is then checked by the `AppConfigProvider` before making a call to the service, and if expired a new session token is requested.

With this change customers using the Parameters utility in long lived execution environments should see decreased bad requests exception.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1798

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.