### PR TITLE
feat(logger): introduce loglevel constant

### DIFF
--- a/packages/logger/src/constants.ts
+++ b/packages/logger/src/constants.ts
@@ -14,4 +14,13 @@ const LogJsonIndent = {
   COMPACT: 0,
 } as const;
 
-export { LogJsonIndent };
+const LogLevel = {
+  DEBUG: 'DEBUG',
+  INFO: 'INFO',
+  WARN: 'WARN',
+  ERROR: 'ERROR',
+  SILENT: 'SILENT',
+  CRITICAL: 'CRITICAL',
+} as const;
+
+export { LogJsonIndent, LogLevel };

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,3 +1,4 @@
 export { Logger } from './Logger.js';
 export { LogFormatter } from './formatter/LogFormatter.js';
 export { LogItem } from './formatter/LogItem.js';
+export { LogLevel } from './constants.js';

--- a/packages/logger/src/types/Log.ts
+++ b/packages/logger/src/types/Log.ts
@@ -1,27 +1,11 @@
 import type { EnvironmentVariablesService } from '../config/EnvironmentVariablesService.js';
 import type { LogItem } from '../formatter/LogItem.js';
 import type { UnformattedAttributes } from './Logger.js';
-
-type LogLevelDebug = 'DEBUG';
-type LogLevelInfo = 'INFO';
-type LogLevelWarn = 'WARN';
-type LogLevelError = 'ERROR';
-type LogLevelSilent = 'SILENT';
-type LogLevelCritical = 'CRITICAL';
+import { LogLevel } from '../constants.js';
 
 type LogLevel =
-  | LogLevelDebug
-  | Lowercase<LogLevelDebug>
-  | LogLevelInfo
-  | Lowercase<LogLevelInfo>
-  | LogLevelWarn
-  | Lowercase<LogLevelWarn>
-  | LogLevelError
-  | Lowercase<LogLevelError>
-  | LogLevelSilent
-  | Lowercase<LogLevelSilent>
-  | LogLevelCritical
-  | Lowercase<LogLevelCritical>;
+  | (typeof LogLevel)[keyof typeof LogLevel]
+  | Lowercase<(typeof LogLevel)[keyof typeof LogLevel]>;
 
 type LogLevelThresholds = {
   [key in Uppercase<LogLevel>]: number;

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -5,11 +5,14 @@
  */
 import context from '@aws-lambda-powertools/testing-utils/context';
 import type { LambdaInterface } from '@aws-lambda-powertools/commons/types';
-import { Logger, LogFormatter } from '../../src/index.js';
+import { Logger, LogFormatter, LogLevel } from '../../src/index.js';
 import { ConfigServiceInterface } from '../../src/types/ConfigServiceInterface.js';
 import { EnvironmentVariablesService } from '../../src/config/EnvironmentVariablesService.js';
 import { PowertoolsLogFormatter } from '../../src/formatter/PowertoolsLogFormatter.js';
-import { LogLevelThresholds, LogLevel } from '../../src/types/Log.js';
+import {
+  LogLevelThresholds,
+  type LogLevel as LogLevelType,
+} from '../../src/types/Log.js';
 import {
   type LogFunction,
   type ConstructorOptions,
@@ -598,7 +601,7 @@ describe('Class: Logger', () => {
         test(`when the level is DEBUG, it ${debugAction} print to stdout`, () => {
           // Prepare
           const logger = new Logger({
-            logLevel: 'DEBUG',
+            logLevel: LogLevel.DEBUG,
           });
           const consoleSpy = jest.spyOn(
             logger['console'],
@@ -656,7 +659,7 @@ describe('Class: Logger', () => {
         test(`when the log level is WARN, it ${warnAction} print to stdout`, () => {
           // Prepare
           const logger = new Logger({
-            logLevel: 'WARN',
+            logLevel: LogLevel.WARN,
           });
           const consoleSpy = jest.spyOn(
             logger['console'],
@@ -714,7 +717,7 @@ describe('Class: Logger', () => {
         test('when the log level is SILENT, it DOES NOT print to stdout', () => {
           // Prepare
           const logger = new Logger({
-            logLevel: 'SILENT',
+            logLevel: LogLevel.SILENT,
           });
           const consoleSpy = jest.spyOn(
             logger['console'],
@@ -2347,7 +2350,7 @@ describe('Class: Logger', () => {
     test('when logEvent is enabled, it logs the event in the first log', async () => {
       // Prepare
       const logger = new Logger({
-        logLevel: 'DEBUG',
+        logLevel: LogLevel.DEBUG,
       });
       const consoleSpy = jest.spyOn(logger['console'], 'info');
       class LambdaFunction implements LambdaInterface {
@@ -3141,7 +3144,7 @@ describe('Class: Logger', () => {
       const logger = new Logger();
 
       // Act
-      logger.setLogLevel('ERROR');
+      logger.setLogLevel(LogLevel.ERROR);
 
       // Assess
       expect(logger.level).toBe(20);
@@ -3153,7 +3156,7 @@ describe('Class: Logger', () => {
       const logger = new Logger();
 
       // Act & Assess
-      expect(() => logger.setLogLevel('INVALID' as LogLevel)).toThrow(
+      expect(() => logger.setLogLevel('INVALID' as LogLevelType)).toThrow(
         'Invalid log level: INVALID'
       );
     });
@@ -3240,7 +3243,7 @@ describe('Class: Logger', () => {
       process.env.POWERTOOLS_LOGGER_SAMPLE_RATE = '1';
 
       const logger: Logger = new Logger({
-        logLevel: 'ERROR',
+        logLevel: LogLevel.ERROR,
       });
 
       // Assess
@@ -3396,7 +3399,7 @@ describe('Class: Logger', () => {
     test('when sample rate in constructor is out of expected range, it should be ignored', () => {
       // Prepare
       const logger: Logger = new Logger({
-        logLevel: 'INFO',
+        logLevel: LogLevel.INFO,
         sampleRateValue: 42,
       });
       const consoleSpy = jest.spyOn(logger['console'], 'info');
@@ -3498,7 +3501,7 @@ describe('Class: Logger', () => {
       test('when sample rate calculation is refreshed, it DOES NOT overwrite the sample rate value', () => {
         // Prepare
         const logger = new Logger({
-          logLevel: 'INFO',
+          logLevel: LogLevel.INFO,
           sampleRateValue: 1,
         });
         const consoleSpy = jest.spyOn(logger['console'], 'info');


### PR DESCRIPTION
## Summary

### Changes

This PR converts the existing LogLevel type definition to a more concise and maintainable enum-like structure using a const object. It also simplifies the LogLevel type to utilize this new structure.

Introduced a new LogLevel const object in `packages/logger/src/constants.ts`:
```typescript
const LogLevel = {
  DEBUG: 'DEBUG',
  INFO: 'INFO',
  WARN: 'WARN',
  ERROR: 'ERROR',
  SILENT: 'SILENT',
  CRITICAL: 'CRITICAL',
} as const;
```

Imported the constants in `packages/logger/src/types/Log.ts` and replace the existing types 
```diff
+import { LogLevel } from '../constants.js';

- type LogLevelDebug = 'DEBUG';
- type LogLevelInfo = 'INFO';
- type LogLevelWarn = 'WARN';
- type LogLevelError = 'ERROR';
- type LogLevelSilent = 'SILENT';
- type LogLevelCritical = 'CRITICAL';

type LogLevel =
-   | LogLevelDebug
-   | Lowercase<LogLevelDebug>
-   | LogLevelInfo
-   | Lowercase<LogLevelInfo>
-   | LogLevelWarn
-   | Lowercase<LogLevelWarn>
-   | LogLevelError
-   | Lowercase<LogLevelError>
-   | LogLevelSilent
-   | Lowercase<LogLevelSilent>
-   | LogLevelCritical
-   | Lowercase<LogLevelCritical>;
+   | (typeof LogLevel)[keyof typeof LogLevel]
+   | Lowercase<(typeof LogLevel)[keyof typeof LogLevel]>;
```

#### Usage

The newly introduced constants can be used to set the log level for the logger. 
Example:

```typescript
const logger = new Logger({
  logLevel: LogLevel.DEBUG,
});
```


**Issue number:** #2780 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
