### PR TITLE
chore(ci): Aggregate lint-staged in top package.json

### DIFF
--- a/layers/package.json
+++ b/layers/package.json
@@ -18,9 +18,7 @@
     "test:e2e": "jest --group=e2e",
     "createLayerFolder": "cdk synth --context BuildFromLocal=true"
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
+
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-powertools/powertools-lambda-typescript.git"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "typescript": "^5.4.5"
   },
   "lint-staged": {
+    "*.{js,ts}": "eslint --fix",
     "*.md": "markdownlint-cli2 --fix"
   },
   "engines": {

--- a/packages/batch/package.json
+++ b/packages/batch/package.json
@@ -25,9 +25,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/batch#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -23,9 +23,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/commons#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -25,9 +25,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/idempotency#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/jmespath/package.json
+++ b/packages/jmespath/package.json
@@ -22,9 +22,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript",
   "license": "MIT-0",
   "type": "module",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -25,9 +25,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/logger#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -24,9 +24,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/metrics#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -25,9 +25,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/parameters#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -21,9 +21,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/parser#readme",
   "license": "MIT-0",
   "type": "module",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -20,9 +20,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-powertools/powertools-lambda-typescript.git"

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -25,9 +25,6 @@
     "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
-  "lint-staged": {
-    "*.{js,ts}": "npm run lint-fix"
-  },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/tracer#readme",
   "license": "MIT-0",
   "devDependencies": {


### PR DESCRIPTION
## Summary

### Changes

In this PR the suggested aggregation of the lint-staged configuration into the top package.json is implemented. Closes #2312

**Issue number:** #2312

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
