### PR TITLE
chore(deps-dev): bump path-to-regexp to 6.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13693,9 +13693,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true
     },
     "node_modules/path-type": {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

Dependabot is flagging this dependency as vulnerable and needing of update, however it's unable to open a PR automatically for whatever reason.

Instead of wasting time troubleshooting the tool, I just ran `npm audit fix` locally and pushed to this branch - fixing the issue.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3069

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
