### PR TITLE
fix(layers): add `createRequire` banner in esm

### DIFF
--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -174,10 +174,24 @@ export class LayerPublisherStack extends Stack {
                   .join(' ')}`
               );
 
-              // Phase 5: Copy files from tmp folder to cdk.out asset folder (the folder is created by CDK)
+              // Phase 5: patch require keyword in ESM Tracer package due to AWS X-Ray SDK for Node.js not being ESM compatible
+              const esmTracerPath = join(
+                tmpBuildDir,
+                'node_modules',
+                '@aws-lambda-powertools/tracer',
+                'lib',
+                'esm',
+                'provider',
+                'ProviderService.js'
+              );
+              execSync(
+                `echo "import { createRequire } from 'module'; const require = createRequire(import.meta.url);$(cat ${esmTracerPath})" > ${esmTracerPath}`
+              );
+
+              // Phase 6: Copy files from tmp folder to cdk.out asset folder (the folder is created by CDK)
               execSync(`cp -R ${tmpBuildPath}${sep}* ${outputDir}`);
 
-              // Phase 6: (Optional) Restore changes to the project root made by the build
+              // Phase 7: (Optional) Restore changes to the project root made by the build
               buildFromLocal &&
                 execSync('git restore packages/*/package.json', {
                   cwd: projectRoot,


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR introduces a new step in the layer publisher workflow that should fix a bug affecting customers using the Powertools Lambda Layers with functions bundled using ESM format.

As described in the linked issue, when the above conditions are met, the function throws a runtime error with the stack trace pointing at the `/opt/nodejs/node_modules`, which is where the code for our utilities is stored when using Layers.

The fix mirrors [the recommendation](https://docs.powertools.aws.dev/lambda/typescript/latest/upgrade/#unable-to-use-esm) that we give to customers having to support the `require` keyword and adds a polyfill at the top of the file causing the issue.

The step adds this banner dynamically when the Lambda layers are built and it does so only on the ESM build and on one specific file, which is importing the AWS X-Ray SDK for Node.js. While this is not a great solution, it's the only one that I could come up with that will allow us to have the polyfill present only in this specific case.

Adding the polyfill to our source would cause it to appear also when bundling for CJS, which would lead to a different runtime error, this time due to the `require` keyword defined twice.

While this PR doesn't add any test, I have tested manually the resulting layer build with functions in CJS and ESM both with and without Lambda Layers and even when adding a banner to the function bundle, it appears to fix the issue.

By the end of this iteration, or the following at the latest, I'll work on adding ESM builds to our integration test matrix.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #2231

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.