### PR TITLE
fix(idempotency): preserve scope of decorated class

### DIFF
--- a/packages/idempotency/src/idempotencyDecorator.ts
+++ b/packages/idempotency/src/idempotencyDecorator.ts
@@ -1,3 +1,4 @@
+import type { Handler } from 'aws-lambda';
 import {
   AnyFunction,
   ItempotentFunctionOptions,
@@ -65,7 +66,10 @@ const idempotent = function (
     descriptor: PropertyDescriptor
   ) {
     const childFunction = descriptor.value;
-    descriptor.value = makeIdempotent(childFunction, options);
+
+    descriptor.value = async function (this: Handler, ...args: unknown[]) {
+      return makeIdempotent(childFunction, options).bind(this)(...args);
+    };
 
     return descriptor;
   };

--- a/packages/idempotency/src/makeIdempotent.ts
+++ b/packages/idempotency/src/makeIdempotent.ts
@@ -72,40 +72,6 @@ const isOptionsWithDataIndexArgument = (
  *
  * ```
  */
-/* const makeIdempotent = <Func extends AnyFunction>(
-  fn: Func,
-  options: ItempotentFunctionOptions<Parameters<Func>>,
-  thisArg: Handler
-): ((...args: Parameters<Func>) => ReturnType<Func>) => {
-  const { persistenceStore, config } = options;
-  const idempotencyConfig = config ? config : new IdempotencyConfig({});
-
-  if (!idempotencyConfig.isEnabled()) return fn;
-
-  return (...args: Parameters<Func>): ReturnType<Func> => {
-    let functionPayloadToBeHashed;
-
-    if (isFnHandler(fn, args)) {
-      idempotencyConfig.registerLambdaContext(args[1]);
-      functionPayloadToBeHashed = args[0];
-    } else {
-      if (isOptionsWithDataIndexArgument(options)) {
-        functionPayloadToBeHashed = args[options.dataIndexArgument];
-      } else {
-        functionPayloadToBeHashed = args[0];
-      }
-    }
-
-    return new IdempotencyHandler({
-      functionToMakeIdempotent: fn,
-      idempotencyConfig: idempotencyConfig,
-      persistenceStore: persistenceStore,
-      functionArguments: args,
-      functionPayloadToBeHashed,
-      thisArg,
-    }).handle() as ReturnType<Func>;
-  };
-}; */
 // eslint-disable-next-line func-style
 function makeIdempotent<Func extends AnyFunction>(
   fn: Func,
@@ -116,7 +82,7 @@ function makeIdempotent<Func extends AnyFunction>(
 
   if (!idempotencyConfig.isEnabled()) return fn;
 
-  return function (...args: Parameters<Func>): ReturnType<Func> {
+  return function (this: Handler, ...args: Parameters<Func>): ReturnType<Func> {
     let functionPayloadToBeHashed;
 
     if (isFnHandler(fn, args)) {
@@ -136,7 +102,6 @@ function makeIdempotent<Func extends AnyFunction>(
       persistenceStore: persistenceStore,
       functionArguments: args,
       functionPayloadToBeHashed,
-      // @ts-expect-error abc
       thisArg: this,
     }).handle() as ReturnType<Func>;
   };

--- a/packages/idempotency/src/types/IdempotencyOptions.ts
+++ b/packages/idempotency/src/types/IdempotencyOptions.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'aws-lambda';
+import type { Context, Handler } from 'aws-lambda';
 import type { BasePersistenceLayer } from '../persistence/BasePersistenceLayer.js';
 import type { IdempotencyConfig } from '../IdempotencyConfig.js';
 import type { JSONValue } from '@aws-lambda-powertools/commons/types';
@@ -139,6 +139,12 @@ type IdempotencyHandlerOptions = {
    * Persistence layer used to store the idempotency records.
    */
   persistenceStore: BasePersistenceLayer;
+  /**
+   * The `this` context to be used when calling the function.
+   *
+   * When decorating a class method, this will be the instance of the class.
+   */
+  thisArg?: Handler;
 };
 
 /**

--- a/packages/idempotency/tests/e2e/idempotentDecorator.test.FunctionCode.ts
+++ b/packages/idempotency/tests/e2e/idempotentDecorator.test.FunctionCode.ts
@@ -25,12 +25,14 @@ const dynamoDBPersistenceLayerCustomized = new DynamoDBPersistenceLayer({
 const config = new IdempotencyConfig({});
 
 class DefaultLambda implements LambdaInterface {
+  private readonly message = 'Got test event:';
+
   @idempotent({ persistenceStore: dynamoDBPersistenceLayer })
   public async handler(
     _event: Record<string, unknown>,
     _context: Context
   ): Promise<void> {
-    logger.info(`Got test event: ${JSON.stringify(_event)}`);
+    logger.info(`${this.message} ${JSON.stringify(_event)}`);
     // sleep to enforce error with parallel execution
     await new Promise((resolve) => setTimeout(resolve, 1000));
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR addresses the bug in the linked issue that caused class methods decorated with the `@idempotent` decorator to lose the original scope of the class.

In simpler terms, when working with classes it's common to reference other class methods or properties. In JavaScript this is done via the `this` keyword, which in the case of classes is bound to the class instance.

For example, in the code snippet below the `handler` method is able to access the `logger` property by using the `this` keyword, which at runtime is bound to the `fooInstance` instance.

```ts
export class Foo {
    private readonly logger = console;

    public async handler(event: unknown): Promise<string> {
        this.logger.debug('Received event');

        return 'success';
    }
}

const fooInstance = new Foo();
```

When working with class method decorators in TypeScript it's important to keep in mind that the decorator replaces the method implementation with one it defines. In doing so, it's important to pass down the original scope so that the decorated method maintains access to the `this` scope.

This PR makes changes to the `makeIdempotent` function, the `IdempotencyHandler` class, and the `idempotent` decorator implementation so that this happens.

Specifically, the PR:
- converts the `makeIdempotent` function from an arrow function to a regular function so that [it maintains a binding to `this`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
- modifies the `idempotent` decorator to explicitly `.bind(this)` on the `makeIdempotent` function when replacing the implementation of the decorated method
- updates the `IdempotencyHandler` to now accept a new `thisArg` parameter and restore it onto the original function when calling it

I have also added a new unit test case and modified one of the integration test cases to confirm that the fix works.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #2692

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
