### PR TITLE
chore(parser): mark parser as GA

### DIFF
--- a/.github/scripts/release_patch_package_json.js
+++ b/.github/scripts/release_patch_package_json.js
@@ -18,80 +18,76 @@ if (process.argv.length < 3) {
 const basePath = resolve(process.argv[2]);
 const packageJsonPath = join(basePath, 'package.json');
 const alphaPackages = [];
-const betaPackages = ['@aws-lambda-powertools/parser'];
+const betaPackages = [];
 
 (() => {
-  try {
-    // Read the original package.json file
-    const pkgJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-    // Extract the fields we want to keep
-    const {
-      name,
-      version: originalVersion,
-      description,
-      author,
-      license,
-      homepage,
-      repository,
-      bugs,
-      keywords,
-      dependencies,
-      peerDependencies,
-      peerDependenciesMeta,
-      exports,
-      typesVersions,
-      main,
-      types,
-      files,
-      private,
-      type,
-    } = pkgJson;
+  // Read the original package.json file
+  const pkgJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  // Extract the fields we want to keep
+  const {
+    name,
+    version: originalVersion,
+    description,
+    author,
+    license,
+    homepage,
+    repository,
+    bugs,
+    keywords,
+    dependencies,
+    peerDependencies,
+    peerDependenciesMeta,
+    exports,
+    typesVersions,
+    main,
+    types,
+    files,
+    private: privateField,
+    type,
+  } = pkgJson;
 
-    let version = originalVersion;
-    // If the package is an alpha or beta package, update the version number to include a suffix
-    if (alphaPackages.includes(name)) {
-      version = `${version}-alpha`;
-    } else if (betaPackages.includes(name)) {
-      version = `${version}-beta`;
-    }
-
-    // Create a new package.json file with the updated version for the tarball
-    const newPkgJson = {
-      name,
-      version,
-      description,
-      author,
-      license,
-      homepage,
-      repository,
-      bugs,
-      keywords,
-      dependencies,
-      peerDependencies,
-      peerDependenciesMeta,
-      main,
-      types,
-      files,
-      type,
-    };
-
-    // Not all utilities have these fields, so only add them if they exist to avoid
-    // having empty or undefined fields in the package.json file.
-    if (exports) {
-      newPkgJson.exports = exports;
-    }
-    if (typesVersions) {
-      newPkgJson.typesVersions = typesVersions;
-    }
-    if (private) {
-      newPkgJson.private = private;
-    }
-
-    // Temporarily update the original package.json file.
-    // This version will be picked up during the `npm publish` step, so that
-    // the version number and metadata in the registry are correct and match the tarball.
-    writeFileSync('package.json', JSON.stringify(newPkgJson, null, 2));
-  } catch (err) {
-    throw err;
+  let version = originalVersion;
+  // If the package is an alpha or beta package, update the version number to include a suffix
+  if (alphaPackages.includes(name)) {
+    version = `${version}-alpha`;
+  } else if (betaPackages.includes(name)) {
+    version = `${version}-beta`;
   }
+
+  // Create a new package.json file with the updated version for the tarball
+  const newPkgJson = {
+    name,
+    version,
+    description,
+    author,
+    license,
+    homepage,
+    repository,
+    bugs,
+    keywords,
+    dependencies,
+    peerDependencies,
+    peerDependenciesMeta,
+    main,
+    types,
+    files,
+    type,
+  };
+
+  // Not all utilities have these fields, so only add them if they exist to avoid
+  // having empty or undefined fields in the package.json file.
+  if (exports) {
+    newPkgJson.exports = exports;
+  }
+  if (typesVersions) {
+    newPkgJson.typesVersions = typesVersions;
+  }
+  if (privateField) {
+    newPkgJson.private = privateField;
+  }
+
+  // Temporarily update the original package.json file.
+  // This version will be picked up during the `npm publish` step, so that
+  // the version number and metadata in the registry are correct and match the tarball.
+  writeFileSync('package.json', JSON.stringify(newPkgJson, null, 2));
 })();

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -18,5 +18,4 @@ packages/jmespath/README.md
 packages/logger/README.md
 packages/metrics/README.md
 packages/parameters/README.md
-packages/parser/README.md
 packages/tracer/README.md

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -1,12 +1,5 @@
 # Powertools for AWS Lambda (TypeScript) - Parser Utility <!-- omit in toc -->
 
-
-| ⚠️ **WARNING: Do not use this utility in production just yet!** ⚠️                                                                                                                                                                                                                                                                                                  |
-| :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| This AWS Lambda Powertools for TypeScript utility is currently released as beta developer preview and is intended strictly for feedback and testing purposes only.  <br/>This version is not stable, and significant breaking changes might incur before going [before the GA release](https://github.com/aws-powertools/powertools-lambda-typescript/milestone/16). | _ |
-
-
-
 Powertools for AWS Lambda (TypeScript) is a developer toolkit to implement Serverless [best practices and increase developer velocity](https://docs.powertools.aws.dev/lambda/typescript/latest/#features).
 
 You can use the package in both TypeScript and JavaScript code bases.
@@ -14,18 +7,18 @@ You can use the package in both TypeScript and JavaScript code bases.
 - [Intro](#intro)
 - [Key features](#key-features)
 - [Usage](#usage)
-  - [Middleware](#middleware)
-  - [Decorator](#decorator)
-  - [Manual parsing](#manual-parsing)
-  - [Safe parsing](#safe-parsing)
-  - [Built-in schemas and envelopes](#built-in-schemas-and-envelopes)
+    - [Middleware](#middleware)
+    - [Decorator](#decorator)
+    - [Manual parsing](#manual-parsing)
+    - [Safe parsing](#safe-parsing)
+    - [Built-in schemas and envelopes](#built-in-schemas-and-envelopes)
 - [Contribute](#contribute)
 - [Roadmap](#roadmap)
 - [Connect](#connect)
 - [How to support Powertools for AWS Lambda (TypeScript)?](#how-to-support-powertools-for-aws-lambda-typescript)
-  - [Becoming a reference customer](#becoming-a-reference-customer)
-  - [Sharing your work](#sharing-your-work)
-  - [Using Lambda Layer](#using-lambda-layer)
+    - [Becoming a reference customer](#becoming-a-reference-customer)
+    - [Sharing your work](#sharing-your-work)
+    - [Using Lambda Layer](#using-lambda-layer)
 - [Credits](#credits)
 - [License](#license)
 
@@ -35,11 +28,11 @@ The parser utility provides data validation and parsing using [Zod](https://zod.
 
 ## Key features
 
-* Define data schema as Zod schema, then parse, validate and extract only what you want
-* Built-in envelopes to unwrap and validate popular AWS event sources payloads
-* Extend and customize envelopes to fit your needs
-* Safe parsing option to avoid throwing errors and custom error handling
-* Available for Middy.js middleware and TypeScript method decorators
+- Define data schema as Zod schema, then parse, validate and extract only what you want
+- Built-in envelopes to unwrap and validate popular AWS event sources payloads
+- Extend and customize envelopes to fit your needs
+- Safe parsing option to avoid throwing errors and custom error handling
+- Available for Middy.js middleware and TypeScript method decorators
 
 ## Usage
 
@@ -197,7 +190,6 @@ export const handler = async (
 
 When parsing data, you can use the `safeParse` method to avoid throwing errors and handle them manually:
 
-
 ```typescript
 import type { Context } from 'aws-lambda';
 import { parser } from '@aws-lambda-powertools/parser/middleware';
@@ -304,28 +296,28 @@ Help us prioritize upcoming functionalities or utilities by [upvoting existing R
 
 ## Connect
 
-* **Powertools for AWS Lambda on Discord**: `#typescript` - **[Invite link](https://discord.gg/B8zZKbbyET)**
-* **Email**: aws-lambda-powertools-feedback@amazon.com
+- **Powertools for AWS Lambda on Discord**: `#typescript` - **[Invite link](https://discord.gg/B8zZKbbyET)**
+- **Email**: <aws-lambda-powertools-feedback@amazon.com>
 
 ## How to support Powertools for AWS Lambda (TypeScript)?
 
 ### Becoming a reference customer
 
-Knowing which companies are using this library is important to help prioritize the project internally. If your company is using Powertools for AWS Lambda (TypeScript), you can request to have your name and logo added to the README file by raising a [Support Powertools for AWS Lambda (TypeScript) (become a reference)](https://github.com/aws-powertools/powertools-lambda-typescript/issues/new?assignees=&labels=customer-reference&template=support_powertools.yml&title=%5BSupport+Lambda+Powertools%5D%3A+%3Cyour+organization+name%3E) issue.
+Knowing which companies are using this library is important to help prioritize the project internally. If your company is using Powertools for AWS Lambda (TypeScript), you can request to have your name and logo added to the README file by raising a [Support Powertools for AWS Lambda (TypeScript) (become a reference)](https://s12d.com/become-a-reference-ts) issue.
 
 The following companies, among others, use Powertools:
 
-* [Hashnode](https://hashnode.com/)
-* [Trek10](https://www.trek10.com/)
-* [Elva](https://elva-group.com)
-* [globaldatanet](https://globaldatanet.com/)
-* [Bailey Nelson](https://www.baileynelson.com.au)
-* [Perfect Post](https://www.perfectpost.fr)
-* [Sennder](https://sennder.com/)
-* [Certible](https://www.certible.com/)
-* [tecRacer GmbH & Co. KG](https://www.tecracer.com/)
-* [AppYourself](https://appyourself.net)
-* [Alma Media](https://www.almamedia.fi)
+- [Hashnode](https://hashnode.com/)
+- [Trek10](https://www.trek10.com/)
+- [Elva](https://elva-group.com)
+- [globaldatanet](https://globaldatanet.com/)
+- [Bailey Nelson](https://www.baileynelson.com.au)
+- [Perfect Post](https://www.perfectpost.fr)
+- [Sennder](https://sennder.com/)
+- [Certible](https://www.certible.com/)
+- [tecRacer GmbH & Co. KG](https://www.tecracer.com/)
+- [AppYourself](https://appyourself.net)
+- [Alma Media](https://www.almamedia.fi)
 
 ### Sharing your work
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR removes the `-beta` suffix from the Parser utility and the notice from its `README` file, to signify to customers that the utility can now be used in production workloads.

With the addition of Biome in previous PRs, I also had to address a couple of changes in the script I modified to ungate the GA - hence the diff on that file.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #2830

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
