### PR TITLE
chore(idempotency): expiration timestamp rounded to the nearest second 

### DIFF
--- a/packages/idempotency/src/persistence/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/BasePersistenceLayer.ts
@@ -260,7 +260,7 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
   private getExpiryTimestamp(): number {
     const currentTime: number = Date.now() / 1000;
 
-    return currentTime + this.expiresAfterSeconds;
+    return Math.round(currentTime + this.expiresAfterSeconds);
   }
 
   private getFromCache(idempotencyKey: string): IdempotencyRecord | undefined {

--- a/packages/idempotency/tests/e2e/makeIdempotent.test.ts
+++ b/packages/idempotency/tests/e2e/makeIdempotent.test.ts
@@ -137,9 +137,14 @@ describe(`Idempotency E2E tests, wrapper function usage`, () => {
       );
       // Since records 1 and 3 have the same payload, only 2 records should be created
       expect(idempotencyRecords?.Items?.length).toEqual(2);
-      const idempotencyRecordsItems = idempotencyRecords.Items?.sort((a, b) =>
-        a.expiration > b.expiration ? 1 : -1
-      );
+      const idempotencyRecordsItems = [
+        idempotencyRecords.Items?.find(
+          (record) => record.id === `${functionNameDefault}#${payloadHashes[0]}`
+        ),
+        idempotencyRecords.Items?.find(
+          (record) => record.id === `${functionNameDefault}#${payloadHashes[1]}`
+        ),
+      ];
 
       expect(idempotencyRecordsItems?.[0]).toStrictEqual({
         id: `${functionNameDefault}#${payloadHashes[0]}`,
@@ -197,14 +202,27 @@ describe(`Idempotency E2E tests, wrapper function usage`, () => {
       );
       /**
        * Each record should have a corresponding entry in the persistence store,
-       * if so then we sort the entries by expiry time and compare them to the
-       * expected values. Expiry times should be in the same order as the
-       * payload records.
+       * if so then we retrieve the records based on their custom IDs
+       * The records are retrieved in the same order as the payload records.
        */
       expect(idempotencyRecords.Items?.length).toEqual(3);
-      const idempotencyRecordsItems = idempotencyRecords.Items?.sort((a, b) =>
-        a.expiryAttr > b.expiryAttr ? 1 : -1
-      );
+      const idempotencyRecordsItems = [
+        idempotencyRecords.Items?.find(
+          (record) =>
+            record.customId ===
+            `${functionNameCustomConfig}#${payloadHashes[0]}`
+        ),
+        idempotencyRecords.Items?.find(
+          (record) =>
+            record.customId ===
+            `${functionNameCustomConfig}#${payloadHashes[1]}`
+        ),
+        idempotencyRecords.Items?.find(
+          (record) =>
+            record.customId ===
+            `${functionNameCustomConfig}#${payloadHashes[2]}`
+        ),
+      ];
 
       expect(idempotencyRecordsItems?.[0]).toStrictEqual({
         customId: `${functionNameCustomConfig}#${payloadHashes[0]}`,

--- a/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
+++ b/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
@@ -373,7 +373,7 @@ describe('Class: BasePersistenceLayer', () => {
         expect.objectContaining({
           idempotencyKey: 'my-lambda-function#mocked-hash',
           status: IdempotencyRecordStatus.INPROGRESS,
-          expiryTimestamp: Date.now() / 1000 + 3600,
+          expiryTimestamp: Math.round(Date.now() / 1000 + 3600),
           payloadHash: '',
           inProgressExpiryTimestamp: Date.now() + remainingTimeInMs,
           responseData: undefined,
@@ -443,7 +443,7 @@ describe('Class: BasePersistenceLayer', () => {
         expect.objectContaining({
           idempotencyKey: 'my-lambda-function#mocked-hash',
           status: IdempotencyRecordStatus.COMPLETED,
-          expiryTimestamp: Date.now() / 1000 + 3600,
+          expiryTimestamp: Math.round(Date.now() / 1000 + 3600),
           payloadHash: '',
           inProgressExpiryTimestamp: undefined,
           responseData: result,


### PR DESCRIPTION
## Summary

For consistency, we need to align timestamp formats for `expiration` and `in_progress_expiration` in idempotency table. To achieve this we have to round off `expiration` attribute.

### Changes

- Round off the return value of `getExpiryTimestamp` function
- Fix failing tests because of the rounding off

**Issue number:**  #2298

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
