### PR TITLE
fix(parser): handle API Gateway Test UI sourceIp

### DIFF
--- a/packages/parser/src/schemas/apigw.ts
+++ b/packages/parser/src/schemas/apigw.ts
@@ -22,7 +22,16 @@ const APIGatewayEventIdentity = z.object({
   cognitoIdentityId: z.string().nullish(),
   cognitoIdentityPoolId: z.string().nullish(),
   principalOrgId: z.string().nullish(),
-  sourceIp: z.string().ip().optional(),
+  /**
+   * When invoking the API Gateway REST API using the Test Invoke feature,
+   * the sourceIp is hardcoded to `test-invoke-source-ip`. This is a stopgap
+   * solution to allow customers to test their API and have successful parsing.
+   *
+   * See aws-powertools/powertools-lambda-python#1562 for more information.
+   */
+  sourceIp: z
+    .union([z.string().ip(), z.literal('test-invoke-source-ip')])
+    .optional(),
   user: z.string().nullish(),
   userAgent: z.string().nullish(),
   userArn: z.string().nullish(),

--- a/packages/parser/tests/events/apiGatewayProxyEventTestUI.json
+++ b/packages/parser/tests/events/apiGatewayProxyEventTestUI.json
@@ -1,0 +1,81 @@
+{
+  "version": "1.0",
+  "resource": "/my/path",
+  "path": "/my/path",
+  "httpMethod": "GET",
+  "headers": {
+    "Header1": "value1",
+    "Header2": "value2",
+    "Origin": "https://aws.amazon.com"
+  },
+  "multiValueHeaders": {
+    "Header1": [
+      "value1"
+    ],
+    "Header2": [
+      "value1",
+      "value2"
+    ]
+  },
+  "queryStringParameters": {
+    "parameter1": "value1",
+    "parameter2": "value"
+  },
+  "multiValueQueryStringParameters": {
+    "parameter1": [
+      "value1",
+      "value2"
+    ],
+    "parameter2": [
+      "value"
+    ]
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "apiId": "id",
+    "authorizer": {
+      "claims": null,
+      "scopes": null
+    },
+    "domainName": "id.execute-api.us-east-1.amazonaws.com",
+    "domainPrefix": "id",
+    "extendedRequestId": "request-id",
+    "httpMethod": "GET",
+    "identity": {
+      "accessKey": null,
+      "accountId": null,
+      "caller": null,
+      "cognitoAuthenticationProvider": null,
+      "cognitoAuthenticationType": null,
+      "cognitoIdentityId": null,
+      "cognitoIdentityPoolId": null,
+      "principalOrgId": null,
+      "sourceIp": "test-invoke-source-ip",
+      "user": null,
+      "userAgent": "user-agent",
+      "userArn": null,
+      "clientCert": {
+        "clientCertPem": "CERT_CONTENT",
+        "subjectDN": "www.example.com",
+        "issuerDN": "Example issuer",
+        "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+        "validity": {
+          "notBefore": "May 28 12:30:02 2019 GMT",
+          "notAfter": "Aug  5 09:36:04 2021 GMT"
+        }
+      }
+    },
+    "path": "/my/path",
+    "protocol": "HTTP/1.1",
+    "requestId": "id=",
+    "requestTime": "04/Mar/2020:19:15:17 +0000",
+    "requestTimeEpoch": 1583349317135,
+    "resourceId": null,
+    "resourcePath": "/my/path",
+    "stage": "$default"
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "body": "Hello from Lambda!",
+  "isBase64Encoded": false
+}

--- a/packages/parser/tests/unit/schema/apigw.test.ts
+++ b/packages/parser/tests/unit/schema/apigw.test.ts
@@ -68,6 +68,12 @@ describe('APIGateway ', () => {
       apiGatewayProxyOtherEvent
     );
   });
+  it('should not throw when event has sourceIp as test-invoke-source-ip', () => {
+    const apiGatewayProxyEventTestUi = TestEvents.apiGatewayProxyEventTestUI;
+    expect(() =>
+      APIGatewayProxyEventSchema.parse(apiGatewayProxyEventTestUi)
+    ).not.toThrow();
+  });
   it('should throw error when event is not a valid proxy event', () => {
     const event = {
       resource: '/',

--- a/packages/parser/tests/unit/schema/utils.ts
+++ b/packages/parser/tests/unit/schema/utils.ts
@@ -20,6 +20,7 @@ const filenames = [
   'apiGatewayProxyEventPrincipalId',
   'apiGatewayProxyEvent_noVersionAuth',
   'apiGatewayProxyOtherEvent',
+  'apiGatewayProxyEventTestUI',
   'apiGatewayProxyV2Event',
   'apiGatewayProxyV2EventPathTrailingSlash',
   'apiGatewayProxyV2Event_GET',


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the `APIGatewayProxyEvent` schema in the Parser utility to account for an edge case occurring when using the API Gateway Test UI to call an endpoint.

In these cases API Gateway doesn't send a real `sourceIp` but instead sends a string hardcoded to `test-invoke-source-ip`. This caused the schema to fail parsing preventing customers from using the Test UI with endpoints using the Parser utility.

Normally we wouldn't have made changes of this type, but since previous efforts to have the API Gateway service change this behavior have failed, and there's no workaround for customers, we are making an exception until the situation improves.

As of this PR the `sourceIp` field can be either a valid IP address or a string with value `test-invoke-source-ip`.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #2526

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
