### PR TITLE
improv(parameters): include cause in set parameter error

### DIFF
--- a/packages/parameters/src/errors.ts
+++ b/packages/parameters/src/errors.ts
@@ -1,19 +1,23 @@
 /**
  * Error thrown when a parameter cannot be retrieved.
+ *
+ * You can use this error to catch and handle errors when getting a parameter, the `cause` property will contain the original error.
  */
 class GetParameterError extends Error {
-  public constructor(message?: string) {
-    super(message);
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'GetParameterError';
   }
 }
 
 /**
  * Error thrown when a parameter cannot be set.
+ *
+ * You can use this error to catch and handle errors when setting a parameter, the `cause` property will contain the original error.
  */
 class SetParameterError extends Error {
-  public constructor(message?: string) {
-    super(message);
+  public constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SetParameterError';
   }
 }

--- a/packages/parameters/src/ssm/SSMProvider.ts
+++ b/packages/parameters/src/ssm/SSMProvider.ts
@@ -376,11 +376,12 @@ class SSMProvider extends BaseProvider {
     try {
       result = await this.client.send(new PutParameterCommand(sdkOptions));
     } catch (error) {
-      throw new SetParameterError(`Unable to set parameter with name ${name}`);
+      throw new SetParameterError(`Unable to set parameter with name ${name}`, {
+        cause: error,
+      });
     }
 
-    // biome-ignore lint/style/noNonNullAssertion: The API for PutParameter states that there will always be a value returned when the request was successful.
-    return result.Version!;
+    return result.Version as number;
   }
 
   /**

--- a/packages/parameters/src/ssm/setParameter.ts
+++ b/packages/parameters/src/ssm/setParameter.ts
@@ -71,8 +71,8 @@ import { SSMProvider } from './SSMProvider.js';
  *
  *  For more usage examples, see [our documentation](https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parameters/).
  *
- *  @param {string} name - Name of the parameter
- *  @param {SSMSetOptions} options - Options to configure the parameter
+ *  @param name - Name of the parameter
+ *  @param options - Options to configure the parameter
  *  @see https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/parameters/
  */
 const setParameter = async <

--- a/packages/parameters/src/ssm/setParameter.ts
+++ b/packages/parameters/src/ssm/setParameter.ts
@@ -35,7 +35,7 @@ import { SSMProvider } from './SSMProvider.js';
  * };
  * ```
  *
- * ### Extra SDK options
+ * **Extra SDK options**
  *
  * When setting a parameter, you can pass extra options to the AWS SDK v3 for JavaScript client by using the sdkOptions parameter.
  *
@@ -52,17 +52,15 @@ import { SSMProvider } from './SSMProvider.js';
  *    },
  *  });
  * };
- *  ```
+ * ```
  *
- *  This object accepts the same options as the AWS SDK v3 for JavaScript `PutParameterCommandInput` interface.
+ * This object accepts the same options as the AWS SDK v3 for JavaScript `PutParameterCommandInput` interface.
  *
- *  **Built-in provider class**
+ * For greater flexibility such as configuring the underlying SDK client used by built-in providers, you can use the {@link SSMProvider} utility.
  *
- *  For greater flexibility such as configuring the underlying SDK client used by built-in providers, you can use the {@link SSMProvider} class.
+ * **Options**
  *
- *  **Options**
- *
- *   You can customize the storage of the value by passing options to the function:
+ * You can customize the storage of the value by passing options to the function:
  * * `value` - The value of the parameter, which is a mandatory option.
  * * `overwrite` - Whether to overwrite the value if it already exists (default: `false`)
  * * `description` - The description of the parameter

--- a/packages/parameters/src/ssm/setParameter.ts
+++ b/packages/parameters/src/ssm/setParameter.ts
@@ -3,36 +3,21 @@ import type { SSMSetOptions } from '../types/SSMProvider.js';
 import { SSMProvider } from './SSMProvider.js';
 
 /**
- * ## Intro
- * The Parameters utility provides an SSMProvider that allows setting parameters in AWS Systems Manager.
+ * Set a parameter in AWS Systems Manager Parameter Store.
  *
- * ## Getting started
- *
- * This utility supports AWS SDK v3 for JavaScript only. This allows the utility to be modular, and you to install only
- * the SDK packages you need and keep your bundle size small.
- *
- * To use the provider, you must install the Parameters utility and the AWS SDK v3 for JavaScript for SSM:
- *
- * ```sh
- * npm install @aws-lambda-powertools/parameters @aws-sdk/client-ssm
- *```
- *
- * ## Basic Usage
+ * **Basic Usage**
  *
  * @example
  * ```typescript
  * import { setParameter } from '@aws-lambda-powertools/parameters/ssm';
  *
- * export const handler = async (): Promise<void> => {
- *  // Set a parameter
- *  const version = await setParameter('/my-parameter', { value: 'my-value' });
- *  console.log(Parameter version: ${version});
+ * export const handler = async () => {
+ *   // Set a parameter
+ *   const version = await setParameter('/my-parameter', { value: 'my-value' });
  * };
  * ```
  *
- * ## Advanced Usage
- *
- * ### Overwriting a parameter
+ * **Overwriting a parameter**
  *
  * By default, the provider will not overwrite a parameter if it already exists. You can force the provider to overwrite the parameter by using the `overwrite` option.
  *
@@ -71,11 +56,11 @@ import { SSMProvider } from './SSMProvider.js';
  *
  *  This object accepts the same options as the AWS SDK v3 for JavaScript `PutParameterCommandInput` interface.
  *
- *  ### Built-in provider class
+ *  **Built-in provider class**
  *
  *  For greater flexibility such as configuring the underlying SDK client used by built-in providers, you can use the {@link SSMProvider} class.
  *
- *  ### Options
+ *  **Options**
  *
  *   You can customize the storage of the value by passing options to the function:
  * * `value` - The value of the parameter, which is a mandatory option.


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR is a follow up to #3020 and brings a small DX improvement by including the cause of the error we throw when setting a parameter fails.

Before this PR, when the put parameter operation failed, we threw an opaque `SetParameterError`. Now, we include the original error from the AWS SDK as cause for an easier troubleshooting.

With this PR, the error would instead be:

```json
{
  "error":{
      "name":"SetParameterError",
      "location":"file:///var/task/index.mjs:1317",
      "message":"Unable to set parameter with name /my-service/parameter",
      "stack":"SetParameterError: Unable to set parameter with name /my-service/parameter\n    at _SSMProvider.set (file:///var/task/index.mjs:1317:13)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async Runtime.handler (file:///var/task/index.mjs:3477:5)",
      "cause":{
         "name":"ParameterAlreadyExists",
         "location":"/var/runtime/node_modules/@aws-sdk/client-ssm/dist-cjs/index.js:7913",
         "message":"The parameter already exists. To overwrite this value, set the overwrite option in the request to true.",
         "stack":"ParameterAlreadyExists: The parameter already exists. To overwrite this value, set the overwrite option in the request to true.\n    at de_ParameterAlreadyExistsRes (/var/runtime/node_modules/@aws-sdk/client-ssm/dist-cjs/index.js:7913:21)\n    at de_CommandError (/var/runtime/node_modules/@aws-sdk/client-ssm/dist-cjs/index.js:6931:19)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async /var/runtime/node_modules/@aws-sdk/node_modules/@smithy/middleware-serde/dist-cjs/index.js:35:20\n    at async /var/runtime/node_modules/@aws-sdk/node_modules/@smithy/core/dist-cjs/index.js:165:18\n    at async /var/runtime/node_modules/@aws-sdk/node_modules/@smithy/middleware-retry/dist-cjs/index.js:320:38\n    at async file:///var/task/index.mjs:927:12\n    at async /var/runtime/node_modules/@aws-sdk/middleware-logger/dist-cjs/index.js:34:22\n    at async _SSMProvider.set (file:///var/task/index.mjs:1315:16)\n    at async Runtime.handler (file:///var/task/index.mjs:3477:5)"
      }
   }
}
```

While working on this, I also slightly improved the API docs for the new feature.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3046

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
