### PR TITLE
chore(parser): adds exports for Record schemas

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -62,10 +62,7 @@
   },
   "typesVersions": {
     "*": {
-      "types": [
-        "./lib/cjs/types/index.d.ts",
-        "./lib/esm/types/index.d.ts"
-      ],
+      "types": ["./lib/cjs/types/index.d.ts", "./lib/esm/types/index.d.ts"],
       "middleware": [
         "./lib/cjs/middleware/parser.d.ts",
         "./lib/esm/middleware/parser.d.ts"
@@ -90,9 +87,7 @@
   },
   "main": "./lib/cjs/index.js",
   "types": "./lib/cjs/index.d.ts",
-  "files": [
-    "lib"
-  ],
+  "files": ["lib"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/aws-powertools/powertools-lambda-typescript.git"

--- a/packages/parser/src/schemas/index.ts
+++ b/packages/parser/src/schemas/index.ts
@@ -29,8 +29,8 @@ export { KinesisDataStreamSchema, KinesisDataStreamRecord } from './kinesis.js';
 export {
   KinesisFirehoseSchema,
   KinesisFirehoseSqsSchema,
-  KinesisFirehoseRecord,
-  KinesisFirehoseSqsRecord,
+  KinesisFirehoseRecordSchema,
+  KinesisFirehoseSqsRecordSchema,
 } from './kinesis-firehose.js';
 export { LambdaFunctionUrlSchema } from './lambda.js';
 export {

--- a/packages/parser/src/schemas/index.ts
+++ b/packages/parser/src/schemas/index.ts
@@ -20,11 +20,17 @@ export {
 } from './cloudwatch.js';
 export { DynamoDBStreamSchema } from './dynamodb.js';
 export { EventBridgeSchema } from './eventbridge.js';
-export { KafkaMskEventSchema, KafkaSelfManagedEventSchema } from './kafka.js';
-export { KinesisDataStreamSchema } from './kinesis.js';
+export {
+  KafkaMskEventSchema,
+  KafkaSelfManagedEventSchema,
+  KafkaRecordSchema,
+} from './kafka.js';
+export { KinesisDataStreamSchema, KinesisDataStreamRecord } from './kinesis.js';
 export {
   KinesisFirehoseSchema,
   KinesisFirehoseSqsSchema,
+  KinesisFirehoseRecord,
+  KinesisFirehoseSqsRecord,
 } from './kinesis-firehose.js';
 export { LambdaFunctionUrlSchema } from './lambda.js';
 export {
@@ -33,8 +39,13 @@ export {
   S3ObjectLambdaEventSchema,
   S3Schema,
 } from './s3.js';
-export { SesSchema } from './ses.js';
-export { SnsSchema } from './sns.js';
-export { SqsSchema } from './sqs.js';
+export { SesSchema, SesRecordSchema } from './ses.js';
+export {
+  SnsSchema,
+  SnsRecordSchema,
+  SnsSqsNotificationSchema,
+  SnsNotificationSchema,
+} from './sns.js';
+export { SqsSchema, SqsRecordSchema } from './sqs.js';
 export { VpcLatticeSchema } from './vpc-lattice.js';
 export { VpcLatticeV2Schema } from './vpc-latticev2.js';

--- a/packages/parser/src/schemas/kafka.ts
+++ b/packages/parser/src/schemas/kafka.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+/**
+ * Zod schema for a Kafka record from an Kafka event.
+ */
 const KafkaRecordSchema = z.object({
   topic: z.string(),
   partition: z.number(),

--- a/packages/parser/src/schemas/kinesis-firehose.ts
+++ b/packages/parser/src/schemas/kinesis-firehose.ts
@@ -22,12 +22,18 @@ const KinesisFireHoseBaseSchema = z.object({
   sourceKinesisStreamArn: z.string().optional(),
 });
 
+/**
+ * Zod schema for a Kinesis Firehose record from an Kinesis Firehose event.
+ */
 const KinesisFirehoseRecord = KinesisFireHoseRecordBase.extend({
   data: z
     .string()
     .transform((data) => Buffer.from(data, 'base64').toString('utf8')),
 });
 
+/**
+ * Zod schema for a SQS record from an Kinesis Firehose event.
+ */
 const KinesisFirehoseSqsRecord = KinesisFireHoseRecordBase.extend({
   data: z.string().transform((data) => {
     try {
@@ -111,4 +117,9 @@ const KinesisFirehoseSqsSchema = KinesisFireHoseBaseSchema.extend({
   records: z.array(KinesisFirehoseSqsRecord),
 });
 
-export { KinesisFirehoseSchema, KinesisFirehoseSqsSchema };
+export {
+  KinesisFirehoseSchema,
+  KinesisFirehoseSqsSchema,
+  KinesisFirehoseRecord,
+  KinesisFirehoseSqsRecord,
+};

--- a/packages/parser/src/schemas/kinesis-firehose.ts
+++ b/packages/parser/src/schemas/kinesis-firehose.ts
@@ -25,7 +25,7 @@ const KinesisFireHoseBaseSchema = z.object({
 /**
  * Zod schema for a Kinesis Firehose record from an Kinesis Firehose event.
  */
-const KinesisFirehoseRecord = KinesisFireHoseRecordBase.extend({
+const KinesisFirehoseRecordSchema = KinesisFireHoseRecordBase.extend({
   data: z
     .string()
     .transform((data) => Buffer.from(data, 'base64').toString('utf8')),
@@ -34,7 +34,7 @@ const KinesisFirehoseRecord = KinesisFireHoseRecordBase.extend({
 /**
  * Zod schema for a SQS record from an Kinesis Firehose event.
  */
-const KinesisFirehoseSqsRecord = KinesisFireHoseRecordBase.extend({
+const KinesisFirehoseSqsRecordSchema = KinesisFireHoseRecordBase.extend({
   data: z.string().transform((data) => {
     try {
       return SqsRecordSchema.parse(
@@ -89,7 +89,7 @@ const KinesisFirehoseSqsRecord = KinesisFireHoseRecordBase.extend({
  * @see {@link https://docs.aws.amazon.com/lambda/latest/dg/services-kinesisfirehose.html}
  */
 const KinesisFirehoseSchema = KinesisFireHoseBaseSchema.extend({
-  records: z.array(KinesisFirehoseRecord),
+  records: z.array(KinesisFirehoseRecordSchema),
 });
 
 /**
@@ -114,12 +114,12 @@ const KinesisFirehoseSchema = KinesisFireHoseBaseSchema.extend({
  * @see {@link types.KinesisFireHoseSqsEvent | KinesisFireHoseSqsEvent}
  */
 const KinesisFirehoseSqsSchema = KinesisFireHoseBaseSchema.extend({
-  records: z.array(KinesisFirehoseSqsRecord),
+  records: z.array(KinesisFirehoseSqsRecordSchema),
 });
 
 export {
   KinesisFirehoseSchema,
   KinesisFirehoseSqsSchema,
-  KinesisFirehoseRecord,
-  KinesisFirehoseSqsRecord,
+  KinesisFirehoseRecordSchema,
+  KinesisFirehoseSqsRecordSchema,
 };

--- a/packages/parser/src/schemas/ses.ts
+++ b/packages/parser/src/schemas/ses.ts
@@ -52,6 +52,9 @@ const SesMessage = z.object({
   receipt: SesReceipt,
 });
 
+/**
+ * Zod schema for a SES record from an SES event.
+ */
 const SesRecordSchema = z.object({
   eventSource: z.literal('aws:ses'),
   eventVersion: z.string(),
@@ -173,4 +176,4 @@ const SesSchema = z.object({
   Records: z.array(SesRecordSchema),
 });
 
-export { SesSchema };
+export { SesSchema, SesRecordSchema };

--- a/packages/parser/src/schemas/sns.ts
+++ b/packages/parser/src/schemas/sns.ts
@@ -5,6 +5,9 @@ const SnsMsgAttribute = z.object({
   Value: z.string(),
 });
 
+/**
+ * Zod schema for a SNS event notification record.
+ */
 const SnsNotificationSchema = z.object({
   Subject: z.string().optional(),
   TopicArn: z.string(),
@@ -58,6 +61,9 @@ const SnsSqsNotificationSchema = SnsNotificationSchema.extend({
   SigningCertUrl: true,
 });
 
+/**
+ * Zod schema for a SNS record inside of an SNS event.
+ */
 const SnsRecordSchema = z.object({
   EventSource: z.literal('aws:sns'),
   EventVersion: z.string(),
@@ -110,4 +116,9 @@ const SnsSchema = z.object({
   Records: z.array(SnsRecordSchema),
 });
 
-export { SnsSchema, SnsSqsNotificationSchema };
+export {
+  SnsSchema,
+  SnsSqsNotificationSchema,
+  SnsRecordSchema,
+  SnsNotificationSchema,
+};

--- a/packages/parser/src/schemas/sqs.ts
+++ b/packages/parser/src/schemas/sqs.ts
@@ -23,6 +23,9 @@ const SqsAttributesSchema = z.object({
   DeadLetterQueueSourceArn: z.string().optional(),
 });
 
+/**
+ * Zod schema for a SQS record inside an SQS event.
+ */
 const SqsRecordSchema = z.object({
   messageId: z.string(),
   receiptHandle: z.string(),

--- a/packages/parser/src/types/schema.ts
+++ b/packages/parser/src/types/schema.ts
@@ -11,17 +11,25 @@ import type {
   DynamoDBStreamSchema,
   EventBridgeSchema,
   KafkaMskEventSchema,
+  KafkaRecordSchema,
   KafkaSelfManagedEventSchema,
   KinesisDataStreamSchema,
+  KinesisFirehoseRecordSchema,
   KinesisFirehoseSchema,
+  KinesisFirehoseSqsRecordSchema,
   KinesisFirehoseSqsSchema,
   LambdaFunctionUrlSchema,
   S3EventNotificationEventBridgeSchema,
   S3ObjectLambdaEventSchema,
   S3Schema,
   S3SqsEventNotificationSchema,
+  SesRecordSchema,
   SesSchema,
+  SnsNotificationSchema,
+  SnsRecordSchema,
   SnsSchema,
+  SnsSqsNotificationSchema,
+  SqsRecordSchema,
   SqsSchema,
   VpcLatticeSchema,
   VpcLatticeV2Schema,
@@ -55,13 +63,19 @@ type EventBridgeEvent = z.infer<typeof EventBridgeSchema>;
 
 type KafkaSelfManagedEvent = z.infer<typeof KafkaSelfManagedEventSchema>;
 
+type KafkaRecord = z.infer<typeof KafkaRecordSchema>;
+
 type KafkaMskEvent = z.infer<typeof KafkaMskEventSchema>;
 
 type KinesisDataStreamEvent = z.infer<typeof KinesisDataStreamSchema>;
 
 type KinesisFireHoseEvent = z.infer<typeof KinesisFirehoseSchema>;
 
+type KinesisFirehoseRecord = z.infer<typeof KinesisFirehoseRecordSchema>;
+
 type KinesisFireHoseSqsEvent = z.infer<typeof KinesisFirehoseSqsSchema>;
+
+type KinesisFirehoseSqsRecord = z.infer<typeof KinesisFirehoseSqsRecordSchema>;
 
 type LambdaFunctionUrlEvent = z.infer<typeof LambdaFunctionUrlSchema>;
 
@@ -77,9 +91,19 @@ type S3ObjectLambdaEvent = z.infer<typeof S3ObjectLambdaEventSchema>;
 
 type SesEvent = z.infer<typeof SesSchema>;
 
+type SesRecord = z.infer<typeof SesRecordSchema>;
+
 type SnsEvent = z.infer<typeof SnsSchema>;
 
+type SnsSqsNotification = z.infer<typeof SnsSqsNotificationSchema>;
+
+type SnsNotification = z.infer<typeof SnsNotificationSchema>;
+
+type SnsRecord = z.infer<typeof SnsRecordSchema>;
+
 type SqsEvent = z.infer<typeof SqsSchema>;
+
+type SqsRecord = z.infer<typeof SqsRecordSchema>;
 
 type VpcLatticeEvent = z.infer<typeof VpcLatticeSchema>;
 
@@ -98,17 +122,25 @@ export type {
   EventBridgeEvent,
   KafkaSelfManagedEvent,
   KafkaMskEvent,
+  KafkaRecord,
   KinesisDataStreamEvent,
   KinesisFireHoseEvent,
+  KinesisFirehoseRecord,
   KinesisFireHoseSqsEvent,
+  KinesisFirehoseSqsRecord,
   LambdaFunctionUrlEvent,
   S3Event,
   S3EventNotificationEventBridge,
   S3SqsEventNotification,
   S3ObjectLambdaEvent,
   SesEvent,
+  SesRecord,
   SnsEvent,
+  SnsSqsNotification,
+  SnsNotification,
+  SnsRecord,
   SqsEvent,
+  SqsRecord,
   VpcLatticeEvent,
   VpcLatticeEventV2,
 };

--- a/packages/parser/tests/unit/schema/kafka.test.ts
+++ b/packages/parser/tests/unit/schema/kafka.test.ts
@@ -6,8 +6,11 @@
 
 import {
   KafkaMskEventSchema,
+  KafkaRecordSchema,
   KafkaSelfManagedEventSchema,
 } from '../../../src/schemas/';
+import type { KafkaSelfManagedEvent } from '../../../src/types';
+import type { KafkaRecord } from '../../../src/types/schema';
 import { TestEvents } from './utils.js';
 
 describe('Kafka ', () => {
@@ -59,5 +62,13 @@ describe('Kafka ', () => {
     const parsed = KafkaSelfManagedEventSchema.parse(kafkaEventSelfManaged);
 
     expect(parsed.bootstrapServers).toBeUndefined();
+  });
+  it('should parse kafka record from kafka event', () => {
+    const kafkaEventMsk: KafkaSelfManagedEvent =
+      TestEvents.kafkaEventSelfManaged as KafkaSelfManagedEvent;
+    const parsedRecord: KafkaRecord = KafkaRecordSchema.parse(
+      kafkaEventMsk.records['mytopic-0'][0]
+    );
+    expect(parsedRecord.topic).toEqual('mytopic');
   });
 });

--- a/packages/parser/tests/unit/schema/kinesis.test.ts
+++ b/packages/parser/tests/unit/schema/kinesis.test.ts
@@ -5,10 +5,22 @@
  */
 
 import {
+  KinesisDataStreamRecord,
   KinesisDataStreamSchema,
+  KinesisFirehoseRecordSchema,
   KinesisFirehoseSchema,
+  KinesisFirehoseSqsRecordSchema,
   KinesisFirehoseSqsSchema,
 } from '../../../src/schemas/';
+import type {
+  KinesisDataStreamEvent,
+  KinesisFireHoseEvent,
+  KinesisFireHoseSqsEvent,
+} from '../../../src/types';
+import type {
+  KinesisFirehoseRecord,
+  KinesisFirehoseSqsRecord,
+} from '../../../src/types/schema';
 import { TestEvents } from './utils.js';
 
 describe('Kinesis ', () => {
@@ -68,5 +80,34 @@ describe('Kinesis ', () => {
     kinesisFirehoseSQSEvent.records[0].data = 'not a valid json';
     const parsed = KinesisFirehoseSqsSchema.parse(kinesisFirehoseSQSEvent);
     expect(parsed.records[0].data).toEqual('not a valid json');
+  });
+  it('should parse a kinesis record from a kinesis event', () => {
+    const kinesisStreamEvent: KinesisDataStreamEvent =
+      TestEvents.kinesisStreamEvent as KinesisDataStreamEvent;
+    const parsedRecord = KinesisDataStreamRecord.parse(
+      kinesisStreamEvent.Records[0]
+    );
+
+    expect(parsedRecord.eventName).toEqual('aws:kinesis:record');
+  });
+
+  it('should parse a kinesis firehose record from a kinesis firehose event', () => {
+    const kinesisFirehoseEvent: KinesisFireHoseEvent =
+      TestEvents.kinesisFirehoseKinesisEvent as KinesisFireHoseEvent;
+    const parsedRecord: KinesisFirehoseRecord =
+      KinesisFirehoseRecordSchema.parse(kinesisFirehoseEvent.records[0]);
+
+    expect(parsedRecord.data).toEqual('Hello World');
+  });
+
+  it('should parse a sqs record from a kinesis firehose event', () => {
+    const kinesisFireHoseSqsEvent: KinesisFireHoseSqsEvent =
+      TestEvents.kinesisFirehoseSQSEvent as KinesisFireHoseSqsEvent;
+    const parsed: KinesisFirehoseSqsRecord =
+      KinesisFirehoseSqsRecordSchema.parse(kinesisFireHoseSqsEvent.records[0]);
+
+    expect(parsed.recordId).toEqual(
+      '49640912821178817833517986466168945147170627572855734274000000'
+    );
   });
 });

--- a/packages/parser/tests/unit/schema/ses.test.ts
+++ b/packages/parser/tests/unit/schema/ses.test.ts
@@ -4,12 +4,21 @@
  * @group unit/parser/schema/
  */
 
-import { SesSchema } from '../../../src/schemas/';
+import { SesRecordSchema, SesSchema } from '../../../src/schemas/';
+import type { SesEvent } from '../../../src/types';
+import type { SesRecord } from '../../../src/types/schema';
 import { TestEvents } from './utils.js';
 
-describe('Schema:', () => {
-  it('SES should parse ses event', () => {
+describe('SES', () => {
+  it('should parse ses event', () => {
     const sesEvent = TestEvents.sesEvent;
     expect(SesSchema.parse(sesEvent)).toEqual(sesEvent);
+  });
+
+  it('should parse record from ses event', () => {
+    const sesEvent: SesEvent = TestEvents.sesEvent as SesEvent;
+    const parsed: SesRecord = SesRecordSchema.parse(sesEvent.Records[0]);
+
+    expect(parsed.ses.mail.source).toEqual('janedoe@example.com');
   });
 });

--- a/packages/parser/tests/unit/schema/sns.test.ts
+++ b/packages/parser/tests/unit/schema/sns.test.ts
@@ -4,12 +4,45 @@
  * @group unit/parser/schema/
  */
 
-import { SnsSchema } from '../../../src/schemas/';
+import {
+  SnsNotificationSchema,
+  SnsRecordSchema,
+  SnsSchema,
+  SnsSqsNotificationSchema,
+} from '../../../src/schemas/';
+import type { SnsEvent, SqsEvent } from '../../../src/types';
+import type {
+  SnsNotification,
+  SnsRecord,
+  SnsSqsNotification,
+} from '../../../src/types/schema';
 import { TestEvents } from './utils.js';
 
-describe('Schema:', () => {
-  it('SNS should parse sns event', () => {
+describe('SNS', () => {
+  it('should parse sns event', () => {
     const snsEvent = TestEvents.snsEvent;
     expect(SnsSchema.parse(snsEvent)).toEqual(snsEvent);
+  });
+  it('should parse record from sns event', () => {
+    const snsEvent: SnsEvent = TestEvents.snsEvent as SnsEvent;
+    const parsed: SnsRecord = SnsRecordSchema.parse(snsEvent.Records[0]);
+    expect(parsed.Sns.Message).toEqual('Hello from SNS!');
+  });
+  it('should parse sns notification from sns event', () => {
+    const snsEvent: SnsEvent = TestEvents.snsEvent as SnsEvent;
+    const parsed: SnsNotification = SnsNotificationSchema.parse(
+      snsEvent.Records[0].Sns
+    );
+    expect(parsed.Message).toEqual('Hello from SNS!');
+  });
+  it('should parse sns notification from sqs -> sns event', () => {
+    const sqsEvent: SqsEvent = TestEvents.snsSqsEvent as SqsEvent;
+    console.log(sqsEvent.Records[0].body);
+    const parsed: SnsSqsNotification = SnsSqsNotificationSchema.parse(
+      JSON.parse(sqsEvent.Records[0].body)
+    );
+    expect(parsed.TopicArn).toEqual(
+      'arn:aws:sns:eu-west-1:231436140809:powertools265'
+    );
   });
 });

--- a/packages/parser/tests/unit/schema/sqs.test.ts
+++ b/packages/parser/tests/unit/schema/sqs.test.ts
@@ -4,12 +4,19 @@
  * @group unit/parser/schema/
  */
 
-import { SqsSchema } from '../../../src/schemas/';
+import { SqsRecordSchema, SqsSchema } from '../../../src/schemas/';
+import type { SqsEvent } from '../../../src/types';
+import type { SqsRecord } from '../../../src/types/schema';
 import { TestEvents } from './utils.js';
 
-describe('SQS ', () => {
+describe('SQS', () => {
   it('should parse sqs event', () => {
     const sqsEvent = TestEvents.sqsEvent;
     expect(SqsSchema.parse(sqsEvent)).toEqual(sqsEvent);
+  });
+  it('should parse record from sqs event', () => {
+    const sqsEvent: SqsEvent = TestEvents.sqsEvent as SqsEvent;
+    const parsed: SqsRecord = SqsRecordSchema.parse(sqsEvent.Records[0]);
+    expect(parsed.body).toEqual('Test message.');
   });
 });


### PR DESCRIPTION
## Summary

### Changes

Adds the export for the schema and the corresponding types of the `Record` schemas.

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

**Issue number: closes #2811** 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
