### PR TITLE
chore(deps): bump @aws-cdk/cli-lib-alpha to 2.160.0-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,14 +194,6 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
-    "node_modules/@aws-cdk/cli-lib-alpha": {
-      "version": "2.155.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cli-lib-alpha/-/cli-lib-alpha-2.155.0-alpha.0.tgz",
-      "integrity": "sha512-2hXV65AP3h21aelU//ygGdQi/33kjzD2hEe+Giv7ISuMFPk3zCIS7L+uClmtXISLGLyyCLY9xS/OmMzb3m6pxQ==",
-      "engines": {
-        "node": ">= 14.15.0"
-      }
-    },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "38.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
@@ -17888,7 +17880,7 @@
       "version": "2.8.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-cdk/cli-lib-alpha": "^2.155.0-alpha.0",
+        "@aws-cdk/cli-lib-alpha": "^2.160.0-alpha.0",
         "@aws-sdk/client-lambda": "^3.656.0",
         "@smithy/util-utf8": "^3.0.0",
         "aws-cdk-lib": "^2.160.0",
@@ -17897,6 +17889,14 @@
       },
       "devDependencies": {
         "@types/promise-retry": "^1.1.6"
+      }
+    },
+    "packages/testing/node_modules/@aws-cdk/cli-lib-alpha": {
+      "version": "2.160.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cli-lib-alpha/-/cli-lib-alpha-2.160.0-alpha.0.tgz",
+      "integrity": "sha512-1SOl12B5/Kvi83T4he7Y9KVucc+VEGCXNs2qoBDOke/df3eLvZy6VqzztfUezNBvP0hkboUG7sMKRgYMdY/sEw==",
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "packages/tracer": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -98,7 +98,7 @@
   },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/testing#readme",
   "dependencies": {
-    "@aws-cdk/cli-lib-alpha": "^2.155.0-alpha.0",
+    "@aws-cdk/cli-lib-alpha": "^2.160.0-alpha.0",
     "@aws-sdk/client-lambda": "^3.656.0",
     "@smithy/util-utf8": "^3.0.0",
     "aws-cdk-lib": "^2.160.0",


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR manually updates the `@aws-cdk/cli-lib-alpha` dependency since it's being excluded by Dependabot updates.

We think this is because the dependency has a pre release suffix in the version number (i.e. `2.160.0-alpha.0`) but we are still investigating and are unsure.

For the meantime, since this is blocking our e2e tests, I am updating this manually.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3117

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
