### PR TITLE
improv(metrics): avoid emitting empty EMF metric

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -428,17 +428,15 @@ class Metrics extends Utility implements MetricsInterface {
    * ```
    */
   public publishStoredMetrics(): void {
-    if (
-      !this.shouldThrowOnEmptyMetrics &&
-      Object.keys(this.storedMetrics).length === 0
-    ) {
+    const hasMetrics = Object.keys(this.storedMetrics).length > 0;
+    if (!this.shouldThrowOnEmptyMetrics && !hasMetrics) {
       console.warn(
         'No application metrics to publish. The cold-start metric may be published if enabled. ' +
           'If application metrics should never be empty, consider using `throwOnEmptyMetrics`'
       );
     }
-    const target = this.serializeMetrics();
-    this.console.log(JSON.stringify(target));
+    const emfOutput = this.serializeMetrics();
+    hasMetrics && this.console.log(JSON.stringify(emfOutput));
     this.clearMetrics();
     this.clearDimensions();
     this.clearMetadata();

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -1256,15 +1256,17 @@ describe('Class: Metrics', () => {
       // Prepare
       const metrics: Metrics = new Metrics({ namespace: TEST_NAMESPACE });
       const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
 
       // Act
       metrics.publishStoredMetrics();
 
       // Assess
-      expect(consoleWarnSpy).toBeCalledTimes(1);
-      expect(consoleWarnSpy).toBeCalledWith(
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
         'No application metrics to publish. The cold-start metric may be published if enabled. If application metrics should never be empty, consider using `throwOnEmptyMetrics`'
       );
+      expect(consoleLogSpy).not.toHaveBeenCalled();
     });
 
     test('it should call serializeMetrics && log the stringified return value of serializeMetrics', () => {

--- a/packages/metrics/tests/unit/middleware/middy.test.ts
+++ b/packages/metrics/tests/unit/middleware/middy.test.ts
@@ -107,19 +107,16 @@ describe('Middy middleware', () => {
       await handler(event, context);
 
       // Assess
-      const loggedData = [
-        JSON.parse(consoleSpy.mock.calls[0][0]),
-        JSON.parse(consoleSpy.mock.calls[1][0]),
-      ];
-      expect(consoleSpy).toBeCalledTimes(2);
-      expect(loggedData[0]._aws.CloudWatchMetrics[0].Metrics.length).toBe(1);
-      expect(loggedData[0]._aws.CloudWatchMetrics[0].Metrics[0].Name).toBe(
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      const loggedData = JSON.parse(consoleSpy.mock.calls[0][0]);
+      expect(loggedData._aws.CloudWatchMetrics[0].Metrics.length).toBe(1);
+      expect(loggedData._aws.CloudWatchMetrics[0].Metrics[0].Name).toBe(
         'ColdStart'
       );
-      expect(loggedData[0]._aws.CloudWatchMetrics[0].Metrics[0].Unit).toBe(
+      expect(loggedData._aws.CloudWatchMetrics[0].Metrics[0].Unit).toBe(
         'Count'
       );
-      expect(loggedData[0].ColdStart).toBe(1);
+      expect(loggedData.ColdStart).toBe(1);
     });
 
     test('should not capture cold start metrics if set to false', async () => {
@@ -143,9 +140,7 @@ describe('Middy middleware', () => {
       await handler(event, context);
 
       // Assess
-      const loggedData = JSON.parse(consoleSpy.mock.calls[0][0]);
-
-      expect(loggedData._aws.CloudWatchMetrics[0].Metrics.length).toBe(0);
+      expect(consoleSpy).not.toHaveBeenCalled();
     });
 
     test('should not throw on empty metrics if not set', async () => {

--- a/packages/metrics/tests/unit/repro.test.ts
+++ b/packages/metrics/tests/unit/repro.test.ts
@@ -1,0 +1,71 @@
+import middy from '@middy/core';
+import type { Context } from 'aws-lambda';
+import { Metrics } from '../../src/Metrics.js';
+import { logMetrics } from '../../src/middleware/middy.js';
+
+describe('Metrics', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'warn').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('does not log', () => {
+    process.env.POWERTOOLS_DEV = 'true';
+    const metrics = new Metrics({
+      serviceName: 'foo',
+      namespace: 'bar',
+      defaultDimensions: {
+        aws_account_id: '123456789012',
+        aws_region: 'us-west-2',
+      },
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    metrics.publishStoredMetrics();
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('does log because of captureColdStartMetric enabled', () => {
+    process.env.POWERTOOLS_DEV = 'true';
+    const metrics = new Metrics({
+      serviceName: 'foo',
+      namespace: 'bar',
+      defaultDimensions: {
+        aws_account_id: '123456789012',
+        aws_region: 'us-west-2',
+      },
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+    const handler = middy(() => {}).use(
+      logMetrics(metrics, { captureColdStartMetric: true })
+    );
+
+    handler({}, {} as Context);
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not log because of captureColdStartMetric disabled', () => {
+    process.env.POWERTOOLS_DEV = 'true';
+    const metrics = new Metrics({
+      serviceName: 'foo',
+      namespace: 'bar',
+      defaultDimensions: {
+        aws_account_id: '123456789012',
+        aws_region: 'us-west-2',
+      },
+    });
+    const logSpy = jest.spyOn(console, 'log').mockImplementation();
+    const handler = middy(() => {}).use(
+      logMetrics(metrics, { captureColdStartMetric: false })
+    );
+
+    handler({}, {} as Context);
+
+    expect(logSpy).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR improves the Metrics utility by avoiding to log an empty metric when the buffer is flushed and no metric is present.

Before this PR the utility would log an EMF log with no metrics when attempting to flush the buffer and no metrics were set. The PR aligns the behavior with the Python version of Powertools for AWS.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3023

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
