### PR TITLE
chore(tracer): mark captureAWS & captureAWSClient functions as deprecated

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -253,6 +253,7 @@ class Tracer extends Utility implements TracerInterface {
    * }
    * ```
    *
+   * @deprecated Use {@link captureAWSv3Client} instead.
    * @param aws - AWS SDK v2 import
    * @returns AWS - Instrumented AWS SDK
    */
@@ -281,7 +282,7 @@ class Tracer extends Utility implements TracerInterface {
    *   ...
    * }
    * ```
-   *
+   * @deprecated Use {@link captureAWSv3Client} instead.
    * @param service - AWS SDK v2 client
    * @returns service - Instrumented AWS SDK v2 client
    */

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -31,10 +31,16 @@ import {
 import type { DiagnosticsChannel } from 'undici-types';
 
 class ProviderService implements ProviderServiceInterface {
+  /**
+   * @deprecated
+   */
   public captureAWS<T>(awssdk: T): T {
     return captureAWS(awssdk);
   }
 
+  /**
+   * @deprecated
+   */
   public captureAWSClient<T>(service: T): T {
     return captureAWSClient(service);
   }


### PR DESCRIPTION
## Summary
As described in the issue, AWS SDK for JavaScript v2 will reach end-of-support in September 8, 2025. In response to this announcement, adding deprecated tags for the Tracer methods used to instrument clients for this version.

### Changes
Add @deprecated notice on the `captureAWS` & `captureAWSClient` methods.


**Issue number:** #2397 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
