### PR TITLE
fix(idempotency): validate idempotency record returned in conditional write

### DIFF
--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -313,11 +313,17 @@ export class IdempotencyHandler<Func extends AnyFunction> {
         );
       } catch (e) {
         if (e instanceof IdempotencyItemAlreadyExistsError) {
-          const idempotencyRecord: IdempotencyRecord =
-            e.existingRecord ||
-            (await this.#persistenceStore.getRecord(
+          let idempotencyRecord = e.existingRecord;
+          if (idempotencyRecord !== undefined) {
+            this.#persistenceStore.validatePayload(
+              this.#functionPayloadToBeHashed,
+              idempotencyRecord
+            );
+          } else {
+            idempotencyRecord = await this.#persistenceStore.getRecord(
               this.#functionPayloadToBeHashed
-            ));
+            );
+          }
 
           return IdempotencyHandler.determineResultFromIdempotencyRecord(
             idempotencyRecord

--- a/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
+++ b/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
@@ -3,6 +3,7 @@
  *
  * @group unit/idempotency/persistence/base
  */
+import { createHash } from 'node:crypto';
 import { ContextExamples as dummyContext } from '@aws-lambda-powertools/commons';
 import { IdempotencyConfig, IdempotencyRecordStatus } from '../../../src';
 import {
@@ -461,6 +462,92 @@ describe('Class: BasePersistenceLayer', () => {
           responseData: result,
         })
       );
+    });
+  });
+
+  describe('Method: validatePayload', () => {
+    it('throws an error if the payload does not match the stored record', () => {
+      // Prepare
+      const persistenceLayer = new PersistenceLayerTestClass();
+      persistenceLayer.configure({
+        config: new IdempotencyConfig({
+          payloadValidationJmesPath: 'foo',
+        }),
+      });
+      const existingRecord = new IdempotencyRecord({
+        idempotencyKey: 'my-lambda-function#mocked-hash',
+        status: IdempotencyRecordStatus.INPROGRESS,
+        payloadHash: 'different-hash',
+      });
+
+      // Act & Assess
+      expect(() =>
+        persistenceLayer.validatePayload({ foo: 'bar' }, existingRecord)
+      ).toThrow(
+        new IdempotencyValidationError(
+          'Payload does not match stored record for this event key',
+          existingRecord
+        )
+      );
+    });
+
+    it('returns if the payload matches the stored record', () => {
+      // Prepare
+      const persistenceLayer = new PersistenceLayerTestClass();
+      persistenceLayer.configure({
+        config: new IdempotencyConfig({
+          payloadValidationJmesPath: 'foo',
+        }),
+      });
+      const existingRecord = new IdempotencyRecord({
+        idempotencyKey: 'my-lambda-function#mocked-hash',
+        status: IdempotencyRecordStatus.INPROGRESS,
+        payloadHash: 'mocked-hash',
+      });
+
+      // Act & Assess
+      expect(() =>
+        persistenceLayer.validatePayload({ foo: 'bar' }, existingRecord)
+      ).not.toThrow();
+    });
+
+    it('skips validation if payload validation is not enabled', () => {
+      // Prepare
+      const persistenceLayer = new PersistenceLayerTestClass();
+      const existingRecord = new IdempotencyRecord({
+        idempotencyKey: 'my-lambda-function#mocked-hash',
+        status: IdempotencyRecordStatus.INPROGRESS,
+        payloadHash: 'different-hash',
+      });
+
+      // Act & Assess
+      expect(() =>
+        persistenceLayer.validatePayload({ foo: 'bar' }, existingRecord)
+      ).not.toThrow();
+    });
+
+    it('skips hashing if the payload is already an IdempotencyRecord', () => {
+      // Prepare
+      const persistenceLayer = new PersistenceLayerTestClass();
+      persistenceLayer.configure({
+        config: new IdempotencyConfig({
+          payloadValidationJmesPath: 'foo',
+        }),
+      });
+      const existingRecord = new IdempotencyRecord({
+        idempotencyKey: 'my-lambda-function#mocked-hash',
+        status: IdempotencyRecordStatus.INPROGRESS,
+        payloadHash: 'mocked-hash',
+      });
+      const payload = new IdempotencyRecord({
+        idempotencyKey: 'my-lambda-function#mocked-hash',
+        status: IdempotencyRecordStatus.INPROGRESS,
+        payloadHash: 'mocked-hash',
+      });
+
+      // Act
+      persistenceLayer.validatePayload(payload, existingRecord);
+      expect(createHash).toHaveBeenCalledTimes(0);
     });
   });
 


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR fixes a bug that was introduced in the last release and that caused the Idempotency utility to skip the validation of a payload on subsequent requests.

In order to leverage the new capability of `ConditionalCheckFailedException` to return the item that made the conditional check to fail, we had to implement a logic that sort of looks like this:

```mermaid
flowchart LR
    A[saveRecord] -->|ConditionalWrite| B{is new SDK}
    B -->|Yes| C[throw IdempotencyItemAlreadyExistsError with IdempotencyRecord]
    B -->|No| D[throw IdempotencyItemAlreadyExistsError  only]
```

The pseudo-`saveRecord` from the chart above is called by the `IdempotencyHandler`, which handled it this way:

```mermaid
flowchart LR
    A[catch IdempotencyItemAlreadyExistsError] --> B{does it have IdempotencyRecord?}
    B -->|Yes| C[use it as is]
    C --> H[carry on]
    B -->|No| E[read record from DDB]
    E --> F[validate current request vs stored record]
    F --> G{do they match}
    G -->|Yes| H
    G -->|No| I[throw IdempotencyValidationError]
```

As you can see from the flow above, in one of the paths the payload was never validated.

This PR changes the access property of the `validatePayload` method from `private` to `public` so that it's exposed on the persistence layer and can be called directly by the `IdempotencyHandler`. 

The flow now looks like this:

```mermaid
flowchart LR
    A[catch IdempotencyItemAlreadyExistsError] --> B{does it have IdempotencyRecord?}
    B -->|Yes| C[validate payload]
    C --> G
    B -->|No| E[read record from DDB]
    E --> F[validate current request vs stored record]
    F --> G{do they match}
    G -->|Yes| H[carry on]
    G -->|No| I[throw IdempotencyValidationError]
```

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #2058

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.