### PR TITLE
chore(parser): add DeadLetterQueueSourceArn attribute

### DIFF
--- a/packages/parser/src/schemas/sqs.ts
+++ b/packages/parser/src/schemas/sqs.ts
@@ -17,6 +17,7 @@ const SqsAttributesSchema = z.object({
   SentTimestamp: z.string(),
   SequenceNumber: z.string().optional(),
   AWSTraceHeader: z.string().optional(),
+  DeadLetterQueueSourceArn: z.string().optional(), // Undocumented, but used by AWS to support their re-drive functionality in the console
 });
 
 const SqsRecordSchema = z.object({

--- a/packages/parser/src/schemas/sqs.ts
+++ b/packages/parser/src/schemas/sqs.ts
@@ -17,7 +17,10 @@ const SqsAttributesSchema = z.object({
   SentTimestamp: z.string(),
   SequenceNumber: z.string().optional(),
   AWSTraceHeader: z.string().optional(),
-  DeadLetterQueueSourceArn: z.string().optional(), // Undocumented, but used by AWS to support their re-drive functionality in the console
+  /**
+   * Undocumented, but used by AWS to support their re-drive functionality in the console
+   */
+  DeadLetterQueueSourceArn: z.string().optional(),
 });
 
 const SqsRecordSchema = z.object({

--- a/packages/parser/tests/events/sqsEvent.json
+++ b/packages/parser/tests/events/sqsEvent.json
@@ -30,7 +30,8 @@
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1545082650636",
         "SenderId": "AIDAIENQZJOLO23YVJ4VO",
-        "ApproximateFirstReceiveTimestamp": "1545082650649"
+        "ApproximateFirstReceiveTimestamp": "1545082650649",
+        "DeadLetterQueueSourceArn": "arn:aws:sqs:us-east-2:123456789012:my-queue-dead"
       },
       "messageAttributes": {},
       "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

This PR adds `DeadLetterQueueSourceArn` field to SQS message attributes. 

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #2361 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [ ] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.