### PR TITLE
chore(ci): update Dependabot groups for typedoc

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,8 +35,6 @@ updates:
     ignore:
       - dependency-name: "@middy/core"
         update-types: [ "version-update:semver-major" ]
-      - dependency-name: "lerna"
-        update-types: [ "version-update:semver-major" ]
     groups:
       aws-sdk-v3:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,15 +35,21 @@ updates:
     ignore:
       - dependency-name: "@middy/core"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "lerna"
+        update-types: [ "version-update:semver-major" ]
     groups:
-      aws-sdk:
+      aws-sdk-v3:
         patterns:
-        - "@aws-sdk/**"
-        - "@smithy/**"
+        - "@aws-sdk/*"
+        - "@smithy/*"
         - "aws-sdk-client-mock"
         - "aws-sdk-client-mock-jest"
       aws-cdk:
         patterns:
-        - "@aws-cdk/**"
+        - "@aws-cdk/*"
         - "aws-cdk-lib"
         - "aws-cdk"
+      typedoc:
+        patterns:
+        - "typedoc"
+        - "typedoc-plugin-*"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the Dependabot configuration to group together the `typedoc` module and its plugins so that the bot opens PRs for all the packages together.

This is beneficial since the plugins usually support a specific version or range of `typedoc`, which means upgrading one without the others is not desirable.

Typedoc updates usually come out together with new TypeScript "major" releases, so I could've added TS to the group as well, however I opted not to so that we have a discrete PR for TypeScript, given the large blast radius of a botched upgrade.

While touching the file, I also made two minor changes to other groups:
- Renamed the `aws-sdk` group to `aws-sdk-v3` so to not confuse it with PRs opened for the `aws-sdk` (v2) dependency
- Changed the wildcard patterns from `**` to `*`. I made this change because I noticed that [this CDK package](https://github.com/aws-powertools/powertools-lambda-typescript/blob/34c261e2b4643a4a85aec37235b98a78d1c6e0a8/packages/testing/package.json#L94-L95) was not being picked up, which is weird since the same glob pattern was working on the AWS SDK for JavaScript v3. After checking [the Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#example-1) I couldn't find any example of `**` so I changed to `*` which is used extensively.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #2715

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
