### PR TITLE
chore(layers): deploy Lambda layers in `ap-south-2` and `me-central-1`

### DIFF
--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -41,6 +41,7 @@ jobs:
             "us-west-2",
             "ap-east-1",
             "ap-south-1",
+            "ap-south-2",
             "ap-northeast-1",
             "ap-northeast-2",
             "ap-northeast-3",
@@ -58,6 +59,7 @@ jobs:
             "eu-north-1",
             "sa-east-1",
             "me-south-1",
+            "me-central-1",
             "il-central-1",
           ]
     steps:

--- a/docs/index.md
+++ b/docs/index.md
@@ -260,6 +260,7 @@ You can use the Lambda Layer both with CommonJS and ESM (ECMAScript modules) for
     | `us-west-1`      | [arn:aws:lambda:us-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:      |
     | `us-west-2`      | [arn:aws:lambda:us-west-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:      |
     | `ap-south-1`     | [arn:aws:lambda:ap-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
+    | `ap-south-2`     | [arn:aws:lambda:ap-south-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
     | `ap-east-1`      | [arn:aws:lambda:ap-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:      |
     | `ap-northeast-1` | [arn:aws:lambda:ap-northeast-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard: |
     | `ap-northeast-2` | [arn:aws:lambda:ap-northeast-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard: |
@@ -281,6 +282,7 @@ You can use the Lambda Layer both with CommonJS and ESM (ECMAScript modules) for
     | `sa-east-1`      | [arn:aws:lambda:sa-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:      |
     | `af-south-1`     | [arn:aws:lambda:af-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
     | `me-south-1`     | [arn:aws:lambda:me-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
+    | `me-central-1`     | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
     | `il-central-1`   | [arn:aws:lambda:il-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:   |
 
 **Want to inspect the contents of the Layer?**

--- a/docs/index.md
+++ b/docs/index.md
@@ -282,7 +282,7 @@ You can use the Lambda Layer both with CommonJS and ESM (ECMAScript modules) for
     | `sa-east-1`      | [arn:aws:lambda:sa-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:      |
     | `af-south-1`     | [arn:aws:lambda:af-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
     | `me-south-1`     | [arn:aws:lambda:me-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
-    | `me-central-1`     | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
+    | `me-central-1`   | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:     |
     | `il-central-1`   | [arn:aws:lambda:il-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:12](#){: .copyMe}:clipboard:   |
 
 **Want to inspect the contents of the Layer?**


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds the necessary config to the CI workflows to deploy our public Lambda layers to two new commercial regions: `ap-south-2` and `me-central-1`.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #2674

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
