### PR TITLE
feat(parser): allow parser set event type of handler with middy

### DIFF
--- a/packages/parser/src/envelopes/cloudwatch.ts
+++ b/packages/parser/src/envelopes/cloudwatch.ts
@@ -17,7 +17,7 @@ export class CloudWatchEnvelope extends Envelope {
   public static parse<T extends ZodSchema>(
     data: unknown,
     schema: T
-  ): z.infer<T> {
+  ): z.infer<T>[] {
     const parsedEnvelope = CloudWatchLogsSchema.parse(data);
 
     return parsedEnvelope.awslogs.data.logEvents.map((record) => {

--- a/packages/parser/src/envelopes/dynamodb.ts
+++ b/packages/parser/src/envelopes/dynamodb.ts
@@ -3,11 +3,7 @@ import { DynamoDBStreamSchema } from '../schemas/index.js';
 import type { ParsedResult, ParsedResultError } from '../types/index.js';
 import { Envelope } from './envelope.js';
 import { ParseError } from '../errors.js';
-
-type DynamoDBStreamEnvelopeResponse<T extends ZodSchema> = {
-  NewImage: z.infer<T>;
-  OldImage: z.infer<T>;
-};
+import type { DynamoDBStreamEnvelopeResponse } from '../types/envelope.js';
 
 /**
  * DynamoDB Stream Envelope to extract data within NewImage/OldImage

--- a/packages/parser/src/envelopes/kafka.ts
+++ b/packages/parser/src/envelopes/kafka.ts
@@ -20,7 +20,7 @@ export class KafkaEnvelope extends Envelope {
   public static parse<T extends ZodSchema>(
     data: unknown,
     schema: T
-  ): z.infer<T> {
+  ): z.infer<T>[] {
     // manually fetch event source to deside between Msk or SelfManaged
     const eventSource = (data as KafkaMskEvent)['eventSource'];
 

--- a/packages/parser/src/envelopes/kinesis-firehose.ts
+++ b/packages/parser/src/envelopes/kinesis-firehose.ts
@@ -20,7 +20,7 @@ export class KinesisFirehoseEnvelope extends Envelope {
   public static parse<T extends ZodSchema>(
     data: unknown,
     schema: T
-  ): z.infer<T> {
+  ): z.infer<T>[] {
     const parsedEnvelope = KinesisFirehoseSchema.parse(data);
 
     return parsedEnvelope.records.map((record) => {

--- a/packages/parser/src/envelopes/kinesis.ts
+++ b/packages/parser/src/envelopes/kinesis.ts
@@ -18,7 +18,7 @@ export class KinesisEnvelope extends Envelope {
   public static parse<T extends ZodSchema>(
     data: unknown,
     schema: T
-  ): z.infer<T> {
+  ): z.infer<T>[] {
     const parsedEnvelope = KinesisDataStreamSchema.parse(data);
 
     return parsedEnvelope.Records.map((record) => {

--- a/packages/parser/src/envelopes/sns.ts
+++ b/packages/parser/src/envelopes/sns.ts
@@ -18,7 +18,7 @@ export class SnsEnvelope extends Envelope {
   public static parse<T extends ZodSchema>(
     data: unknown,
     schema: T
-  ): z.infer<T> {
+  ): z.infer<T>[] {
     const parsedEnvelope = SnsSchema.parse(data);
 
     return parsedEnvelope.Records.map((record) => {

--- a/packages/parser/src/envelopes/sqs.ts
+++ b/packages/parser/src/envelopes/sqs.ts
@@ -9,7 +9,7 @@ import { ParseError } from '../errors.js';
  *
  *  The record's body parameter is a string, though it can also be a JSON encoded string.
  *  Regardless of its type it'll be parsed into a BaseModel object.
- *w
+ *
  *  Note: Records will be parsed the same way so if model is str,
  *  all items in the list will be parsed as str and npt as JSON (and vice versa)
  */

--- a/packages/parser/src/envelopes/sqs.ts
+++ b/packages/parser/src/envelopes/sqs.ts
@@ -9,7 +9,7 @@ import { ParseError } from '../errors.js';
  *
  *  The record's body parameter is a string, though it can also be a JSON encoded string.
  *  Regardless of its type it'll be parsed into a BaseModel object.
- *
+ *w
  *  Note: Records will be parsed the same way so if model is str,
  *  all items in the list will be parsed as str and npt as JSON (and vice versa)
  */
@@ -17,7 +17,7 @@ export class SqsEnvelope extends Envelope {
   public static parse<T extends ZodSchema>(
     data: unknown,
     schema: T
-  ): z.infer<T> {
+  ): z.infer<T>[] {
     const parsedEnvelope = SqsSchema.parse(data);
 
     return parsedEnvelope.Records.map((record) => {

--- a/packages/parser/src/middleware/parser.ts
+++ b/packages/parser/src/middleware/parser.ts
@@ -1,8 +1,9 @@
 import { type MiddyLikeRequest } from '@aws-lambda-powertools/commons/types';
 import { type MiddlewareObj } from '@middy/core';
-import { type ZodSchema } from 'zod';
-import { type ParserOptions } from '../types/parser.js';
+import { ZodType } from 'zod';
+import type { ParserOptions, ParseOutput } from '../types/parser.js';
 import { parse } from '../parser.js';
+import type { Envelope } from '../types/envelope.js';
 
 /**
  * A middiy middleware to parse your event.
@@ -32,9 +33,13 @@ import { parse } from '../parser.js';
  *
  * @param options
  */
-const parser = <S extends ZodSchema>(
-  options: ParserOptions<S>
-): MiddlewareObj => {
+const parser = <
+  TSchema extends ZodType,
+  TEnvelope extends Envelope = undefined,
+  TSafeParse extends boolean = false,
+>(
+  options: ParserOptions<TSchema, TEnvelope, TSafeParse>
+): MiddlewareObj<ParseOutput<TSchema, TEnvelope, TSafeParse>> => {
   const before = (request: MiddyLikeRequest): void => {
     const { schema, envelope, safeParse } = options;
 

--- a/packages/parser/src/middleware/parser.ts
+++ b/packages/parser/src/middleware/parser.ts
@@ -1,7 +1,7 @@
 import { type MiddyLikeRequest } from '@aws-lambda-powertools/commons/types';
 import { type MiddlewareObj } from '@middy/core';
 import { ZodType } from 'zod';
-import type { ParserOptions, ParseOutput } from '../types/parser.js';
+import type { ParserOptions, ParserOutput } from '../types/parser.js';
 import { parse } from '../parser.js';
 import type { Envelope } from '../types/envelope.js';
 
@@ -39,7 +39,7 @@ const parser = <
   TSafeParse extends boolean = false,
 >(
   options: ParserOptions<TSchema, TEnvelope, TSafeParse>
-): MiddlewareObj<ParseOutput<TSchema, TEnvelope, TSafeParse>> => {
+): MiddlewareObj<ParserOutput<TSchema, TEnvelope, TSafeParse>> => {
   const before = (request: MiddyLikeRequest): void => {
     const { schema, envelope, safeParse } = options;
 

--- a/packages/parser/src/parserDecorator.ts
+++ b/packages/parser/src/parserDecorator.ts
@@ -3,7 +3,7 @@ import type { Context, Handler } from 'aws-lambda';
 import { type ZodSchema } from 'zod';
 import { parse } from './parser.js';
 import type { ParserOptions, Envelope } from './types/index.js';
-import type { ParseOutput } from './types/parser.js';
+import type { ParserOutput } from './types/parser.js';
 
 /**
  * A decorator to parse your event.
@@ -82,7 +82,7 @@ export const parser = <
 
     descriptor.value = async function (
       this: Handler,
-      event: ParseOutput<TSchema, TEnvelope, TSafeParse>,
+      event: ParserOutput<TSchema, TEnvelope, TSafeParse>,
       context: Context,
       callback
     ) {

--- a/packages/parser/src/parserDecorator.ts
+++ b/packages/parser/src/parserDecorator.ts
@@ -1,8 +1,9 @@
 import type { HandlerMethodDecorator } from '@aws-lambda-powertools/commons/types';
 import type { Context, Handler } from 'aws-lambda';
-import { ZodSchema, z } from 'zod';
+import { type ZodSchema } from 'zod';
 import { parse } from './parser.js';
-import type { ParserOptions, ParsedResult } from './types/index.js';
+import type { ParserOptions, Envelope } from './types/index.js';
+import type { ParseOutput } from './types/parser.js';
 
 /**
  * A decorator to parse your event.
@@ -67,8 +68,12 @@ import type { ParserOptions, ParsedResult } from './types/index.js';
  *
  * @param options Configure the parser with the `schema`, `envelope` and whether to `safeParse` or not
  */
-export const parser = <S extends ZodSchema>(
-  options: ParserOptions<S>
+export const parser = <
+  TSchema extends ZodSchema,
+  TEnvelope extends Envelope = undefined,
+  TSafeParse extends boolean = false,
+>(
+  options: ParserOptions<TSchema, TEnvelope, TSafeParse>
 ): HandlerMethodDecorator => {
   return (_target, _propertyKey, descriptor) => {
     const original = descriptor.value!;
@@ -77,14 +82,11 @@ export const parser = <S extends ZodSchema>(
 
     descriptor.value = async function (
       this: Handler,
-      event: unknown,
+      event: ParseOutput<TSchema, TEnvelope, TSafeParse>,
       context: Context,
       callback
     ) {
-      const parsedEvent: ParsedResult<
-        typeof event,
-        z.infer<typeof schema>
-      > = parse(event, envelope, schema, safeParse);
+      const parsedEvent = parse(event, envelope, schema, safeParse);
 
       return original.call(this, parsedEvent, context, callback);
     };

--- a/packages/parser/src/types/envelope.ts
+++ b/packages/parser/src/types/envelope.ts
@@ -14,8 +14,14 @@ import type {
   VpcLatticeEnvelope,
   VpcLatticeV2Envelope,
 } from '../envelopes/index.js';
+import { z, type ZodSchema } from 'zod';
 
-export type Envelope =
+type DynamoDBStreamEnvelopeResponse<Schema extends ZodSchema> = {
+  NewImage: z.infer<Schema>;
+  OldImage: z.infer<Schema>;
+};
+
+type Envelope =
   | typeof ApiGatewayEnvelope
   | typeof ApiGatewayV2Envelope
   | typeof CloudWatchEnvelope
@@ -29,4 +35,23 @@ export type Envelope =
   | typeof SnsSqsEnvelope
   | typeof SqsEnvelope
   | typeof VpcLatticeEnvelope
-  | typeof VpcLatticeV2Envelope;
+  | typeof VpcLatticeV2Envelope
+  | undefined;
+
+/**
+ * Envelopes that return an array, needed to narrow down the return type of the parser
+ */
+type EnvelopeArrayReturnType =
+  | typeof CloudWatchEnvelope
+  | typeof DynamoDBStreamEnvelope
+  | typeof KafkaEnvelope
+  | typeof KinesisEnvelope
+  | typeof KinesisFirehoseEnvelope
+  | typeof SnsEnvelope
+  | typeof SqsEnvelope;
+
+export type {
+  Envelope,
+  DynamoDBStreamEnvelopeResponse,
+  EnvelopeArrayReturnType,
+};

--- a/packages/parser/src/types/parser.ts
+++ b/packages/parser/src/types/parser.ts
@@ -62,7 +62,7 @@ type ZodInferredSafeParseResult<
 /**
  * The output of the parser function, can be either schema inferred type or a ParsedResult
  */
-type ParseOutput<
+type ParserOutput<
   TSchema extends ZodSchema,
   TEnvelope extends Envelope,
   TSafeParse = false,
@@ -79,5 +79,5 @@ export type {
   ParsedResult,
   ParsedResultError,
   ParsedResultSuccess,
-  ParseOutput,
+  ParserOutput,
 };

--- a/packages/parser/src/types/parser.ts
+++ b/packages/parser/src/types/parser.ts
@@ -1,13 +1,17 @@
-import type { ZodSchema, ZodError } from 'zod';
-import type { Envelope } from './envelope.js';
+import { type ZodSchema, type ZodError, z } from 'zod';
+import type { Envelope, EnvelopeArrayReturnType } from './envelope.js';
 
 /**
  * Options for the parser used in middy middleware and decorator
  */
-type ParserOptions<S extends ZodSchema> = {
-  schema: S;
-  envelope?: Envelope;
-  safeParse?: boolean;
+type ParserOptions<
+  TSchema extends ZodSchema,
+  TEnvelope extends Envelope,
+  TSafeParse extends boolean,
+> = {
+  schema: TSchema;
+  envelope?: TEnvelope;
+  safeParse?: TSafeParse;
 };
 
 /**
@@ -34,9 +38,46 @@ type ParsedResult<Input = unknown, Output = unknown> =
   | ParsedResultSuccess<Output>
   | ParsedResultError<Input>;
 
+/**
+ * The inferred result of the schema, can be either an array or a single object depending on the envelope
+ */
+type ZodInferredResult<
+  TSchema extends ZodSchema,
+  TEnvelope extends Envelope,
+> = undefined extends TEnvelope
+  ? z.infer<TSchema>
+  : TEnvelope extends EnvelopeArrayReturnType
+    ? z.infer<TSchema>[]
+    : z.infer<TSchema>;
+
+type ZodInferredSafeParseResult<
+  TSchema extends ZodSchema,
+  TEnvelope extends Envelope,
+> = undefined extends TEnvelope
+  ? ParsedResult<unknown, z.infer<TSchema>>
+  : TEnvelope extends EnvelopeArrayReturnType
+    ? ParsedResult<unknown, z.infer<TSchema>>
+    : ParsedResult<unknown, z.infer<TSchema>[]>;
+
+/**
+ * The output of the parser function, can be either schema inferred type or a ParsedResult
+ */
+type ParseOutput<
+  TSchema extends ZodSchema,
+  TEnvelope extends Envelope,
+  TSafeParse = false,
+> = undefined extends TSafeParse
+  ? ZodInferredResult<TSchema, TEnvelope>
+  : TSafeParse extends true
+    ? ZodInferredSafeParseResult<TSchema, TEnvelope>
+    : TSafeParse extends false
+      ? ZodInferredResult<TSchema, TEnvelope>
+      : never;
+
 export type {
   ParserOptions,
   ParsedResult,
   ParsedResultError,
   ParsedResultSuccess,
+  ParseOutput,
 };

--- a/packages/parser/tests/unit/parser.decorator.test.ts
+++ b/packages/parser/tests/unit/parser.decorator.test.ts
@@ -27,7 +27,7 @@ describe('Parser Decorator', () => {
     public async handler(
       event: TestEvent,
       _context: Context
-    ): Promise<unknown> {
+    ): Promise<TestEvent> {
       return event;
     }
 
@@ -60,7 +60,7 @@ describe('Parser Decorator', () => {
       safeParse: true,
     })
     public async handlerWithSchemaAndSafeParse(
-      event: ParsedResult<TestEvent, TestEvent>,
+      event: ParsedResult<unknown, TestEvent>,
       _context: Context
     ): Promise<ParsedResult> {
       return event;
@@ -99,9 +99,7 @@ describe('Parser Decorator', () => {
     testEvent.detail = customPayload;
 
     const resp = await lambda.handlerWithSchemaAndEnvelope(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      testEvent,
+      testEvent as unknown as TestEvent,
       {} as Context
     );
 
@@ -130,9 +128,7 @@ describe('Parser Decorator', () => {
     testEvent.detail = customPayload;
 
     const resp = await lambda.handlerWithParserCallsAnotherMethod(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      testEvent,
+      testEvent as unknown as TestEvent,
       {} as Context
     );
 
@@ -143,9 +139,7 @@ describe('Parser Decorator', () => {
     const testEvent = generateMock(TestSchema);
 
     const resp = await lambda.handlerWithSchemaAndSafeParse(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      testEvent,
+      testEvent as unknown as ParsedResult<unknown, TestEvent>,
       {} as Context
     );
 
@@ -157,9 +151,10 @@ describe('Parser Decorator', () => {
 
   it('should parse event with schema and safeParse and return error', async () => {
     expect(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      await lambda.handlerWithSchemaAndSafeParse({ foo: 'bar' }, {} as Context)
+      await lambda.handlerWithSchemaAndSafeParse(
+        { foo: 'bar' } as unknown as ParsedResult<unknown, TestEvent>,
+        {} as Context
+      )
     ).toEqual({
       error: expect.any(ParseError),
       success: false,
@@ -173,9 +168,7 @@ describe('Parser Decorator', () => {
     event.detail = testEvent;
 
     const resp = await lambda.harndlerWithEnvelopeAndSafeParse(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      event,
+      event as unknown as ParsedResult<TestEvent, TestEvent>,
       {} as Context
     );
 
@@ -188,9 +181,7 @@ describe('Parser Decorator', () => {
   it('should parse event with envelope and safeParse and return error', async () => {
     expect(
       await lambda.harndlerWithEnvelopeAndSafeParse(
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        { foo: 'bar' },
+        { foo: 'bar' } as unknown as ParsedResult<TestEvent, TestEvent>,
         {} as Context
       )
     ).toEqual({


### PR DESCRIPTION
## Summary

This PR introduces type inference for event type of handler when using parser with middy middleware. Based on the combination of provided inputs (schema, envelope, safeParse) the type can change between a single object, an array (i.e. `SqsEnvelope`) and safeParse, where we wrap the result into `ParsedResult`. I have modified the unit tests to use the inference which should have an error, if the type inference breaks.

### Changes

* fixed return types to array for envelopes that return multiple items of provided schema objects
* added `ParseOutput` to narrow down the type of the modified event
* moved `DynamoDBStreamEnvelopeResponse` to types folder
* replaced eslit comments with type casts in unit tests as mentioned in our docs

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #2407 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
