### PR TITLE
fix(tracer): include request pathname in trace data

### DIFF
--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -28,7 +28,7 @@ import { addUserAgentMiddleware } from '@aws-lambda-powertools/commons';
 import type { DiagnosticsChannel } from 'undici-types';
 import {
   findHeaderAndDecode,
-  getOriginURL,
+  getRequestURL,
   isHttpSubsegment,
 } from './utilities.js';
 
@@ -107,16 +107,18 @@ class ProviderService implements ProviderServiceInterface {
       const { request } = message as DiagnosticsChannel.RequestCreateMessage;
 
       const parentSubsegment = this.getSegment();
-      if (parentSubsegment && request.origin) {
-        const origin = getOriginURL(request.origin);
+      const requestURL = getRequestURL(request);
+      if (parentSubsegment && requestURL) {
         const method = request.method;
 
-        const subsegment = parentSubsegment.addNewSubsegment(origin.hostname);
+        const subsegment = parentSubsegment.addNewSubsegment(
+          requestURL.hostname
+        );
         subsegment.addAttribute('namespace', 'remote');
 
         (subsegment as HttpSubsegment).http = {
           request: {
-            url: origin.hostname,
+            url: `${requestURL.protocol}//${requestURL.hostname}${requestURL.pathname}`,
             method,
           },
         };

--- a/packages/tracer/src/provider/utilities.ts
+++ b/packages/tracer/src/provider/utilities.ts
@@ -1,5 +1,6 @@
 import { URL } from 'node:url';
 import type { Segment, Subsegment } from 'aws-xray-sdk-core';
+import type { DiagnosticsChannel } from 'undici-types';
 import type { HttpSubsegment } from '../types/ProviderService.js';
 
 const decoder = new TextDecoder();
@@ -52,12 +53,24 @@ const isHttpSubsegment = (
 };
 
 /**
- * Convert the origin url to a URL object when it is a string
+ * Convert the origin url to a URL object when it is a string and append the path if provided
  *
- * @param origin The origin url
+ * @param origin The request object containing the origin url and path
  */
-const getOriginURL = (origin: string | URL): URL => {
-  return origin instanceof URL ? origin : new URL(origin);
+const getRequestURL = (
+  request: DiagnosticsChannel.Request
+): URL | undefined => {
+  if (typeof request.origin === 'string') {
+    return new URL(`${request.origin}${request.path || ''}`);
+  }
+
+  if (request.origin instanceof URL) {
+    request.origin.pathname = request.path || '';
+
+    return request.origin;
+  }
+
+  return undefined;
 };
 
-export { findHeaderAndDecode, isHttpSubsegment, getOriginURL };
+export { findHeaderAndDecode, isHttpSubsegment, getRequestURL };

--- a/packages/tracer/tests/e2e/middy.test.ts
+++ b/packages/tracer/tests/e2e/middy.test.ts
@@ -110,7 +110,7 @@ describe('Tracer E2E tests, middy instrumentation', () => {
     const httpSubsegment = subsegments.get('docs.powertools.aws.dev');
     expect(httpSubsegment?.namespace).toBe('remote');
     expect(httpSubsegment?.http?.request?.url).toEqual(
-      'docs.powertools.aws.dev'
+      'https://docs.powertools.aws.dev/lambda/typescript/latest/'
     );
     expect(httpSubsegment?.http?.request?.method).toBe('GET');
     expect(httpSubsegment?.http?.response?.status).toEqual(expect.any(Number));

--- a/packages/tracer/tests/helpers/mockRequests.ts
+++ b/packages/tracer/tests/helpers/mockRequests.ts
@@ -2,7 +2,8 @@ import { channel } from 'node:diagnostics_channel';
 import type { URL } from 'node:url';
 
 type MockFetchOptions = {
-  origin: string | URL;
+  origin?: string | URL;
+  path?: string;
   method?: string;
   headers?: { [key: string]: string };
 } & (
@@ -25,6 +26,7 @@ type MockFetchOptions = {
  */
 const mockFetch = ({
   origin,
+  path,
   method,
   statusCode,
   headers,
@@ -37,6 +39,7 @@ const mockFetch = ({
   const request = {
     origin,
     method: method ?? 'GET',
+    path,
   };
 
   requestCreateChannel.publish({


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR modifies the internal implementation of the Tracer patching for the `fetch` request module so that it includes the pathname of a request in the segment data.

As reported in the linked issue, the current implementation only records the host name, so a request to `https://aws.amazon.com/free` would generate a segment similar to this:

```json
{
  "id": "45b22f447784c44f",
  "name": "aws.amazon.com",
  "start_time": 1724108234.18,
  "namespace": "remote",
  "http": {
    "request": {
      "url": "aws.amazon.com",
      "method": "GET"
    },
    "response": {
      "status": 301,
      "content_length": 0
    }
  },
  "end_time": 1724108234.849
}
```

while it should have generated one like this:

```json
{
  "id": "e861c05fa31a14ab",
  "name": "aws.amazon.com",
  "start_time": 1724108234.856,
  "namespace": "remote",
  "http": {
    "request": {
      "url": "https://aws.amazon.com/free",
      "method": "GET"
    },
    "response": {
      "status": 301,
      "content_length": 0
    }
  },
  "end_time": 1724108235.218
}
```

Notice how the `http.request.url` includes both the path and protocol.

The PR also modifies and adds some unit tests to account for the updated logic.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #2954

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
