### PR TITLE
fix(parser): lambda function url cognitoIdentity and principalOrgId nullable

### DIFF
--- a/packages/parser/src/schemas/apigwv2.ts
+++ b/packages/parser/src/schemas/apigwv2.ts
@@ -44,7 +44,7 @@ const RequestContextV2 = z.object({
     .object({
       clientCert: APIGatewayCert.optional(),
     })
-    .nullable(),
+    .nullish(),
   domainName: z.string(),
   domainPrefix: z.string(),
   http: RequestContextV2Http,

--- a/packages/parser/src/schemas/apigwv2.ts
+++ b/packages/parser/src/schemas/apigwv2.ts
@@ -13,14 +13,16 @@ const RequestContextV2Authorizer = z.object({
       accessKey: z.string().optional(),
       accountId: z.string().optional(),
       callerId: z.string().optional(),
-      principalOrgId: z.string().optional(),
+      principalOrgId: z.string().nullable(),
       userArn: z.string().optional(),
       userId: z.string().optional(),
-      cognitoIdentity: z.object({
-        amr: z.array(z.string()),
-        identityId: z.string(),
-        identityPoolId: z.string(),
-      }),
+      cognitoIdentity: z
+        .object({
+          amr: z.array(z.string()),
+          identityId: z.string(),
+          identityPoolId: z.string(),
+        })
+        .nullable(),
     })
     .optional(),
   lambda: z.record(z.string(), z.any()).optional(),
@@ -42,7 +44,7 @@ const RequestContextV2 = z.object({
     .object({
       clientCert: APIGatewayCert.optional(),
     })
-    .optional(),
+    .nullable(),
   domainName: z.string(),
   domainPrefix: z.string(),
   http: RequestContextV2Http,

--- a/packages/parser/src/schemas/apigwv2.ts
+++ b/packages/parser/src/schemas/apigwv2.ts
@@ -13,7 +13,7 @@ const RequestContextV2Authorizer = z.object({
       accessKey: z.string().optional(),
       accountId: z.string().optional(),
       callerId: z.string().optional(),
-      principalOrgId: z.string().nullable(),
+      principalOrgId: z.string().nullish(),
       userArn: z.string().optional(),
       userId: z.string().optional(),
       cognitoIdentity: z
@@ -22,7 +22,7 @@ const RequestContextV2Authorizer = z.object({
           identityId: z.string(),
           identityPoolId: z.string(),
         })
-        .nullable(),
+        .nullish(),
     })
     .optional(),
   lambda: z.record(z.string(), z.any()).optional(),

--- a/packages/parser/tests/unit/schema/lambda.test.ts
+++ b/packages/parser/tests/unit/schema/lambda.test.ts
@@ -15,4 +15,10 @@ describe('Lambda ', () => {
       lambdaFunctionUrlEvent
     );
   });
+
+  it('should parse url IAM event', () => {
+    const urlIAMEvent = TestEvents.lambdaFunctionUrlIAMEvent;
+
+    expect(LambdaFunctionUrlSchema.parse(urlIAMEvent)).toEqual(urlIAMEvent);
+  });
 });


### PR DESCRIPTION
<!--- 
Instructions:
1. Make sure you follow our Contributing Guidelines: https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md
2. Please follow the template, and do not remove any section/item. If something is not applicable leave it empty, but leave it in the PR. 
3. -->

## Description of your changes

This PR closes #2427 . I have used `optional` in most of the places where we don't expect to have a value, but this did not cover the `null` value case. 

<!---
Include here a summary of the change.

Please include also relevant motivation and context.

Add any applicable code snippets, links, screenshots, or other resources
that can help us verify your changes.
-->

### Related issues, RFCs

<!--- 
Add here the number (i.e. #42) to the Github Issue or RFC that is related to this PR.

Don't include any other text, otherwise the Github Issue will not be detected.

Note: If no issue is present the PR might get blocked and not be reviewed.
-->
**Issue number:** closes #2427

## Checklist

- [x] [My changes meet the tenets criteria](https://docs.powertools.aws.dev/lambda/typescript/#tenets)
- [x] I have performed a *self-review* of my own code
- [ ] I have *commented* my code where necessary, particularly in areas that should be flagged with a TODO, or hard-to-understand areas
- [ ] I have made corresponding changes to the *documentation*
- [x] My changes generate *no new warnings*
- [ ] I have *added tests* that prove my change is effective and works
- [x] The PR title follows the [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)

### Breaking change checklist

***Is it a breaking change?:*** NO

- [ ] I have documented the migration process
- [ ] I have added, implemented necessary warnings (if it can live side by side)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.