### PR TITLE
docs: bump mkdocs docker image to 3.5.35

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,5 +1,5 @@
-# version 9.5.2
-FROM squidfunk/mkdocs-material@sha256:a2e3a31c00cfe1dd2dae83ba21dbfa2c04aee2fa2414275c230c27b91a4eda09
+# version 9.5.35
+FROM squidfunk/mkdocs-material@sha256:2a703999163cdb8257a85849fb2d39914a82587769f95c297bb3f01acf72a609
 
 COPY requirements.txt /tmp/
 RUN pip install --require-hashes -r /tmp/requirements.txt


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

This PR bumps [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material/tags) image to v3.5.35 that fixes the issue in #3073 

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3073 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
