### PR TITLE
fix(idempotency): return correct value from in-memory cache

### DIFF
--- a/packages/idempotency/src/persistence/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/BasePersistenceLayer.ts
@@ -178,10 +178,11 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
       );
     }
 
-    if (this.getFromCache(idempotencyRecord.idempotencyKey)) {
+    const existingRecord = this.getFromCache(idempotencyRecord.idempotencyKey);
+    if (existingRecord) {
       throw new IdempotencyItemAlreadyExistsError(
         `Failed to put record for already existing idempotency key: ${idempotencyRecord.idempotencyKey}`,
-        idempotencyRecord
+        existingRecord
       );
     }
 

--- a/packages/idempotency/src/persistence/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/BasePersistenceLayer.ts
@@ -178,11 +178,11 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
       );
     }
 
-    const existingRecord = this.getFromCache(idempotencyRecord.idempotencyKey);
-    if (existingRecord) {
+    const cachedRecord = this.getFromCache(idempotencyRecord.idempotencyKey);
+    if (cachedRecord) {
       throw new IdempotencyItemAlreadyExistsError(
         `Failed to put record for already existing idempotency key: ${idempotencyRecord.idempotencyKey}`,
-        existingRecord
+        cachedRecord
       );
     }
 

--- a/packages/idempotency/tests/e2e/makeIdempotent.test.FunctionCode.ts
+++ b/packages/idempotency/tests/e2e/makeIdempotent.test.FunctionCode.ts
@@ -100,6 +100,7 @@ export const handlerLambda = makeIdempotent(
     persistenceStore: dynamoDBPersistenceLayer,
     config: new IdempotencyConfig({
       eventKeyJmesPath: 'foo',
+      useLocalCache: true,
     }),
   }
 );

--- a/packages/idempotency/tests/unit/makeIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeIdempotent.test.ts
@@ -399,4 +399,38 @@ describe('Function: makeIdempotent', () => {
     expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
     expect(saveSuccessSpy).toHaveBeenCalledWith('456', '123456');
   });
+  /* it('handles a cached execution', async () => {
+    // Prepare
+    const handler = makeIdempotent(
+      async (_event: unknown, context: Context) => context.awsRequestId,
+      {
+        ...mockIdempotencyOptions,
+        config: new IdempotencyConfig({
+          useLocalCache: true,
+        }),
+      }
+    );
+    const saveInProgressSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    );
+    const saveSuccessSpy = jest.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveSuccess'
+    );
+
+    // Act
+    const result = await handler(event, context);
+    const resultTwo = await handler(event, context);
+
+    // Assess
+    expect(result).toEqual(resultTwo);
+    expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
+    expect(saveInProgressSpy).toHaveBeenCalledWith(
+      event,
+      remainingTImeInMillis
+    );
+    expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
+    expect(saveSuccessSpy).toHaveBeenCalledWith(event, context.awsRequestId);
+  }); */
 });

--- a/packages/idempotency/tests/unit/makeIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeIdempotent.test.ts
@@ -399,38 +399,4 @@ describe('Function: makeIdempotent', () => {
     expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
     expect(saveSuccessSpy).toHaveBeenCalledWith('456', '123456');
   });
-  /* it('handles a cached execution', async () => {
-    // Prepare
-    const handler = makeIdempotent(
-      async (_event: unknown, context: Context) => context.awsRequestId,
-      {
-        ...mockIdempotencyOptions,
-        config: new IdempotencyConfig({
-          useLocalCache: true,
-        }),
-      }
-    );
-    const saveInProgressSpy = jest.spyOn(
-      mockIdempotencyOptions.persistenceStore,
-      'saveInProgress'
-    );
-    const saveSuccessSpy = jest.spyOn(
-      mockIdempotencyOptions.persistenceStore,
-      'saveSuccess'
-    );
-
-    // Act
-    const result = await handler(event, context);
-    const resultTwo = await handler(event, context);
-
-    // Assess
-    expect(result).toEqual(resultTwo);
-    expect(saveInProgressSpy).toHaveBeenCalledTimes(1);
-    expect(saveInProgressSpy).toHaveBeenCalledWith(
-      event,
-      remainingTImeInMillis
-    );
-    expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
-    expect(saveSuccessSpy).toHaveBeenCalledWith(event, context.awsRequestId);
-  }); */
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR fixes a bug in the Idempotency utility that caused retries performed while the utility's in-memory cache was enabled to be rejected as "already in-progress" rather than returning the value from the previous execution.

Due to this bug happening exclusively on repeated (aka subsequent) idempotent requests it's highly unlikely that customers might have experienced data loss but instead they would have observed an artificially high number of [`IdempotencyAlreadyInProgressError`](https://docs.powertools.aws.dev/lambda/typescript/latest/api/classes/_aws_lambda_powertools_idempotency.index.IdempotencyAlreadyInProgressError.html) errors as if the previous execution was not yet complete, which is still not great.

The PR addresses the bug by returning the value from cache whenever one is found. It also addresses a gap in our tests that was evidenced by us not catching the bug by enabling the `useLocalCache` setting in some existing cases both in the unit & integration tests.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #2309

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.