### PR TITLE
improv(tracer): set `AWS_XRAY_CONTEXT_MISSING` to `IGNORE_ERROR` when no value is set

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -1,3 +1,15 @@
+/**
+ * If the AWS_XRAY_CONTEXT_MISSING environment variable is not set, we set it to IGNORE_ERROR.
+ *
+ * This is to prevent the AWS X-Ray SDK from logging errors when using top-level await features that make HTTP requests.
+ * For example, when using the Parameters utility to fetch parameters during the initialization of the Lambda handler - See #2046
+ */
+if (
+  process.env.AWS_XRAY_CONTEXT_MISSING === '' ||
+  process.env.AWS_XRAY_CONTEXT_MISSING === undefined
+) {
+  process.env.AWS_XRAY_CONTEXT_MISSING = 'IGNORE_ERROR';
+}
 import { Utility } from '@aws-lambda-powertools/commons';
 import type {
   AsyncHandler,

--- a/packages/tracer/src/index.ts
+++ b/packages/tracer/src/index.ts
@@ -1,1 +1,13 @@
+/**
+ * If the AWS_XRAY_CONTEXT_MISSING environment variable is not set, we set it to IGNORE_ERROR.
+ *
+ * This is to prevent the AWS X-Ray SDK from logging errors when using top-level await features that make HTTP requests.
+ * For example, when using the Parameters utility to fetch parameters during the initialization of the Lambda handler - See #2046
+ */
+if (
+  process.env.AWS_XRAY_CONTEXT_MISSING === '' ||
+  process.env.AWS_XRAY_CONTEXT_MISSING === undefined
+) {
+  process.env.AWS_XRAY_CONTEXT_MISSING = 'IGNORE_ERROR';
+}
 export { Tracer } from './Tracer.js';

--- a/packages/tracer/src/index.ts
+++ b/packages/tracer/src/index.ts
@@ -1,13 +1,1 @@
-/**
- * If the AWS_XRAY_CONTEXT_MISSING environment variable is not set, we set it to IGNORE_ERROR.
- *
- * This is to prevent the AWS X-Ray SDK from logging errors when using top-level await features that make HTTP requests.
- * For example, when using the Parameters utility to fetch parameters during the initialization of the Lambda handler - See #2046
- */
-if (
-  process.env.AWS_XRAY_CONTEXT_MISSING === '' ||
-  process.env.AWS_XRAY_CONTEXT_MISSING === undefined
-) {
-  process.env.AWS_XRAY_CONTEXT_MISSING = 'IGNORE_ERROR';
-}
 export { Tracer } from './Tracer.js';

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -59,6 +59,13 @@ describe('Class: Tracer', () => {
   });
 
   describe('Method: constructor', () => {
+    it('sets the AWS_XRAY_CONTEXT_MISSING environment variable to IGNORE_ERROR when it is not set', () => {
+      // We are setting the environment variable as a side effect of importing the module, setting it within the Tracer would
+      // require introducing async code to the constructor, which is not a good practice, in order to lazy load the AWS X-Ray SDK for Node.js
+      // on demand. Between that option, and setting it as a side effect of importing the module, the latter is the better option.
+      expect(process.env.AWS_XRAY_CONTEXT_MISSING).toBe('IGNORE_ERROR');
+    });
+
     it('instantiates with default settings when no option is passed', () => {
       // Prepare & Act
       const tracer = new Tracer(undefined);


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the Tracer utility to set the `AWS_XRAY_CONTEXT_MISSING` environment variable to `IGNORE_ERROR` by default.

This change has been made in response to customers adopting features that rely on top-level await and finding the error logs produced by X-Ray SDK not useful.

The X-Ray SDK for Node.js was not designed with this feature in mind, and by default it logs an error when a code path attempts to send trace data outside of the context of a request.

This is because without the request context, there's no X-Ray Trace ID, and so the SDK is unable to establish the lineage of a segment/span.

In many cases this is a desired behavior (although I'd have preferred it was a warning rather than an error log), however now that making async operations during the init phase is possible, it's not uncommon to make outbound http requests or use the AWS SDK to retrieve data or perform setup operations.

In those cases, the auto instrumentation features of Tracer (& the underlying X-Ray SDK) attempt to create a segment for these operations but don't find one because these tasks are run during the init phase, and thus outside of the context of a request.

The change has been made with backwards compatibility in mind, to an extent. Before setting the value we check if the env variable is already set and if so, we leave it as-is. 

I believe this is a good middle ground between furthering our features and maintaining flexibility.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #2406

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
