### PR TITLE
fix(idempotency): check error identity via names

### DIFF
--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -346,8 +346,11 @@ export class IdempotencyHandler<Func extends AnyFunction> {
 
       return returnValue;
     } catch (e) {
+      /* if (!(e instanceof Error)) throw e;
+      if (e.name === 'IdempotencyItemAlreadyExistsError') { */
       if (e instanceof IdempotencyItemAlreadyExistsError) {
-        let idempotencyRecord = e.existingRecord;
+        let idempotencyRecord = (e as IdempotencyItemAlreadyExistsError)
+          .existingRecord;
         if (idempotencyRecord !== undefined) {
           // If the error includes the existing record, we can use it to validate
           // the record being processed and cache it in memory.

--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -12,6 +12,7 @@ import {
   IdempotencyInconsistentStateError,
   IdempotencyItemAlreadyExistsError,
   IdempotencyPersistenceLayerError,
+  IdempotencyUnknownError,
 } from './errors.js';
 import { BasePersistenceLayer } from './persistence/BasePersistenceLayer.js';
 import { IdempotencyRecord } from './persistence/IdempotencyRecord.js';
@@ -176,8 +177,13 @@ export class IdempotencyHandler<Func extends AnyFunction> {
 
         return await this.getFunctionResult();
       } catch (error) {
+        if (!(error instanceof Error))
+          throw new IdempotencyUnknownError(
+            'An unknown error occurred while processing the request.',
+            { cause: error }
+          );
         if (
-          error instanceof IdempotencyInconsistentStateError &&
+          error.name === 'IdempotencyInconsistentStateError' &&
           retryNo < MAX_RETRIES
         ) {
           // Retry
@@ -241,7 +247,12 @@ export class IdempotencyHandler<Func extends AnyFunction> {
         break;
       } catch (error) {
         if (
-          error instanceof IdempotencyInconsistentStateError &&
+          /**
+           * It's safe to cast the error here because this catch block is only
+           * reached when an error is thrown in code paths that we control,
+           * and we only throw instances of `Error`.
+           */
+          (error as Error).name === 'IdempotencyInconsistentStateError' &&
           retryNo < MAX_RETRIES
         ) {
           // Retry
@@ -313,10 +324,10 @@ export class IdempotencyHandler<Func extends AnyFunction> {
       await this.#persistenceStore.deleteRecord(
         this.#functionPayloadToBeHashed
       );
-    } catch (e) {
+    } catch (error) {
       throw new IdempotencyPersistenceLayerError(
         'Failed to delete record from idempotency store',
-        e as Error
+        { cause: error }
       );
     }
   };
@@ -345,11 +356,14 @@ export class IdempotencyHandler<Func extends AnyFunction> {
       );
 
       return returnValue;
-    } catch (e) {
-      /* if (!(e instanceof Error)) throw e;
-      if (e.name === 'IdempotencyItemAlreadyExistsError') { */
-      if (e instanceof IdempotencyItemAlreadyExistsError) {
-        let idempotencyRecord = (e as IdempotencyItemAlreadyExistsError)
+    } catch (error) {
+      if (!(error instanceof Error))
+        throw new IdempotencyUnknownError(
+          'An unknown error occurred while processing the request.',
+          { cause: error }
+        );
+      if (error.name === 'IdempotencyItemAlreadyExistsError') {
+        let idempotencyRecord = (error as IdempotencyItemAlreadyExistsError)
           .existingRecord;
         if (idempotencyRecord !== undefined) {
           // If the error includes the existing record, we can use it to validate
@@ -377,7 +391,7 @@ export class IdempotencyHandler<Func extends AnyFunction> {
       } else {
         throw new IdempotencyPersistenceLayerError(
           'Failed to save in progress record to idempotency store',
-          e as Error
+          { cause: error }
         );
       }
     }
@@ -396,10 +410,10 @@ export class IdempotencyHandler<Func extends AnyFunction> {
         this.#functionPayloadToBeHashed,
         result
       );
-    } catch (e) {
+    } catch (error) {
       throw new IdempotencyPersistenceLayerError(
         'Failed to update success record to idempotency store',
-        e as Error
+        { cause: error }
       );
     }
   };

--- a/packages/idempotency/src/errors.ts
+++ b/packages/idempotency/src/errors.ts
@@ -8,6 +8,7 @@ class IdempotencyItemAlreadyExistsError extends Error {
 
   public constructor(message?: string, existingRecord?: IdempotencyRecord) {
     super(message);
+    this.name = 'IdempotencyItemAlreadyExistsError';
     this.existingRecord = existingRecord;
   }
 }

--- a/packages/idempotency/src/errors.ts
+++ b/packages/idempotency/src/errors.ts
@@ -1,13 +1,29 @@
 import type { IdempotencyRecord } from './persistence/IdempotencyRecord.js';
 
 /**
+ * Base error for idempotency errors.
+ *
+ * Generally this error should not be thrown directly unless you are throwing a generic and unknown error.
+ */
+class IdempotencyUnknownError extends Error {
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IdempotencyError';
+  }
+}
+
+/**
  * Item attempting to be inserted into persistence store already exists and is not expired
  */
-class IdempotencyItemAlreadyExistsError extends Error {
+class IdempotencyItemAlreadyExistsError extends IdempotencyUnknownError {
   public existingRecord?: IdempotencyRecord;
 
-  public constructor(message?: string, existingRecord?: IdempotencyRecord) {
-    super(message);
+  public constructor(
+    message?: string,
+    existingRecord?: IdempotencyRecord,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
     this.name = 'IdempotencyItemAlreadyExistsError';
     this.existingRecord = existingRecord;
   }
@@ -16,26 +32,53 @@ class IdempotencyItemAlreadyExistsError extends Error {
 /**
  * Item does not exist in persistence store
  */
-class IdempotencyItemNotFoundError extends Error {}
+class IdempotencyItemNotFoundError extends IdempotencyUnknownError {
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IdempotencyItemNotFoundError';
+  }
+}
 
 /**
  * Execution with idempotency key is already in progress
  */
-class IdempotencyAlreadyInProgressError extends Error {}
+class IdempotencyAlreadyInProgressError extends IdempotencyUnknownError {
+  public existingRecord?: IdempotencyRecord;
+
+  public constructor(
+    message?: string,
+    existingRecord?: IdempotencyRecord,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'IdempotencyAlreadyInProgressError';
+    this.existingRecord = existingRecord;
+  }
+}
 
 /**
  * An invalid status was provided
  */
-class IdempotencyInvalidStatusError extends Error {}
+class IdempotencyInvalidStatusError extends IdempotencyUnknownError {
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IdempotencyInvalidStatusError';
+  }
+}
 
 /**
  * Payload does not match stored idempotency record
  */
-class IdempotencyValidationError extends Error {
+class IdempotencyValidationError extends IdempotencyUnknownError {
   public existingRecord?: IdempotencyRecord;
 
-  public constructor(message?: string, existingRecord?: IdempotencyRecord) {
-    super(message);
+  public constructor(
+    message?: string,
+    existingRecord?: IdempotencyRecord,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'IdempotencyValidationError';
     this.existingRecord = existingRecord;
   }
 }
@@ -43,27 +86,37 @@ class IdempotencyValidationError extends Error {
 /**
  * State is inconsistent across multiple requests to persistence store
  */
-class IdempotencyInconsistentStateError extends Error {}
+class IdempotencyInconsistentStateError extends IdempotencyUnknownError {
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IdempotencyInconsistentStateError';
+  }
+}
 
 /**
  * Unrecoverable error from the data store
  */
-class IdempotencyPersistenceLayerError extends Error {
+class IdempotencyPersistenceLayerError extends IdempotencyUnknownError {
   public readonly cause: Error | undefined;
 
-  public constructor(message: string, cause: Error) {
-    const errorMessage = `${message}. This error was caused by: ${cause.message}.`;
-    super(errorMessage);
-    this.cause = cause;
+  public constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IdempotencyPersistenceLayerError';
   }
 }
 
 /**
  * Payload does not contain an idempotent key
  */
-class IdempotencyKeyError extends Error {}
+class IdempotencyKeyError extends IdempotencyUnknownError {
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'IdempotencyKeyError';
+  }
+}
 
 export {
+  IdempotencyUnknownError,
   IdempotencyItemAlreadyExistsError,
   IdempotencyItemNotFoundError,
   IdempotencyAlreadyInProgressError,

--- a/packages/idempotency/src/errors.ts
+++ b/packages/idempotency/src/errors.ts
@@ -8,7 +8,7 @@ import type { IdempotencyRecord } from './persistence/IdempotencyRecord.js';
 class IdempotencyUnknownError extends Error {
   public constructor(message?: string, options?: ErrorOptions) {
     super(message, options);
-    this.name = 'IdempotencyError';
+    this.name = 'IdempotencyUnknownError';
   }
 }
 

--- a/packages/idempotency/src/index.ts
+++ b/packages/idempotency/src/index.ts
@@ -7,6 +7,7 @@ export {
   IdempotencyInconsistentStateError,
   IdempotencyPersistenceLayerError,
   IdempotencyKeyError,
+  IdempotencyUnknownError,
 } from './errors.js';
 export { IdempotencyConfig } from './IdempotencyConfig.js';
 export { makeIdempotent } from './makeIdempotent.js';


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR makes changes to the custom errors that can be thrown by the Idempotency utility so that their respective [`name` property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name) is set to the actual name of the error, for example:

```diff
class IdempotencyUnknownError extends Error {
  public constructor(message?: string, options?: ErrorOptions) {
    super(message, options);
+   this.name = 'IdempotencyUnknownError';
  }
}
```

This change allows to handle errors without having to import the error class itself, and without having to rely on a [referential identity](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness) check (i.e. `error instanceof IdempotencyUnknownError`).

Currently, we use `error instanceof ...` in several places within the internals of the utility. This is a result of two factors: **a/** the implementation relies heavily on throwing errors as a way of controlling flow, and **b/** composition and object-oriented programming patterns are prevalent, with errors being thrown in certain code paths and then handled gracefully with `try/catch` blocks in other parts. 

For example, we have a few instances in which we do something [like this](https://github.com/aws-powertools/powertools-lambda-typescript/blob/416093ed0fdc582f2e5e8c3db1662a4498c5f4ed/packages/idempotency/src/IdempotencyHandler.ts#L172C7-L189C8):

```ts
try {
  const { isIdempotent, result } =
    await this.#saveInProgressOrReturnExistingResult();
  if (isIdempotent) return result as ReturnType<Func>;

  return await this.getFunctionResult();
} catch (error) {
  if (
    error instanceof IdempotencyInconsistentStateError &&
    retryNo < MAX_RETRIES
  ) {
    // Retry
    continue;
  }
  // Retries exhausted or other error
  e = error;
  break;
}
```

Without getting too much into the weeds of what the code above does, the important parts to know are that:
1. we run some code in the `try` block - this code might throw either an error that we can recover from, or other types of errors that we can't handle
2. in the `catch` block we check if the error being caught is one that we know how to handle
  - if this is the case, we handle it
  - if not, we re-throw it

Because the code above relies on `instanceof`, JavaScript checks that the object in the left side of the statement is an instance of the class in the right side which might not be the case (for [a number of reasons](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness)). 

One of these reasons can happen because of the famed [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard), which in simple terms means when one part of your code imports the CommonJS (CJS) version of a module, and another part of your code imports the same module but using ECMAScript modules (ESM).

This is something that our utilities are naturally exposed to since we started shipping ESM and CJS in v2.0. This is a tradeoff that we accepted at the time to allow customers to use Powertools for AWS Lambda regardless of what they used. 

In practice, this is relatively unlikely to happen to our customers since our utilities have only a few entry points and most of them do a relatively good job [at isolating state](https://nodejs.org/api/packages.html#approach-2-isolate-state). This PR tries to address one of the areas that did not do this propertly.

Specifically, under certain circumstances ([[1]](https://github.com/aws-powertools/powertools-lambda-typescript/issues/2517#issuecomment-2212531459) & [[2]](https://github.com/aws-powertools/powertools-lambda-typescript/issues/2517#issuecomment-2212538881)) customers might end up with multiple copies of the errors defined in the Idempotency utility.

When this happens, the internal flow of the utility breaks down causing requests to be repeated, which is what was happening in the linked issue. Once the changes in this PR are merged, it will be possible the utility should be more resilient to this type of issue because the checks on errors won't rely on referential identity anymore.

For example, the code from above would change to this:

```ts
try {
  const { isIdempotent, result } =
    await this.#saveInProgressOrReturnExistingResult();
  if (isIdempotent) return result as ReturnType<Func>;

  return await this.getFunctionResult();
} catch (error) {
  if (!(error instanceof Error))
    throw new IdempotencyUnknownError(
      'An unknown error occurred while processing the request.',
      { cause: error }
    );
  if (
    error.name === 'IdempotencyInconsistentStateError' && // we now use `error.name` instead of instanceof
    retryNo < MAX_RETRIES
  ) {
    // Retry
    continue;
  }
  // Retries exhausted or other error
  e = error;
  break;
}
```

With the changes above, it won't matter if the objects don't share the same identity, meaning that as long as they share the same implementation the utility will behave as expected.

There are additional areas of improvements that we can address to further decrease the risk of dual-package hazard such as providing even more granular subpath scoped exports (i.e. this customer was importing `IdempotencyConfig` via default export - aka barrel file - which caused the errors to be brought in because they're exported in the `packages/idempotency/src/index.ts` file [here](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/packages/idempotency/src/index.ts#L1-L10)). However, in the interest of keeping this essay short (_lol_) and the PR focused I'll look into making these changes in a future PR.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #2517

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
