### PR TITLE
chore(ci): fix docs workflow permissions

### DIFF
--- a/.github/workflows/on_doc_merge.yml
+++ b/.github/workflows/on_doc_merge.yml
@@ -15,6 +15,7 @@ jobs:
   release-docs:
     permissions:
       id-token: write  # trade JWT token for AWS credentials in AWS Docs account
+      contents: read
     secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:

--- a/.github/workflows/on_doc_merge.yml
+++ b/.github/workflows/on_doc_merge.yml
@@ -15,7 +15,7 @@ jobs:
   release-docs:
     permissions:
       id-token: write  # trade JWT token for AWS credentials in AWS Docs account
-      contents: read
+      contents: read  # read from this repo to publish docs
     secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -29,6 +29,7 @@ jobs:
   release-docs:
     permissions:
       id-token: write  # trade JWT token for AWS credentials in AWS Docs account
+      contents: read
     secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:

--- a/.github/workflows/rebuild_latest_docs.yml
+++ b/.github/workflows/rebuild_latest_docs.yml
@@ -29,7 +29,7 @@ jobs:
   release-docs:
     permissions:
       id-token: write  # trade JWT token for AWS credentials in AWS Docs account
-      contents: read
+      contents: read  # read from this repo to publish docs
     secrets: inherit
     uses: ./.github/workflows/reusable_publish_docs.yml
     with:


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR adds new permissions to the `rebuild_latest_docs.yml` and `on_doc_merge.yml` to match the permissions requested by the reusable workflow called by both (`reusable_publish_docs.yml`).

The reusable workflow requires `contents: read` to be able to read the repository contents, however the two caller workflows were not specifying any `content` related permission at the job level, implicitly setting it to `none` and thus causing the workflow runs to fail ([example](https://github.com/aws-powertools/powertools-lambda-typescript/actions/runs/7724705134)).

With this change the workflows should be able to publish docs again.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #1799

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.