### PR TITLE
fix(jmespath): refactor custom function introspection to work with minification

### DIFF
--- a/packages/jmespath/src/Functions.ts
+++ b/packages/jmespath/src/Functions.ts
@@ -532,6 +532,23 @@ class Functions {
     return Object.values(arg);
   }
 
+  /**
+   * Lazily introspects the methods of the class instance and all child classes
+   * to get the names of the methods that correspond to JMESPath functions.
+   *
+   * This method is used to get the names of the custom functions that are available
+   * in the class instance and all child classes. The names of the functions are used
+   * to create the custom function map that is passed to the JMESPath search function.
+   *
+   * The method traverses the inheritance chain going from the leaf class to the root class
+   * and stops when it reaches the `Functions` class, which is the root class.
+   *
+   * In doing so, it collects the names of the methods that start with `func` and adds them
+   * to the `methods` set. Finally, when the recursion collects back to the current instance,
+   * it adds the collected methods to the `this.methods` set so that they can be accessed later.
+   *
+   * @param scope The scope of the class instance to introspect
+   */
   public introspectMethods(scope?: Functions): Set<string> {
     const prototype = Object.getPrototypeOf(this);
     const methods = new Set<string>();

--- a/packages/jmespath/src/Functions.ts
+++ b/packages/jmespath/src/Functions.ts
@@ -48,7 +48,11 @@ import { arityCheck, typeCheck } from './utils.js';
  * ```
  */
 class Functions {
+  /**
+   * A set of all the custom functions available in this and all child classes.
+   */
   public methods: Set<string> = new Set();
+
   /**
    * Get the absolute value of the provided number.
    *
@@ -530,12 +534,13 @@ class Functions {
 
   public introspectMethods(scope?: Functions): Set<string> {
     const prototype = Object.getPrototypeOf(this);
-    const ownName = prototype.constructor.name;
     const methods = new Set<string>();
-    if (ownName !== 'Functions') {
+    if (this instanceof Functions) {
       for (const method of prototype.introspectMethods(scope)) {
         methods.add(method);
       }
+    } else {
+      return methods;
     }
 
     // This block is executed for every class in the inheritance chain

--- a/packages/jmespath/tests/unit/index.test.ts
+++ b/packages/jmespath/tests/unit/index.test.ts
@@ -388,17 +388,14 @@ describe('Coverage tests', () => {
         @PowertoolsFunctions.signature({
           argumentsSpecs: [['string']],
         })
-        public funcDecodeBrotliCompression(value: string): string {
-          const encoded = fromBase64(value, 'base64');
-          const uncompressed = brotliDecompressSync(encoded);
-
-          return uncompressed.toString();
+        public funcPassThrough(value: string): string {
+          return value
         }
       }
 
       // Act
       const customFunctions = new CustomFunctions();
-      search('foo', {}, { customFunctions });
+      search('pass_through(foo)', { foo: 1 }, { customFunctions });
 
       // Assess
       expect(customFunctions.methods.size).toBeGreaterThan(

--- a/packages/jmespath/tests/unit/index.test.ts
+++ b/packages/jmespath/tests/unit/index.test.ts
@@ -395,7 +395,7 @@ describe('Coverage tests', () => {
 
       // Act
       const customFunctions = new CustomFunctions();
-      search('pass_through(foo)', { foo: 1 }, { customFunctions });
+      search('pass_through(foo)', { foo: 'bar' }, { customFunctions });
 
       // Assess
       expect(customFunctions.methods.size).toBeGreaterThan(

--- a/packages/jmespath/tests/unit/index.test.ts
+++ b/packages/jmespath/tests/unit/index.test.ts
@@ -389,7 +389,7 @@ describe('Coverage tests', () => {
           argumentsSpecs: [['string']],
         })
         public funcPassThrough(value: string): string {
-          return value
+          return value;
         }
       }
 

--- a/packages/jmespath/tests/unit/index.test.ts
+++ b/packages/jmespath/tests/unit/index.test.ts
@@ -351,9 +351,6 @@ describe('Coverage tests', () => {
     it('uses the custom function extending the powertools custom functions', () => {
       // Prepare
       class CustomFunctions extends PowertoolsFunctions {
-        public constructor() {
-          super();
-        }
         @PowertoolsFunctions.signature({
           argumentsSpecs: [['string']],
         })
@@ -383,6 +380,30 @@ describe('Coverage tests', () => {
 
       // Assess
       expect(messages).toStrictEqual(['hello world']);
+    });
+
+    it('correctly registers all the custom functions', () => {
+      // Prepare
+      class CustomFunctions extends PowertoolsFunctions {
+        @PowertoolsFunctions.signature({
+          argumentsSpecs: [['string']],
+        })
+        public funcDecodeBrotliCompression(value: string): string {
+          const encoded = fromBase64(value, 'base64');
+          const uncompressed = brotliDecompressSync(encoded);
+
+          return uncompressed.toString();
+        }
+      }
+
+      // Act
+      const customFunctions = new CustomFunctions();
+      search('foo', {}, { customFunctions });
+
+      // Assess
+      expect(customFunctions.methods.size).toBeGreaterThan(
+        new PowertoolsFunctions().methods.size
+      );
     });
   });
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

This PR fixes a bug that caused JMESPath custom functions to fail to be detected and throw a runtime error when running on minified functions.

The previous logic relied on the name of the class (via `prototype.constructor.name`) which caused it to fail when the code is minified since entities are aliased to use shorter names.

The new logic introduced in this PR uses an identity check (`value instanceof Class`) which minification-proof since even when aliased both classes will still maintain their inheritance.

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** #2383

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [x] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [x] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.