### PR TITLE
refactor(logger): use `LogLevelThreshold` constant inside `Logger` class 

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -119,7 +119,7 @@ class Logger extends Utility implements LoggerInterface {
   /**
    * Log level used internally by the current instance of Logger.
    */
-  private logLevel = 12;
+  private logLevel: number = LogLevelThreshold.INFO;
   /**
    * Persistent log attributes that will be logged in all log items.
    */

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -206,7 +206,6 @@ type LoggerInterface = {
 
 export type {
   Environment,
-  LogLevelThresholds,
   LogAttributes,
   LogLevel,
   LogFunction,

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -20,15 +20,6 @@ type LogLevel =
   | Lowercase<(typeof LogLevelList)[keyof typeof LogLevelList]>;
 
 /**
- * Type definition for the log level thresholds.
- *
- * Each log level has a corresponding number that represents its severity.
- */
-type LogLevelThresholds = {
-  [key in Uppercase<LogLevel>]: number;
-};
-
-/**
  * Type definition for a function that logs messages at different levels to the console.
  */
 type LogFunction = {

--- a/packages/logger/src/types/index.ts
+++ b/packages/logger/src/types/index.ts
@@ -1,6 +1,5 @@
 export type {
   Environment,
-  LogLevelThresholds,
   LogAttributes,
   LogLevel,
   LogItemMessage,


### PR DESCRIPTION
## Summary
The PR removes the local `LogLevelThreshold` object from `Logger` class and replaces it with `LogLevelThreshold` constant.
### Changes

- Removed the `LogLevelThreshold` object from the Logger class and replaced it with the `LogLevelThreshold` constant.
- Removed the `LogLevelThresholds` type and its exports.
- Performed housekeeping, the `private logLevel` property of the `Logger` class now uses the value from `LogLevelThreshold` instead of hardcoding the value.



**Issue number:** #2525 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
