### PR TITLE
chore(tests): revert change timeout reporting in idempotency e2e tests

### DIFF
--- a/packages/idempotency/tests/e2e/idempotentDecorator.test.FunctionCode.ts
+++ b/packages/idempotency/tests/e2e/idempotentDecorator.test.FunctionCode.ts
@@ -80,9 +80,7 @@ class DefaultLambda implements LambdaInterface {
   ): Promise<string> {
     logger.addContext(context);
 
-    await new Promise((resolve) =>
-      setTimeout(resolve, context.getRemainingTimeInMillis())
-    );
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
     logger.info('Processed event', { details: event.foo });
 

--- a/packages/idempotency/tests/e2e/idempotentDecorator.test.ts
+++ b/packages/idempotency/tests/e2e/idempotentDecorator.test.ts
@@ -74,8 +74,7 @@ describe('Idempotency e2e test decorator, default settings', () => {
       function: {
         entry: lambdaFunctionCodeFilePath,
         handler: 'handlerTimeout',
-        timeout: Duration.seconds(3),
-        memorySize: 512,
+        timeout: Duration.seconds(2),
       },
     },
     {
@@ -285,11 +284,10 @@ describe('Idempotency e2e test decorator, default settings', () => {
       });
       expect(idempotencyRecord.Items?.[0].status).toEqual('COMPLETED');
 
-      // During the first invocation the function should timeout so the logs should not contain any log and the report log should contain a timeout message
-      expect(functionLogs[0]).toHaveLength(0);
-      expect(logs[0].getReportLog()).toMatch(/Status: timeout$/);
+      // During the first invocation the handler should be called, so the logs should contain 1 log
+      expect(functionLogs[0]).toHaveLength(2);
+      expect(functionLogs[0][0]).toContain('Task timed out after');
 
-      // During the second invocation the handler should be called and complete, so the logs should contain 1 log
       expect(functionLogs[1]).toHaveLength(1);
       expect(TestInvocationLogs.parseFunctionLog(functionLogs[1][0])).toEqual(
         expect.objectContaining({

--- a/packages/idempotency/tests/e2e/makeHandlerIdempotent.test.FunctionCode.ts
+++ b/packages/idempotency/tests/e2e/makeHandlerIdempotent.test.FunctionCode.ts
@@ -65,11 +65,12 @@ export const handlerTimeout = middy(
     logger.addContext(context);
 
     if (event.invocation === 0) {
-      await new Promise((resolve) => {
-        setTimeout(resolve, context.getRemainingTimeInMillis());
-      });
+      await new Promise((resolve) => setTimeout(resolve, 4000));
     }
-    logger.info('Processed event', { details: event.foo });
+
+    logger.info('Processed event', {
+      details: event.foo,
+    });
 
     return {
       foo: event.foo,

--- a/packages/idempotency/tests/e2e/makeHandlerIdempotent.test.ts
+++ b/packages/idempotency/tests/e2e/makeHandlerIdempotent.test.ts
@@ -74,8 +74,7 @@ describe(`Idempotency E2E tests, middy middleware usage`, () => {
       function: {
         entry: lambdaFunctionCodeFilePath,
         handler: 'handlerTimeout',
-        timeout: Duration.seconds(3),
-        memorySize: 512,
+        timeout: Duration.seconds(2),
       },
     },
     {
@@ -264,9 +263,9 @@ describe(`Idempotency E2E tests, middy middleware usage`, () => {
       });
       expect(idempotencyRecords.Items?.[0].status).toEqual('COMPLETED');
 
-      // During the first invocation the function should timeout so the logs should not contain any log and the report log should contain a timeout message
-      expect(functionLogs[0]).toHaveLength(0);
-      expect(logs[0].getReportLog()).toMatch(/Status: timeout$/);
+      // During the first invocation the function should timeout so the logs should contain 2 logs
+      expect(functionLogs[0]).toHaveLength(2);
+      expect(functionLogs[0][0]).toContain('Task timed out after');
       // During the second invocation the handler should be called and complete, so the logs should
       // contain 1 log
       expect(functionLogs[1]).toHaveLength(1);

--- a/packages/testing/src/TestInvocationLogs.ts
+++ b/packages/testing/src/TestInvocationLogs.ts
@@ -105,22 +105,6 @@ class TestInvocationLogs {
     return filteredLogs;
   }
 
-  /**
-   * Return the log that contains the report of the function `REPORT RequestId`
-   */
-  public getReportLog(): string {
-    const endLogIndex = TestInvocationLogs.getReportLogIndex(this.logs);
-
-    return this.logs[endLogIndex];
-  }
-
-  /**
-   * The index of the log that contains the report of the function `REPORT RequestId`
-   */
-  public static getReportLogIndex(logs: string[]): number {
-    return logs.findIndex((log) => log.startsWith('REPORT RequestId'));
-  }
-
   public static getStartLogIndex(logs: string[]): number {
     return logs.findIndex((log) => log.startsWith('START RequestId'));
   }


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

> [!IMPORTANT]
> This PR reverts #2074

After running more tests it appears that the changes introduced in #2074 were not necessary, so we I am reverting them.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #2076

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

