### PR TITLE
fix(parser): set APIGatewayProxyEventSchema body and query string keys to be nullable

### DIFF
--- a/packages/parser/src/schemas/apigw.ts
+++ b/packages/parser/src/schemas/apigw.ts
@@ -97,14 +97,14 @@ const APIGatewayProxyEventSchema = z.object({
     'OPTIONS',
   ]),
   headers: z.record(z.string()).optional(),
-  queryStringParameters: z.record(z.string()).optional(),
+  queryStringParameters: z.record(z.string()).nullable(),
   multiValueHeaders: z.record(z.array(z.string())).optional(),
-  multiValueQueryStringParameters: z.record(z.array(z.string())).optional(),
+  multiValueQueryStringParameters: z.record(z.array(z.string())).nullable(),
   requestContext: APIGatewayEventRequestContext,
   pathParameters: z.record(z.string()).optional().nullish(),
   stageVariables: z.record(z.string()).optional().nullish(),
   isBase64Encoded: z.boolean().optional(),
-  body: z.string().optional(),
+  body: z.string().nullable(),
 });
 
 export { APIGatewayProxyEventSchema, APIGatewayCert };

--- a/packages/parser/tests/events/apiGatewayAuthorizerRequestEvent.json
+++ b/packages/parser/tests/events/apiGatewayAuthorizerRequestEvent.json
@@ -20,6 +20,9 @@
   "queryStringParameters": {
     "QueryString1": "queryValue1"
   },
+  "multiValueQueryStringParameters": {
+    "QueryString1": ["queryValue1"]
+  },
   "pathParameters": {},
   "stageVariables": {
     "StageVar1": "stageValue1"
@@ -64,5 +67,6 @@
     "resourceId": "ANY /request",
     "resourcePath": "/request",
     "stage": "test"
-  }
+  },
+  "body": null
 }

--- a/packages/parser/tests/unit/envelopes/apigwt.test.ts
+++ b/packages/parser/tests/unit/envelopes/apigwt.test.ts
@@ -24,7 +24,7 @@ describe('ApigwEnvelope ', () => {
 
     it('should throw no body provided', () => {
       const testEvent = TestEvents.apiGatewayProxyEvent as APIGatewayProxyEvent;
-      testEvent.body = undefined;
+      testEvent.body = null;
 
       expect(() => ApiGatewayEnvelope.parse(testEvent, TestSchema)).toThrow(
         ParseError
@@ -56,7 +56,7 @@ describe('ApigwEnvelope ', () => {
 
     it('should return success false with original body if no body provided', () => {
       const testEvent = TestEvents.apiGatewayProxyEvent as APIGatewayProxyEvent;
-      testEvent.body = undefined;
+      testEvent.body = null;
 
       const resp = ApiGatewayEnvelope.safeParse(testEvent, TestSchema);
       expect(resp).toEqual({


### PR DESCRIPTION
## Summary

The APIGatewayProxyEventSchema has incorrect types for these request keys: `body`, `queryStringParameters`, and `multiValueQueryStringParameters`.

The above fields are incorrectly validating against `z.optional()` (undefined) when they are not present in the request, but API Gateway actually sends these values as `null` in this case.

### Changes

This PR addresses the issue by changing the Zod schemas to use `z.nullable()` instead. Unit tests are updated to reflect the change.

**Issue number:** #2461 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
