### PR TITLE
test(tracer): remove `axios` and use `https` directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18864,7 +18864,6 @@
         "@aws-sdk/client-xray": "^3.574.0",
         "@types/promise-retry": "^1.1.6",
         "aws-sdk": "^2.1623.0",
-        "axios": "^1.6.8",
         "promise-retry": "^2.0.1"
       },
       "peerDependencies": {

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -33,7 +33,6 @@
     "@aws-sdk/client-xray": "^3.574.0",
     "@types/promise-retry": "^1.1.6",
     "aws-sdk": "^2.1623.0",
-    "axios": "^1.6.8",
     "promise-retry": "^2.0.1"
   },
   "peerDependencies": {

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -55,8 +55,6 @@ export class MyFunctionBase {
       httpRequest({
         hostname: 'docs.powertools.aws.dev',
         path: '/lambda/typescript/latest/',
-        protocol: 'https',
-        timeout: 5000,
       }),
       new Promise((resolve, reject) => {
         setTimeout(() => {

--- a/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.decorator.test.functionCode.ts
@@ -1,7 +1,7 @@
 import { Tracer } from '../../src/Tracer.js';
 import type { Callback, Context } from 'aws-lambda';
 import AWS from 'aws-sdk';
-import axios from 'axios';
+import { httpRequest } from '../helpers/httpRequest.js';
 
 const serviceName =
   process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandardHandler';
@@ -52,7 +52,10 @@ export class MyFunctionBase {
           Item: { id: `${serviceName}-${event.invocation}-sdkv2` },
         })
         .promise(),
-      axios.get('https://docs.powertools.aws.dev/lambda/typescript/latest/', {
+      httpRequest({
+        hostname: 'docs.powertools.aws.dev',
+        path: '/lambda/typescript/latest/',
+        protocol: 'https',
         timeout: 5000,
       }),
       new Promise((resolve, reject) => {
@@ -66,7 +69,7 @@ export class MyFunctionBase {
         }, 2000); // We need to wait for to make sure previous calls are finished
       }),
     ])
-      .then(([_dynamoDBRes, _axiosRes, promiseRes]) => promiseRes)
+      .then(([_dynamoDBRes, _httpRes, promiseRes]) => promiseRes)
       .catch((err) => {
         throw err;
       });

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
@@ -58,8 +58,6 @@ export const handler = async (
     await httpRequest({
       hostname: 'docs.powertools.aws.dev',
       path: '/lambda/typescript/latest/',
-      protocol: 'https',
-      timeout: 5000,
     });
 
     const res = customResponseValue;

--- a/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.manual.test.functionCode.ts
@@ -1,8 +1,8 @@
 import { Tracer } from '../../src/index.js';
 import type { Context } from 'aws-lambda';
-import axios from 'axios';
 import AWS from 'aws-sdk';
 import type { Subsegment } from 'aws-xray-sdk-core';
+import { httpRequest } from '../helpers/httpRequest.js';
 
 const serviceName =
   process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandardHandler';
@@ -55,10 +55,12 @@ export const handler = async (
         Item: { id: `${serviceName}-${event.invocation}-sdkv2` },
       })
       .promise();
-    await axios.get(
-      'https://docs.powertools.aws.dev/lambda/typescript/latest/',
-      { timeout: 5000 }
-    );
+    await httpRequest({
+      hostname: 'docs.powertools.aws.dev',
+      path: '/lambda/typescript/latest/',
+      protocol: 'https',
+      timeout: 5000,
+    });
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
@@ -3,7 +3,7 @@ import { Tracer } from '../../src/index.js';
 import { captureLambdaHandler } from '../../src/middleware/middy.js';
 import type { Context } from 'aws-lambda';
 import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
-import axios from 'axios';
+import { httpRequest } from '../helpers/httpRequest.js';
 
 const serviceName =
   process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandardHandler';
@@ -46,10 +46,12 @@ const testHandler = async (
         Item: { id: { S: `${serviceName}-${event.invocation}-sdkv3` } },
       })
     );
-    await axios.get(
-      'https://docs.powertools.aws.dev/lambda/typescript/latest/',
-      { timeout: 5000 }
-    );
+    await httpRequest({
+      hostname: 'docs.powertools.aws.dev',
+      path: '/lambda/typescript/latest/',
+      protocol: 'https',
+      timeout: 5000,
+    });
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/allFeatures.middy.test.functionCode.ts
@@ -49,8 +49,6 @@ const testHandler = async (
     await httpRequest({
       hostname: 'docs.powertools.aws.dev',
       path: '/lambda/typescript/latest/',
-      protocol: 'https',
-      timeout: 5000,
     });
 
     const res = customResponseValue;

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -2,7 +2,7 @@ import { Tracer } from '../../src/index.js';
 import type { Context } from 'aws-lambda';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
-import axios from 'axios';
+import { httpRequest } from '../helpers/httpRequest.js';
 
 const serviceName =
   process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandardHandler';
@@ -58,7 +58,12 @@ export class MyFunctionBase {
       const url = 'https://docs.powertools.aws.dev/lambda/typescript/latest/';
       // Add conditional behavior because fetch is not available in Node.js 16 - this can be removed once we drop support for Node.js 16
       if (process.version.startsWith('v16')) {
-        await axios.get(url, { timeout: 5000 });
+        await httpRequest({
+          hostname: 'docs.powertools.aws.dev',
+          path: '/lambda/typescript/latest/',
+          protocol: 'https',
+          timeout: 5000,
+        });
       } else {
         await fetch(url);
       }

--- a/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/asyncHandler.decorator.test.functionCode.ts
@@ -61,8 +61,6 @@ export class MyFunctionBase {
         await httpRequest({
           hostname: 'docs.powertools.aws.dev',
           path: '/lambda/typescript/latest/',
-          protocol: 'https',
-          timeout: 5000,
         });
       } else {
         await fetch(url);

--- a/packages/tracer/tests/helpers/httpRequest.ts
+++ b/packages/tracer/tests/helpers/httpRequest.ts
@@ -1,0 +1,47 @@
+import https, { type RequestOptions } from 'node:https';
+
+/**
+ * Make an HTTP request using the built-in `https` module
+ *
+ * This helper function is used in Tracer's tests to make HTTP requests
+ * and assert that the requests are being traced correctly.
+ *
+ * If the requests are traced correctly, then all 3rd party libraries
+ * built on top of the `https` module should also be traced correctly.
+ *
+ * @param params - The request options
+ */
+const httpRequest = (params: RequestOptions): Promise<unknown> =>
+  new Promise((resolve, reject) => {
+    const req = https.request(params, (res) => {
+      // reject on bad status
+      if (
+        res.statusCode == null ||
+        res.statusCode < 200 ||
+        res.statusCode >= 300
+      ) {
+        return reject(new Error(`statusCode=${res.statusCode || 'unknown'}`));
+      }
+      // cumulate data
+      let body: Uint8Array[] = [];
+      res.on('data', (chunk) => {
+        body.push(chunk);
+      });
+      // resolve on end
+      res.on('end', () => {
+        try {
+          body = JSON.parse(Buffer.concat(body).toString());
+        } catch (e) {
+          reject(e);
+        }
+        resolve(body);
+      });
+    });
+    req.on('error', (err) => {
+      reject(err);
+    });
+
+    req.end();
+  });
+
+export { httpRequest };

--- a/packages/tracer/tests/helpers/httpRequest.ts
+++ b/packages/tracer/tests/helpers/httpRequest.ts
@@ -42,8 +42,8 @@ const httpRequest = (params: RequestOptions): Promise<unknown> =>
         resolve(responseBody);
       });
     });
-    req.on('error', (err) => {
-      reject(err);
+    req.on('error', (error) => {
+      reject(error instanceof Error ? error : new Error(error));
     });
 
     req.end();

--- a/packages/tracer/tests/helpers/httpRequest.ts
+++ b/packages/tracer/tests/helpers/httpRequest.ts
@@ -37,7 +37,7 @@ const httpRequest = (params: RequestOptions): Promise<unknown> =>
         try {
           responseBody = Buffer.concat(incomingData).toString();
         } catch (error) {
-          reject(error);
+          reject(error instanceof Error ? error : new Error('Unknown error'));
         }
         resolve(responseBody);
       });

--- a/packages/tracer/tests/helpers/httpRequest.ts
+++ b/packages/tracer/tests/helpers/httpRequest.ts
@@ -21,7 +21,6 @@ const httpRequest = (params: RequestOptions): Promise<unknown> =>
     }
 
     const req = https.request(params, (res) => {
-      // reject on bad status
       if (
         res.statusCode == null ||
         res.statusCode < 200 ||
@@ -29,19 +28,18 @@ const httpRequest = (params: RequestOptions): Promise<unknown> =>
       ) {
         return reject(new Error(`statusCode=${res.statusCode || 'unknown'}`));
       }
-      // cumulate data
-      let body: Uint8Array[] = [];
+      const incomingData: Uint8Array[] = [];
+      let responseBody: string;
       res.on('data', (chunk) => {
-        body.push(chunk);
+        incomingData.push(chunk);
       });
-      // resolve on end
       res.on('end', () => {
         try {
-          body = JSON.parse(Buffer.concat(body).toString());
-        } catch (e) {
-          reject(e);
+          responseBody = Buffer.concat(incomingData).toString();
+        } catch (error) {
+          reject(error);
         }
-        resolve(body);
+        resolve(responseBody);
       });
     });
     req.on('error', (err) => {

--- a/packages/tracer/tests/helpers/httpRequest.ts
+++ b/packages/tracer/tests/helpers/httpRequest.ts
@@ -13,6 +13,13 @@ import https, { type RequestOptions } from 'node:https';
  */
 const httpRequest = (params: RequestOptions): Promise<unknown> =>
   new Promise((resolve, reject) => {
+    if (!params.protocol) {
+      params.protocol = 'https:';
+    }
+    if (!params.timeout) {
+      params.timeout = 5000;
+    }
+
     const req = https.request(params, (res) => {
       // reject on bad status
       if (


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR removes `axios` from the `devDependencies` and replaces its usage with a custom helper function, used only in integration tests, that is based on the `https` built-in module directly.

With this change the tests remain functionally unchanged and the only difference is that we have one less dependency to manage.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #2558

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
