### PR TITLE
fix(parser): links the error cause with ParseError

### DIFF
--- a/packages/parser/src/errors.ts
+++ b/packages/parser/src/errors.ts
@@ -8,6 +8,7 @@ class ParseError extends Error {
       ? `${message}. This error was caused by: ${options?.cause.message}.`
       : message;
     super(errorMessage);
+    this.cause = options?.cause;
     this.name = 'ParseError';
   }
 }

--- a/packages/parser/src/errors.ts
+++ b/packages/parser/src/errors.ts
@@ -7,8 +7,7 @@ class ParseError extends Error {
     const errorMessage = options?.cause
       ? `${message}. This error was caused by: ${options?.cause.message}.`
       : message;
-    super(errorMessage);
-    this.cause = options?.cause;
+    super(errorMessage, options);
     this.name = 'ParseError';
   }
 }

--- a/packages/parser/tests/unit/envelope.test.ts
+++ b/packages/parser/tests/unit/envelope.test.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 import { Envelope } from '../../src/envelopes/envelope.js';
 import { ParseError } from '../../src/errors.js';
 
@@ -73,6 +73,13 @@ describe('envelope: ', () => {
       expect(() =>
         Envelope.parse({ name: 123 }, z.object({ name: z.string() }))
       ).toThrow();
+    });
+    it('the error has the cause attached to it', () => {
+      try {
+        Envelope.parse('{"name": "John"}', z.object({ name: z.number() }));
+      } catch (error) {
+        expect((error as { cause: Error }).cause).toBeInstanceOf(ZodError);
+      }
     });
   });
 });

--- a/packages/parser/tests/unit/envelope.test.ts
+++ b/packages/parser/tests/unit/envelope.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Test decorator parser
+ *
+ * @group unit/parser
+ */
+
 import { z, ZodError } from 'zod';
 import { Envelope } from '../../src/envelopes/envelope.js';
 import { ParseError } from '../../src/errors.js';
@@ -74,11 +80,11 @@ describe('envelope: ', () => {
         Envelope.parse({ name: 123 }, z.object({ name: z.string() }))
       ).toThrow();
     });
-    it('the error has the cause attached to it', () => {
+    it('includes the ZodError as the cause of the ParseError', () => {
       try {
         Envelope.parse('{"name": "John"}', z.object({ name: z.number() }));
       } catch (error) {
-        expect((error as { cause: Error }).cause).toBeInstanceOf(ZodError);
+        expect((error as Error).cause).toBeInstanceOf(ZodError);
       }
     });
   });


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

The ParseError links the passed error cause with the thrown error. 

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #2773

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
