### PR TITLE
fix(parser): set etag optional for delete object notifications

### DIFF
--- a/packages/parser/src/schemas/s3.ts
+++ b/packages/parser/src/schemas/s3.ts
@@ -72,8 +72,8 @@ const S3EventNotificationEventBridgeDetailSchema = z.object({
   }),
   object: z.object({
     key: z.string(),
-    size: z.number().nonnegative().optional(),
-    etag: z.string().optional(),
+    size: z.number().nonnegative().optional(), // not present in DeleteObject events
+    etag: z.string().optional(), // not present in DeleteObject events
     'version-id': z.string().optional(),
     sequencer: z.string().optional(),
   }),

--- a/packages/parser/src/schemas/s3.ts
+++ b/packages/parser/src/schemas/s3.ts
@@ -73,7 +73,7 @@ const S3EventNotificationEventBridgeDetailSchema = z.object({
   object: z.object({
     key: z.string(),
     size: z.number().nonnegative().optional(),
-    etag: z.string(),
+    etag: z.string().optional(),
     'version-id': z.string().optional(),
     sequencer: z.string().optional(),
   }),

--- a/packages/parser/tests/events/s3EventBridgeNotificationObjectDeletedEvent.json
+++ b/packages/parser/tests/events/s3EventBridgeNotificationObjectDeletedEvent.json
@@ -16,8 +16,6 @@
     },
     "object": {
         "key": "IMG_m7fzo3.jpg",
-        "size": 184662,
-        "etag": "4e68adba0abe2dc8653dc3354e14c01d",
         "sequencer": "006408CAD69598B05E"
     },
     "request-id": "0BH729840619AG5K",


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

In this PR we set etag to optional. We initially discussed in #2410 that it'd be best to split s3 event notification schema into separate objects for event types (delete, create, update, lifecycle, etc) similar to how `@types/aws-lambda` does it.

However `@types/aws-lambda` is not correct for the s3 notification, i.e. etag is a required field in `DeleteObject` events, thus we can't rely on them. In addition, splitting the event types would introduce either redundancy between the events of the common fields, or additional complexity if we decide to split them based on base and specific fields. It'd be hard to read them.


<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #2410 

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.