### PR TITLE
feat(jmespath): add lexer component

### DIFF
--- a/packages/jmespath/src/Lexer.ts
+++ b/packages/jmespath/src/Lexer.ts
@@ -1,0 +1,304 @@
+import {
+  SIMPLE_TOKENS,
+  START_IDENTIFIER,
+  VALID_IDENTIFIER,
+  VALID_NUMBER,
+  WHITESPACE,
+} from './constants.js';
+import { EmptyExpressionError, LexerError } from './errors.js';
+import type { Token } from './types.js';
+
+/**
+ * A lexer for JMESPath expressions.
+ *
+ * This lexer tokenizes a JMESPath expression into a sequence of tokens.
+ */
+class Lexer {
+  #position!: number;
+  #expression!: string;
+  #chars!: string[];
+  #current!: string;
+  #length!: number;
+
+  /**
+   * Tokenize a JMESPath expression.
+   *
+   * This method is a generator that yields tokens for the given expression.
+   *
+   * @param expression The JMESPath expression to tokenize.
+   */
+  public *tokenize(expression: string): Generator<Token> {
+    this.#initializeForExpression(expression);
+    while (this.#current !== '' && this.#current !== undefined) {
+      if (SIMPLE_TOKENS.has(this.#current)) {
+        yield {
+          // We know that SIMPLE_TOKENS has this.#current as a key because
+          // we checked for that above.
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          type: SIMPLE_TOKENS.get(this.#current)!,
+          value: this.#current,
+          start: this.#position,
+          end: this.#position + 1,
+        };
+
+        this.#next();
+      } else if (START_IDENTIFIER.has(this.#current)) {
+        const start = this.#position;
+        let buff = this.#current;
+        while (VALID_IDENTIFIER.has(this.#next())) {
+          buff += this.#current;
+        }
+        yield {
+          type: 'unquoted_identifier',
+          value: buff,
+          start,
+          end: start + buff.length,
+        };
+      } else if (WHITESPACE.has(this.#current)) {
+        this.#next();
+      } else if (this.#current === '[') {
+        const start = this.#position;
+        const nextChar = this.#next();
+        if (nextChar == ']') {
+          this.#next();
+          yield { type: 'flatten', value: '[]', start: start, end: start + 2 };
+        } else if (nextChar == '?') {
+          this.#next();
+          yield { type: 'filter', value: '[?', start: start, end: start + 2 };
+        } else {
+          yield { type: 'lbracket', value: '[', start: start, end: start + 1 };
+        }
+      } else if (this.#current === `'`) {
+        yield this.#consumeRawStringLiteral();
+      } else if (this.#current === '|') {
+        yield this.#matchOrElse('|', 'or', 'pipe');
+      } else if (this.#current === '&') {
+        yield this.#matchOrElse('&', 'and', 'expref');
+      } else if (this.#current === '`') {
+        yield this.#consumeLiteral();
+      } else if (VALID_NUMBER.has(this.#current)) {
+        const start = this.#position;
+        const buff = this.#consumeNumber();
+        yield {
+          type: 'number',
+          value: parseInt(buff),
+          start: start,
+          end: start + buff.length,
+        };
+      } else if (this.#current === '-') {
+        // Negative number.
+        const start = this.#position;
+        const buff = this.#consumeNumber();
+        if (buff.length > 1) {
+          yield {
+            type: 'number',
+            value: parseInt(buff),
+            start: start,
+            end: start + buff.length,
+          };
+        } else {
+          // If the negative sign is not followed by a number, it is an error.
+          throw new LexerError(start, 'Unknown token after "-"');
+        }
+      } else if (this.#current === '"') {
+        yield this.#consumeQuotedIdentifier();
+      } else if (this.#current === '<') {
+        yield this.#matchOrElse('=', 'lte', 'lt');
+      } else if (this.#current === '>') {
+        yield this.#matchOrElse('=', 'gte', 'gt');
+      } else if (this.#current === '!') {
+        yield this.#matchOrElse('=', 'ne', 'not');
+      } else if (this.#current === '=') {
+        if (this.#next() === '=') {
+          yield {
+            type: 'eq',
+            value: '==',
+            start: this.#position - 1,
+            end: this.#position,
+          };
+          this.#next();
+        } else {
+          throw new LexerError(this.#position - 1, '=');
+        }
+      } else {
+        throw new LexerError(this.#position, this.#current);
+      }
+    }
+    yield { type: 'eof', value: '', start: this.#length, end: this.#length };
+  }
+
+  /**
+   * Consume a raw string that is a number.
+   *
+   * It takes the current position and advances
+   * the lexer until it finds a character that
+   * is not a number.
+   */
+  #consumeNumber(): string {
+    let buff = this.#current;
+    while (VALID_NUMBER.has(this.#next())) {
+      buff += this.#current;
+    }
+
+    return buff;
+  }
+
+  /**
+   * Initializes the lexer for the given expression.
+   *
+   * We use a separate method for this instead of the constructor
+   * because we want to be able to reuse the same lexer instance
+   * and also because we want to be able to expose a public API
+   * for tokenizing expressions like `new Lexer().tokenize(expression)`.
+   *
+   * @param expression The JMESPath expression to tokenize.
+   */
+  #initializeForExpression(expression: string): void {
+    if (typeof expression !== 'string') {
+      throw new EmptyExpressionError();
+    }
+
+    this.#position = 0;
+    this.#expression = expression;
+    this.#chars = Array.from(expression);
+    this.#current = this.#chars[0];
+    this.#length = this.#expression.length;
+  }
+
+  /**
+   * Advance the lexer to the next character in the expression.
+   */
+  #next(): string {
+    if (this.#position === this.#length - 1) {
+      this.#current = '';
+    } else {
+      this.#position += 1;
+      this.#current = this.#chars[this.#position];
+    }
+
+    return this.#current;
+  }
+
+  /**
+   * Consume until the given delimiter is reached allowing
+   * for escaping of the delimiter with a backslash (`\`).
+   *
+   * @param delimiter The delimiter to consume until.
+   */
+  #consumeUntil(delimiter: string): string {
+    const start = this.#position;
+    let buff = '';
+    this.#next();
+    while (this.#current !== delimiter) {
+      if (this.#current === '\\') {
+        buff += '\\';
+        this.#next();
+      }
+      if (this.#current === '') {
+        // We've reached the end of the expression (EOF) before
+        // we found the delimiter. This is an error.
+        throw new LexerError(start, this.#expression.substring(start));
+      }
+      buff += this.#current;
+      this.#next();
+    }
+    // Skip the closing delimiter
+    this.#next();
+
+    return buff;
+  }
+
+  /**
+   * Process a literal.
+   *
+   * A literal is a JSON string that is enclosed in backticks.
+   */
+  #consumeLiteral(): Token {
+    const start = this.#position;
+    const lexeme = this.#consumeUntil('`').replace('\\`', '`');
+    try {
+      const parsedJson = JSON.parse(lexeme);
+
+      return {
+        type: 'literal',
+        value: parsedJson,
+        start,
+        end: this.#position - start,
+      };
+    } catch (error) {
+      throw new LexerError(start, lexeme);
+    }
+  }
+
+  /**
+   * Process a quoted identifier.
+   *
+   * A quoted identifier is a string that is enclosed in double quotes.
+   */
+  #consumeQuotedIdentifier(): Token {
+    const start = this.#position;
+    const lexeme = '"' + this.#consumeUntil('"') + '"';
+    const tokenLen = this.#position - start;
+
+    return {
+      type: 'quoted_identifier',
+      value: JSON.parse(lexeme),
+      start,
+      end: tokenLen,
+    };
+  }
+
+  /**
+   * Process a raw string literal.
+   *
+   * A raw string literal is a string that is enclosed in single quotes.
+   */
+  #consumeRawStringLiteral(): Token {
+    const start = this.#position;
+    const lexeme = this.#consumeUntil(`'`).replace(`\\'`, `'`);
+    const tokenLen = this.#position - start;
+
+    return {
+      type: 'literal',
+      value: lexeme,
+      start,
+      end: tokenLen,
+    };
+  }
+
+  /**
+   * Match the expected character and return the corresponding token type.
+   *
+   * @param expected The expected character
+   * @param matchType The token type to return if the expected character is found
+   * @param elseType  The token type to return if the expected character is not found
+   */
+  #matchOrElse(
+    expected: string,
+    matchType: Token['type'],
+    elseType: Token['type']
+  ): Token {
+    const start = this.#position;
+    const current = this.#current;
+    const nextChar = this.#next();
+    if (nextChar === expected) {
+      this.#next();
+
+      return {
+        type: matchType,
+        value: current + nextChar,
+        start,
+        end: start + 2,
+      };
+    }
+
+    return {
+      type: elseType,
+      value: current,
+      start,
+      end: start,
+    };
+  }
+}
+
+export { Lexer };


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR includes the implementation of the `Lexer` component, part of the JMESPath utility.

As discussed in the linked issue, the purpose of a lexer is to break down the input JMESPath expression into smaller meaningful units (tokens). These tokens represent the building blocks of the JMESPath language and are defined in the language grammar (#2192).

The `Lexer`'s main method (`public *tokenize()` is implemented as a generator. This pattern allows the lexer to _walk_ the expression iteratively and yield (aka return) tokens as it goes. While not a direct equivalent, the closest patten to describe this implementation would be a recursive function that maintains an external state (aka a reducer).

At each step, the lexer interprets a certain character and based on its type it performs certain actions.

To describe how the lexer works, let's take this expression as an example: ` foo.bar` (leading white space is intentional).

With the expression above, the lexer will start looking at each character in the order they appear:
- `position: 0` - Since the first character is a white space, the lexer advances with no further action ([source](https://github.com/aws-powertools/powertools-lambda-typescript/blob/4477be92dac1e2b4daead487cad1226240e90373/packages/jmespath/src/Lexer.ts#L57-L59))
- `position: 1` - Next, the lexer encounters a valid character (`f`). At this point the lexer needs to understand how long this identifier is and so it will advance the position until a non-identifier character (aka anything that is not a number or letter) is found ([source](https://github.com/aws-powertools/powertools-lambda-typescript/blob/4477be92dac1e2b4daead487cad1226240e90373/packages/jmespath/src/Lexer.ts#L46-L57)). In this example it will advance to position `4` and interpret `foo` as a single token.
- `position: 4` - The next character is a `dot` (aka `.`) which in the context of a lexer is considered a [simple token](https://github.com/aws-powertools/powertools-lambda-typescript/blob/4477be92dac1e2b4daead487cad1226240e90373/packages/jmespath/src/constants.ts#L76-L77).
- `position: 5` - Next, the lexer encounters another character (`b`), so just like one of the previous steps, it advances until a [non-identifier character](https://github.com/aws-powertools/powertools-lambda-typescript/blob/4477be92dac1e2b4daead487cad1226240e90373/packages/jmespath/src/constants.ts#L64) is found. In this case the lexer reaches the end of the expression.

This is a relatively simple example, but hopefully it helps clarifying the flow of the processing. For simpler tokens the implementation is inlined in the `public *tokenize()` method, while in other cases where the processing of a token required a more involved logic a dedicated method was created.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #2205

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.