### PR TITLE
chore(maintenance): migrate logger utility to biome

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -20,8 +20,8 @@
     "build:cjs": "tsc --build tsconfig.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
     "build:esm": "tsc --build tsconfig.esm.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build": "npm run build:esm & npm run build:cjs",
-    "lint": "eslint --ext .ts,.js --no-error-on-unmatched-pattern .",
-    "lint-fix": "eslint --fix --ext .ts,.js --no-error-on-unmatched-pattern .",
+    "lint": "biome lint .",
+    "lint:fix": "biome check --write .",
     "prepack": "node ../../.github/scripts/release_patch_package_json.js ."
   },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/logger#readme",
@@ -53,10 +53,7 @@
         "lib/cjs/middleware/middy.d.ts",
         "lib/esm/middleware/middy.d.ts"
       ],
-      "types": [
-        "lib/cjs/types/index.d.ts",
-        "lib/esm/types/index.d.ts"
-      ]
+      "types": ["lib/cjs/types/index.d.ts", "lib/esm/types/index.d.ts"]
     }
   },
   "types": "./lib/cjs/index.d.ts",
@@ -73,9 +70,7 @@
       "optional": true
     }
   },
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-powertools/powertools-lambda-typescript.git"

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1,30 +1,30 @@
+import { Console } from 'node:console';
+import { randomInt } from 'node:crypto';
 import { Utility } from '@aws-lambda-powertools/commons';
 import type { HandlerMethodDecorator } from '@aws-lambda-powertools/commons/types';
 import type { Context, Handler } from 'aws-lambda';
 import merge from 'lodash.merge';
-import { Console } from 'node:console';
-import { randomInt } from 'node:crypto';
 import { EnvironmentVariablesService } from './config/EnvironmentVariablesService.js';
 import { LogJsonIndent } from './constants.js';
-import { LogItem } from './formatter/LogItem.js';
+import type { LogItem } from './formatter/LogItem.js';
 import { PowertoolsLogFormatter } from './formatter/PowertoolsLogFormatter.js';
 import type { ConfigServiceInterface } from './types/ConfigServiceInterface.js';
 import type {
   Environment,
   LogAttributes,
+  LogFormatterInterface,
   LogLevel,
   LogLevelThresholds,
-  LogFormatterInterface,
 } from './types/Log.js';
 import type {
-  LogFunction,
   ConstructorOptions,
+  CustomJsonReplacerFn,
   InjectLambdaContextOptions,
+  LogFunction,
   LogItemExtraInput,
   LogItemMessage,
   LoggerInterface,
   PowertoolsLogData,
-  CustomJsonReplacerFn,
 } from './types/Logger.js';
 
 /**
@@ -442,10 +442,7 @@ class Logger extends Utility implements LoggerInterface {
     options?: InjectLambdaContextOptions
   ): HandlerMethodDecorator {
     return (_target, _propertyKey, descriptor) => {
-      /**
-       * The descriptor.value is the method this decorator decorates, it cannot be undefined.
-       */
-      /* eslint-disable  @typescript-eslint/no-non-null-assertion */
+      // biome-ignore lint/style/noNonNullAssertion: The descriptor.value is the method this decorator decorates, it cannot be undefined.
       const originalMethod = descriptor.value!;
 
       // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -463,8 +460,6 @@ class Logger extends Utility implements LoggerInterface {
         let result: unknown;
         try {
           result = await originalMethod.apply(this, [event, context, callback]);
-        } catch (error) {
-          throw error;
         } finally {
           if (options?.clearState || options?.resetKeys) loggerRef.resetKeys();
         }
@@ -697,9 +692,11 @@ class Logger extends Utility implements LoggerInterface {
     const references = new WeakSet();
 
     return (key, value) => {
+      // biome-ignore lint/style/noParameterAssign:
       if (this.#jsonReplacerFn) value = this.#jsonReplacerFn?.(key, value);
 
       if (value instanceof Error) {
+        // biome-ignore lint/style/noParameterAssign:
         value = this.getLogFormatter().formatError(value);
       }
       if (typeof value === 'bigint') {
@@ -855,10 +852,10 @@ class Logger extends Utility implements LoggerInterface {
    * @returns - The name of the log level
    */
   private getLogLevelNameFromNumber(logLevel: number): Uppercase<LogLevel> {
-    let found;
+    let found: Uppercase<LogLevel> | undefined;
     for (const [key, value] of Object.entries(this.logLevelThresholds)) {
       if (value === logLevel) {
-        found = key;
+        found = key as keyof typeof this.logLevelThresholds;
         break;
       }
     }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -855,7 +855,7 @@ class Logger extends Utility implements LoggerInterface {
     let found: Uppercase<LogLevel> | undefined;
     for (const [key, value] of Object.entries(this.logLevelThresholds)) {
       if (value === logLevel) {
-        found = key as keyof typeof this.logLevelThresholds;
+        found = key as Uppercase<LogLevel>;
         break;
       }
     }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -692,24 +692,24 @@ class Logger extends Utility implements LoggerInterface {
     const references = new WeakSet();
 
     return (key, value) => {
-      // biome-ignore lint/style/noParameterAssign:
-      if (this.#jsonReplacerFn) value = this.#jsonReplacerFn?.(key, value);
+      let replacedValue = value;
+      if (this.#jsonReplacerFn)
+        replacedValue = this.#jsonReplacerFn?.(key, replacedValue);
 
-      if (value instanceof Error) {
-        // biome-ignore lint/style/noParameterAssign:
-        value = this.getLogFormatter().formatError(value);
+      if (replacedValue instanceof Error) {
+        replacedValue = this.getLogFormatter().formatError(replacedValue);
       }
-      if (typeof value === 'bigint') {
-        return value.toString();
+      if (typeof replacedValue === 'bigint') {
+        return replacedValue.toString();
       }
-      if (typeof value === 'object' && value !== null) {
-        if (references.has(value)) {
+      if (typeof replacedValue === 'object' && replacedValue !== null) {
+        if (references.has(replacedValue)) {
           return;
         }
-        references.add(value);
+        references.add(replacedValue);
       }
 
-      return value;
+      return replacedValue;
     };
   }
 

--- a/packages/logger/src/config/EnvironmentVariablesService.ts
+++ b/packages/logger/src/config/EnvironmentVariablesService.ts
@@ -1,5 +1,5 @@
-import { ConfigServiceInterface } from '../types/ConfigServiceInterface.js';
 import { EnvironmentVariablesService as CommonEnvironmentVariablesService } from '@aws-lambda-powertools/commons';
+import type { ConfigServiceInterface } from '../types/ConfigServiceInterface.js';
 
 /**
  * Class EnvironmentVariablesService

--- a/packages/logger/src/formatter/LogFormatter.ts
+++ b/packages/logger/src/formatter/LogFormatter.ts
@@ -92,8 +92,8 @@ abstract class LogFormatter implements LogFormatterInterface {
     const stackLines = stack.split('\n');
     const regex = /\(([^)]*?):(\d+?):(\d+?)\)\\?$/;
 
-    for (let i = 0; i < stackLines.length; i++) {
-      const match = regex.exec(stackLines[i]);
+    for (const item of stackLines) {
+      const match = regex.exec(item);
 
       if (Array.isArray(match)) {
         return `${match[1]}:${Number(match[2])}`;

--- a/packages/logger/src/formatter/LogFormatter.ts
+++ b/packages/logger/src/formatter/LogFormatter.ts
@@ -5,7 +5,7 @@ import type {
   LogFormatterOptions,
 } from '../types/Log.js';
 import type { UnformattedAttributes } from '../types/Logger.js';
-import { LogItem } from './LogItem.js';
+import type { LogItem } from './LogItem.js';
 
 /**
  * This class defines and implements common methods for the formatting of log attributes.
@@ -92,8 +92,7 @@ abstract class LogFormatter implements LogFormatterInterface {
     const stackLines = stack.split('\n');
     const regex = /\(([^)]*?):(\d+?):(\d+?)\)\\?$/;
 
-    let i;
-    for (i = 0; i < stackLines.length; i++) {
+    for (let i = 0; i < stackLines.length; i++) {
       const match = regex.exec(stackLines[i]);
 
       if (Array.isArray(match)) {

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -1,10 +1,10 @@
-import { Logger } from '../Logger.js';
-import type { InjectLambdaContextOptions } from '../types/Logger.js';
 import { LOGGER_KEY } from '@aws-lambda-powertools/commons';
 import type {
   MiddlewareLikeObj,
   MiddyLikeRequest,
 } from '@aws-lambda-powertools/commons/types';
+import { Logger } from '../Logger.js';
+import type { InjectLambdaContextOptions } from '../types/Logger.js';
 
 /**
  * A middy middleware that helps emitting CloudWatch EMF metrics in your logs.
@@ -35,7 +35,7 @@ const injectLambdaContext = (
   target: Logger | Logger[],
   options?: InjectLambdaContextOptions
 ): MiddlewareLikeObj => {
-  const loggers = target instanceof Array ? target : [target];
+  const loggers = Array.isArray(target) ? target : [target];
   const isResetStateEnabled =
     options && (options.clearState || options.resetKeys);
 
@@ -54,7 +54,7 @@ const injectLambdaContext = (
   const injectLambdaContextBefore = async (
     request: MiddyLikeRequest
   ): Promise<void> => {
-    loggers.forEach((logger: Logger) => {
+    for (const logger of loggers) {
       if (isResetStateEnabled) {
         setCleanupFunction(request);
       }
@@ -64,14 +64,14 @@ const injectLambdaContext = (
         request.context,
         options
       );
-    });
+    }
   };
 
   const injectLambdaContextAfterOrOnError = async (): Promise<void> => {
     if (isResetStateEnabled) {
-      loggers.forEach((logger: Logger) => {
+      for (const logger of loggers) {
         logger.resetKeys();
-      });
+      }
     }
   };
 

--- a/packages/logger/src/types/Log.ts
+++ b/packages/logger/src/types/Log.ts
@@ -1,11 +1,11 @@
 import type { EnvironmentVariablesService } from '../config/EnvironmentVariablesService.js';
+import type { LogLevel as LogLevelList } from '../constants.js';
 import type { LogItem } from '../formatter/LogItem.js';
 import type { UnformattedAttributes } from './Logger.js';
-import { LogLevel } from '../constants.js';
 
 type LogLevel =
-  | (typeof LogLevel)[keyof typeof LogLevel]
-  | Lowercase<(typeof LogLevel)[keyof typeof LogLevel]>;
+  | (typeof LogLevelList)[keyof typeof LogLevelList]
+  | Lowercase<(typeof LogLevelList)[keyof typeof LogLevelList]>;
 
 type LogLevelThresholds = {
   [key in Uppercase<LogLevel>]: number;

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -1,13 +1,13 @@
 import type { HandlerMethodDecorator } from '@aws-lambda-powertools/commons/types';
+import type { Context } from 'aws-lambda';
 import type { ConfigServiceInterface } from './ConfigServiceInterface.js';
 import type {
   Environment,
   LogAttributes,
   LogAttributesWithMessage,
-  LogLevel,
   LogFormatterInterface,
+  LogLevel,
 } from './Log.js';
-import type { Context } from 'aws-lambda';
 
 type LogFunction = {
   [key in Exclude<Lowercase<LogLevel>, 'silent'>]: (

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.FunctionCode.ts
@@ -1,8 +1,8 @@
+import type { APIGatewayAuthorizerResult, Context } from 'aws-lambda';
+import middy from 'middy5';
 import { Logger } from '../../src/index.js';
 import { injectLambdaContext } from '../../src/middleware/middy.js';
-import type { Context, APIGatewayAuthorizerResult } from 'aws-lambda';
 import type { TestEvent, TestOutput } from '../helpers/types.js';
-import middy from 'middy5';
 
 const PERSISTENT_KEY = process.env.PERSISTENT_KEY || 'persistentKey';
 const PERSISTENT_VALUE = process.env.PERSISTENT_VALUE || 'persistentValue';

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -1,15 +1,15 @@
+import { join } from 'node:path';
 /**
  * Test logger basic features
  *
  * @group e2e/logger/basicFeatures
  */
 import {
-  invokeFunction,
   TestInvocationLogs,
   TestStack,
+  invokeFunction,
 } from '@aws-lambda-powertools/testing-utils';
 import type { APIGatewayAuthorizerResult } from 'aws-lambda';
-import { join } from 'node:path';
 import { LoggerTestNodejsFunction } from '../helpers/resources.js';
 import {
   RESOURCE_NAME_PREFIX,
@@ -21,7 +21,7 @@ import {
   commonEnvironmentVars,
 } from './constants.js';
 
-describe(`Logger E2E tests, basic functionalities middy usage`, () => {
+describe('Logger E2E tests, basic functionalities middy usage', () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,

--- a/packages/logger/tests/e2e/basicFeatures.middy.test.ts
+++ b/packages/logger/tests/e2e/basicFeatures.middy.test.ts
@@ -1,9 +1,9 @@
-import { join } from 'node:path';
 /**
  * Test logger basic features
  *
  * @group e2e/logger/basicFeatures
  */
+import { join } from 'node:path';
 import {
   TestInvocationLogs,
   TestStack,

--- a/packages/logger/tests/e2e/childLogger.manual.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/childLogger.manual.test.FunctionCode.ts
@@ -1,7 +1,7 @@
-import { Logger } from '../../src/index.js';
 import type { Context } from 'aws-lambda';
+import { Logger } from '../../src/index.js';
 import type { LogLevel } from '../../src/types/index.js';
-import { TestEvent, TestOutput } from '../helpers/types.js';
+import type { TestEvent, TestOutput } from '../helpers/types.js';
 
 const PERSISTENT_KEY = process.env.PERSISTENT_KEY || 'persistentKey';
 const PERSISTENT_VALUE = process.env.ERSISTENT_VALUE || 'persistentValue';

--- a/packages/logger/tests/e2e/childLogger.manual.test.ts
+++ b/packages/logger/tests/e2e/childLogger.manual.test.ts
@@ -1,25 +1,25 @@
+import { join } from 'node:path';
 /**
  * Test logger child logger
  *
  * @group e2e/logger/childLogger
  */
 import {
-  invokeFunction,
   TestInvocationLogs,
   TestStack,
+  invokeFunction,
 } from '@aws-lambda-powertools/testing-utils';
-import { join } from 'node:path';
 import { LoggerTestNodejsFunction } from '../helpers/resources.js';
 import {
-  commonEnvironmentVars,
   RESOURCE_NAME_PREFIX,
   SETUP_TIMEOUT,
   STACK_OUTPUT_LOG_GROUP,
   TEARDOWN_TIMEOUT,
   TEST_CASE_TIMEOUT,
+  commonEnvironmentVars,
 } from './constants.js';
 
-describe(`Logger E2E tests, child logger`, () => {
+describe('Logger E2E tests, child logger', () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,

--- a/packages/logger/tests/e2e/childLogger.manual.test.ts
+++ b/packages/logger/tests/e2e/childLogger.manual.test.ts
@@ -1,9 +1,9 @@
-import { join } from 'node:path';
 /**
  * Test logger child logger
  *
  * @group e2e/logger/childLogger
  */
+import { join } from 'node:path';
 import {
   TestInvocationLogs,
   TestStack,

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.FunctionCode.ts
@@ -1,8 +1,8 @@
+import type { Context } from 'aws-lambda';
+import middy from 'middy4';
 import { Logger } from '../../src/index.js';
 import { injectLambdaContext } from '../../src/middleware/middy.js';
 import type { TestEvent, TestOutput } from '../helpers/types.js';
-import type { Context } from 'aws-lambda';
-import middy from 'middy4';
 
 const logger = new Logger();
 

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
@@ -1,9 +1,9 @@
-import { join } from 'node:path';
 /**
  * Test logger basic features
  *
  * @group e2e/logger/logEventEnvVarSetting
  */
+import { join } from 'node:path';
 import {
   TestInvocationLogs,
   TestStack,

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.ts
@@ -1,14 +1,14 @@
+import { join } from 'node:path';
 /**
  * Test logger basic features
  *
  * @group e2e/logger/logEventEnvVarSetting
  */
 import {
-  invokeFunction,
   TestInvocationLogs,
   TestStack,
+  invokeFunction,
 } from '@aws-lambda-powertools/testing-utils';
-import { join } from 'node:path';
 import { LoggerTestNodejsFunction } from '../helpers/resources.js';
 import {
   RESOURCE_NAME_PREFIX,
@@ -18,7 +18,7 @@ import {
   TEST_CASE_TIMEOUT,
 } from './constants.js';
 
-describe(`Logger E2E tests, log event via env var setting with middy`, () => {
+describe('Logger E2E tests, log event via env var setting with middy', () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
@@ -1,9 +1,9 @@
+import type { LambdaInterface } from '@aws-lambda-powertools/commons/types';
+import type { Context } from 'aws-lambda';
 import { Logger } from '../../src/index.js';
 import type { TestEvent, TestOutput } from '../helpers/types.js';
-import type { Context } from 'aws-lambda';
-import type { LambdaInterface } from '@aws-lambda-powertools/commons/types';
 
-const SAMPLE_RATE = parseFloat(process.env.SAMPLE_RATE || '0.1');
+const SAMPLE_RATE = Number.parseFloat(process.env.SAMPLE_RATE || '0.1');
 const LOG_MSG = process.env.LOG_MSG || 'Hello World';
 
 const logger = new Logger({

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.ts
@@ -1,15 +1,15 @@
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
 /**
  * Test logger sample rate feature
  *
  * @group e2e/logger/sampleRate
  */
 import {
-  invokeFunction,
   TestInvocationLogs,
   TestStack,
+  invokeFunction,
 } from '@aws-lambda-powertools/testing-utils';
-import { randomUUID } from 'node:crypto';
-import { join } from 'node:path';
 import { LoggerTestNodejsFunction } from '../helpers/resources.js';
 import {
   RESOURCE_NAME_PREFIX,
@@ -19,7 +19,7 @@ import {
   TEST_CASE_TIMEOUT,
 } from './constants.js';
 
-describe(`Logger E2E tests, sample rate and injectLambdaContext()`, () => {
+describe('Logger E2E tests, sample rate and injectLambdaContext()', () => {
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: RESOURCE_NAME_PREFIX,

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.ts
@@ -1,10 +1,10 @@
-import { randomUUID } from 'node:crypto';
-import { join } from 'node:path';
 /**
  * Test logger sample rate feature
  *
  * @group e2e/logger/sampleRate
  */
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
 import {
   TestInvocationLogs,
   TestStack,

--- a/packages/logger/tests/helpers/resources.ts
+++ b/packages/logger/tests/helpers/resources.ts
@@ -1,10 +1,10 @@
-import { TestNodejsFunction } from '@aws-lambda-powertools/testing-utils/resources/lambda';
 import type { TestStack } from '@aws-lambda-powertools/testing-utils';
-import { CfnOutput } from 'aws-cdk-lib';
+import { TestNodejsFunction } from '@aws-lambda-powertools/testing-utils/resources/lambda';
 import type {
   ExtraTestProps,
   TestNodejsFunctionProps,
 } from '@aws-lambda-powertools/testing-utils/types';
+import { CfnOutput } from 'aws-cdk-lib';
 import { commonEnvironmentVars } from '../e2e/constants';
 
 interface LoggerExtraTestProps extends ExtraTestProps {

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -1,9 +1,9 @@
-import type { LambdaInterface } from '@aws-lambda-powertools/commons/types';
 /**
  * Test Logger class
  *
  * @group unit/logger/logger
  */
+import type { LambdaInterface } from '@aws-lambda-powertools/commons/types';
 import context from '@aws-lambda-powertools/testing-utils/context';
 import type { Context } from 'aws-lambda';
 import { EnvironmentVariablesService } from '../../src/config/EnvironmentVariablesService.js';

--- a/packages/logger/tests/unit/Logger.test.ts
+++ b/packages/logger/tests/unit/Logger.test.ts
@@ -604,7 +604,8 @@ describe('Class: Logger', () => {
             logLevel: LogLevel.DEBUG,
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(method)
           );
           // Act
@@ -633,7 +634,8 @@ describe('Class: Logger', () => {
             logLevel: 'INFO',
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -662,7 +664,8 @@ describe('Class: Logger', () => {
             logLevel: LogLevel.WARN,
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -691,7 +694,8 @@ describe('Class: Logger', () => {
             logLevel: 'ERROR',
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -720,7 +724,8 @@ describe('Class: Logger', () => {
             logLevel: LogLevel.SILENT,
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -735,7 +740,8 @@ describe('Class: Logger', () => {
           process.env.POWERTOOLS_LOG_LEVEL = methodOfLogger.toUpperCase();
           const logger = new Logger();
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -765,7 +771,8 @@ describe('Class: Logger', () => {
             sampleRateValue: 0,
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -786,7 +793,8 @@ describe('Class: Logger', () => {
             sampleRateValue: 1,
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -817,7 +825,8 @@ describe('Class: Logger', () => {
           // Prepare
           const logger = new Logger();
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -847,7 +856,8 @@ describe('Class: Logger', () => {
           });
           logger.addContext(context);
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -1072,7 +1082,8 @@ describe('Class: Logger', () => {
           ({ idx, inputs, expected }) => {
             // Prepare
             const consoleSpy = jest.spyOn(
-              logger.console,
+              // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+              logger['console'],
               getConsoleMethod(methodOfLogger)
             );
 
@@ -1098,7 +1109,8 @@ describe('Class: Logger', () => {
             },
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -1131,7 +1143,8 @@ describe('Class: Logger', () => {
             logLevel: 'DEBUG',
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -1161,7 +1174,8 @@ describe('Class: Logger', () => {
             logLevel: 'DEBUG',
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           // Act
@@ -1191,7 +1205,8 @@ describe('Class: Logger', () => {
             logLevel: 'DEBUG',
           });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           const circularObject = {
@@ -1233,7 +1248,11 @@ describe('Class: Logger', () => {
         test('when a logged item has BigInt value, it does not throw TypeError', () => {
           // Prepare
           const logger = new Logger();
-          jest.spyOn(logger.console, getConsoleMethod(methodOfLogger));
+          jest.spyOn(
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
+            getConsoleMethod(methodOfLogger)
+          );
           const message = `This is an ${methodOfLogger} log with BigInt value`;
           const logItem = { value: BigInt(42) };
           const errorMessage = 'Do not know how to serialize a BigInt';
@@ -1248,7 +1267,8 @@ describe('Class: Logger', () => {
           // Prepare
           const logger = new Logger();
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           const message = `This is an ${methodOfLogger} log with BigInt value`;
@@ -1277,7 +1297,8 @@ describe('Class: Logger', () => {
           // Prepare
           const logger = new Logger();
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           const message = `This is an ${methodOfLogger} log with empty, null, and undefined values`;
@@ -1316,7 +1337,8 @@ describe('Class: Logger', () => {
 
           const logger = new Logger({ jsonReplacerFn });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
           const message = `This is an ${methodOfLogger} log with Set value`;
@@ -1357,7 +1379,8 @@ describe('Class: Logger', () => {
 
           const logger = new Logger({ jsonReplacerFn });
           const consoleSpy = jest.spyOn(
-            logger.console,
+            // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+            logger['console'],
             getConsoleMethod(methodOfLogger)
           );
 
@@ -1560,7 +1583,11 @@ describe('Class: Logger', () => {
         aws_account_id: '0987654321',
       });
 
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
 
       // Act
       logger.info('This is an INFO log with some log attributes');
@@ -1818,7 +1845,11 @@ describe('Class: Logger', () => {
           aws_region: 'eu-west-1',
         },
       });
-      const debugSpy = jest.spyOn(logger.console, 'info');
+      const debugSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       logger.appendKeys({
         aws_region: 'us-east-1',
       });
@@ -1893,7 +1924,11 @@ describe('Class: Logger', () => {
     it('overwrites existing temporary keys with new ones in the next log', () => {
       // Prepare
       const logger = new Logger();
-      const debugSpy = jest.spyOn(logger.console, 'info');
+      const debugSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       logger.appendKeys({
         aws_account_id: '123456789012',
       });
@@ -1921,7 +1956,11 @@ describe('Class: Logger', () => {
       // Prepare
 
       const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext()
         public async handler<TEvent>(
@@ -1965,7 +2004,11 @@ describe('Class: Logger', () => {
     test('it captures Lambda context information and adds it in the printed logs', async () => {
       // Prepare
       const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext()
         public async handler<TEvent>(
@@ -2019,7 +2062,11 @@ describe('Class: Logger', () => {
       // Prepare
       const expectedReturnValue = 'Lambda invoked!';
       const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext()
         public async handler<TEvent>(
@@ -2082,7 +2129,11 @@ describe('Class: Logger', () => {
         biz: 'baz',
       });
 
-      const debugSpy = jest.spyOn(logger.console, 'debug');
+      const debugSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'debug'
+      );
 
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext({ clearState: true })
@@ -2199,7 +2250,11 @@ describe('Class: Logger', () => {
         logLevel: 'DEBUG',
       });
 
-      const debugSpy = jest.spyOn(logger.console, 'debug');
+      const debugSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'debug'
+      );
 
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext({ clearState: true })
@@ -2276,7 +2331,11 @@ describe('Class: Logger', () => {
         logLevel: 'DEBUG',
       });
 
-      const debugSpy = jest.spyOn(logger.console, 'debug');
+      const debugSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'debug'
+      );
 
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext({ clearState: true })
@@ -2342,7 +2401,11 @@ describe('Class: Logger', () => {
       const logger = new Logger({
         logLevel: LogLevel.DEBUG,
       });
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext({ logEvent: true })
         public async handler<TEvent>(
@@ -2389,7 +2452,11 @@ describe('Class: Logger', () => {
       const logger = new Logger({
         logLevel: 'DEBUG',
       });
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext()
         public async handler<TEvent>(
@@ -2435,7 +2502,11 @@ describe('Class: Logger', () => {
       const logger = new Logger({
         logLevel: 'DEBUG',
       });
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         private readonly memberVariable: string;
 
@@ -2490,7 +2561,11 @@ describe('Class: Logger', () => {
         logLevel: 'DEBUG',
       });
       const resetKeysSpy = jest.spyOn(logger, 'resetKeys');
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext({ clearState: true })
         public async handler(
@@ -2530,7 +2605,11 @@ describe('Class: Logger', () => {
           version: '1.0.0',
         },
       });
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       class LambdaFunction implements LambdaInterface {
         @logger.injectLambdaContext({ clearState: true, logEvent: true })
         public async handler(
@@ -3017,7 +3096,11 @@ describe('Class: Logger', () => {
     test('When the feature is disabled, it DOES NOT log the event', () => {
       // Prepare
       const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.logEventIfEnabled(event);
 
@@ -3031,7 +3114,11 @@ describe('Class: Logger', () => {
         something: 'happened!',
       };
       const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.logEventIfEnabled(event, true);
 
@@ -3087,7 +3174,11 @@ describe('Class: Logger', () => {
     test('when the `POWERTOOLS_DEV` env var is NOT SET it makes log output as one-liner', () => {
       // Prepare
       const logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('Message without pretty identation');
 
@@ -3268,7 +3359,11 @@ describe('Class: Logger', () => {
         customConfigService: new MyCustomEnvironmentVariablesService(),
       };
       const logger: Logger = new Logger(loggerOptions);
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('foo');
 
@@ -3301,7 +3396,11 @@ describe('Class: Logger', () => {
         customConfigService: new MyCustomEnvironmentVariablesService(),
       };
       const logger: Logger = new Logger(loggerOptions);
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('foo');
 
@@ -3324,7 +3423,11 @@ describe('Class: Logger', () => {
       // Prepare
       process.env.POWERTOOLS_LOGGER_SAMPLE_RATE = '1';
       const logger: Logger = new Logger();
-      const consoleSpy = jest.spyOn(logger.console, 'debug');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'debug'
+      );
       // Act
       logger.debug('foo');
 
@@ -3367,7 +3470,11 @@ describe('Class: Logger', () => {
       };
 
       const logger: Logger = new Logger(loggerOptions);
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('foo');
 
@@ -3392,7 +3499,11 @@ describe('Class: Logger', () => {
         logLevel: LogLevel.INFO,
         sampleRateValue: 42,
       });
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('foo');
 
@@ -3425,7 +3536,11 @@ describe('Class: Logger', () => {
       };
 
       const logger: Logger = new Logger(loggerOptions);
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('foo');
 
@@ -3450,7 +3565,11 @@ describe('Class: Logger', () => {
       const logger: Logger = new Logger({
         logLevel: 'INFO',
       });
-      const consoleSpy = jest.spyOn(logger.console, 'info');
+      const consoleSpy = jest.spyOn(
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+        logger['console'],
+        'info'
+      );
       // Act
       logger.info('foo');
 
@@ -3494,7 +3613,11 @@ describe('Class: Logger', () => {
           logLevel: LogLevel.INFO,
           sampleRateValue: 1,
         });
-        const consoleSpy = jest.spyOn(logger.console, 'info');
+        const consoleSpy = jest.spyOn(
+          // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+          logger['console'],
+          'info'
+        );
         // Act
         logger.refreshSampleRateCalculation();
         logger.info('foo');

--- a/packages/logger/tests/unit/formatter/PowertoolsLogFormatter.test.ts
+++ b/packages/logger/tests/unit/formatter/PowertoolsLogFormatter.test.ts
@@ -4,11 +4,11 @@
  * @group unit/logger/logFormatter
  */
 import { AssertionError } from 'node:assert';
+import { EnvironmentVariablesService } from '../../../src/config/EnvironmentVariablesService.js';
 import { PowertoolsLogFormatter } from '../../../src/formatter/PowertoolsLogFormatter.js';
 import { LogItem } from '../../../src/index.js';
-import type { UnformattedAttributes } from '../../../src/types/Logger.js';
 import type { LogAttributes } from '../../../src/types/Log.js';
-import { EnvironmentVariablesService } from '../../../src/config/EnvironmentVariablesService.js';
+import type { UnformattedAttributes } from '../../../src/types/Logger.js';
 
 describe('Class: PowertoolsLogFormatter', () => {
   const ENVIRONMENT_VARIABLES = process.env;

--- a/packages/logger/tests/unit/middleware/middy.test.ts
+++ b/packages/logger/tests/unit/middleware/middy.test.ts
@@ -373,8 +373,8 @@ describe('Middy middleware', () => {
     test('when enabled, it logs the event', async () => {
       // Prepare
       const logger = new Logger();
-      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
         .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
@@ -450,8 +450,8 @@ describe('Middy middleware', () => {
       const logger = new Logger({
         customConfigService: configService,
       });
-      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
         .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
@@ -490,8 +490,8 @@ describe('Middy middleware', () => {
       // Prepare
       process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
       const logger = new Logger();
-      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
         .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
@@ -530,8 +530,8 @@ describe('Middy middleware', () => {
       // Prepare
       process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
       const logger = new Logger();
-      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
         .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
@@ -568,8 +568,8 @@ describe('Middy middleware', () => {
           version: '1.0.0',
         },
       });
-      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
+        // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
         .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy(

--- a/packages/logger/tests/unit/middleware/middy.test.ts
+++ b/packages/logger/tests/unit/middleware/middy.test.ts
@@ -8,7 +8,7 @@ import context from '@aws-lambda-powertools/testing-utils/context';
 import middy from '@middy/core';
 import type { Context } from 'aws-lambda';
 import { injectLambdaContext } from '../../../src/middleware/middy.js';
-import { ConfigServiceInterface } from '../../../src/types/ConfigServiceInterface.js';
+import type { ConfigServiceInterface } from '../../../src/types/ConfigServiceInterface.js';
 import { Logger } from './../../../src/Logger.js';
 
 const mockDate = new Date(1466424490000);
@@ -107,7 +107,7 @@ describe('Middy middleware', () => {
         biz: 'baz',
       });
 
-      const debugSpy = jest.spyOn(logger['console'], 'debug');
+      const debugSpy = jest.spyOn(logger.console, 'debug');
 
       const handler = middy((): void => {
         // Only add these keys for the scope of this lambda handler
@@ -174,7 +174,7 @@ describe('Middy middleware', () => {
         biz: 'baz',
       });
 
-      const debugSpy = jest.spyOn(logger['console'], 'debug');
+      const debugSpy = jest.spyOn(logger.console, 'debug');
 
       const handler = middy((): void => {
         // These keys stay only in the scope of this lambda handler
@@ -314,7 +314,7 @@ describe('Middy middleware', () => {
       const logger = new Logger({
         logLevel: 'DEBUG',
       });
-      const loggerSpy = jest.spyOn(logger['console'], 'debug');
+      const loggerSpy = jest.spyOn(logger.console, 'debug');
       const myCustomMiddleware = (): middy.MiddlewareObj => {
         const before = async (
           request: middy.Request
@@ -371,7 +371,7 @@ describe('Middy middleware', () => {
       // Prepare
       const logger = new Logger();
       const consoleSpy = jest
-        .spyOn(logger['console'], 'info')
+        .spyOn(logger.console, 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log with some context');
@@ -447,7 +447,7 @@ describe('Middy middleware', () => {
         customConfigService: configService,
       });
       const consoleSpy = jest
-        .spyOn(logger['console'], 'info')
+        .spyOn(logger.console, 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log with some context');
@@ -486,7 +486,7 @@ describe('Middy middleware', () => {
       process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
       const logger = new Logger();
       const consoleSpy = jest
-        .spyOn(logger['console'], 'info')
+        .spyOn(logger.console, 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log with some context');
@@ -525,7 +525,7 @@ describe('Middy middleware', () => {
       process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
       const logger = new Logger();
       const consoleSpy = jest
-        .spyOn(logger['console'], 'info')
+        .spyOn(logger.console, 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log');
@@ -562,7 +562,7 @@ describe('Middy middleware', () => {
         },
       });
       const consoleSpy = jest
-        .spyOn(logger['console'], 'info')
+        .spyOn(logger.console, 'info')
         .mockImplementation();
       const handler = middy(
         async (event: { foo: string }, _context: Context) => {

--- a/packages/logger/tests/unit/middleware/middy.test.ts
+++ b/packages/logger/tests/unit/middleware/middy.test.ts
@@ -107,7 +107,8 @@ describe('Middy middleware', () => {
         biz: 'baz',
       });
 
-      const debugSpy = jest.spyOn(logger.console, 'debug');
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+      const debugSpy = jest.spyOn(logger['console'], 'debug');
 
       const handler = middy((): void => {
         // Only add these keys for the scope of this lambda handler
@@ -174,7 +175,8 @@ describe('Middy middleware', () => {
         biz: 'baz',
       });
 
-      const debugSpy = jest.spyOn(logger.console, 'debug');
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+      const debugSpy = jest.spyOn(logger['console'], 'debug');
 
       const handler = middy((): void => {
         // These keys stay only in the scope of this lambda handler
@@ -314,7 +316,8 @@ describe('Middy middleware', () => {
       const logger = new Logger({
         logLevel: 'DEBUG',
       });
-      const loggerSpy = jest.spyOn(logger.console, 'debug');
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
+      const loggerSpy = jest.spyOn(logger['console'], 'debug');
       const myCustomMiddleware = (): middy.MiddlewareObj => {
         const before = async (
           request: middy.Request
@@ -370,8 +373,9 @@ describe('Middy middleware', () => {
     test('when enabled, it logs the event', async () => {
       // Prepare
       const logger = new Logger();
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
-        .spyOn(logger.console, 'info')
+        .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log with some context');
@@ -446,8 +450,9 @@ describe('Middy middleware', () => {
       const logger = new Logger({
         customConfigService: configService,
       });
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
-        .spyOn(logger.console, 'info')
+        .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log with some context');
@@ -485,8 +490,9 @@ describe('Middy middleware', () => {
       // Prepare
       process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
       const logger = new Logger();
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
-        .spyOn(logger.console, 'info')
+        .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log with some context');
@@ -524,8 +530,9 @@ describe('Middy middleware', () => {
       // Prepare
       process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
       const logger = new Logger();
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
-        .spyOn(logger.console, 'info')
+        .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy((): void => {
         logger.info('This is an INFO log');
@@ -561,8 +568,9 @@ describe('Middy middleware', () => {
           version: '1.0.0',
         },
       });
+      // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       const consoleSpy = jest
-        .spyOn(logger.console, 'info')
+        .spyOn(logger['console'], 'info')
         .mockImplementation();
       const handler = middy(
         async (event: { foo: string }, _context: Context) => {

--- a/packages/logger/tsconfig.esm.json
+++ b/packages/logger/tsconfig.esm.json
@@ -6,7 +6,5 @@
     "rootDir": "./src",
     "tsBuildInfoFile": ".tsbuildinfo/esm.json"
   },
-  "include": [
-    "./src/**/*"
-  ]
+  "include": ["./src/**/*"]
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -5,7 +5,5 @@
     "rootDir": "./src",
     "tsBuildInfoFile": ".tsbuildinfo/cjs.json"
   },
-  "include": [
-    "./src/**/*"
-  ]
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## Summary

### Changes

Adds biome to the logger package. Closes #2798 

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

**Issue number: 2798** 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
