### PR TITLE
chore(deps-dev): bump aws-cdk from 1.155.0 to 1.161.0 in layers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "examples/app/node_modules/aws-cdk": {
-      "version": "2.155.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.155.0.tgz",
-      "integrity": "sha512-AV7Ym/o7/xyDh6sqcGatWD6Bqa7Swe0OWJq+1srVww0MdBiy5yM3zYAA1+ZeqZNjFQThJPA+pYZQFTgojuaVBA==",
+      "version": "2.161.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.161.1.tgz",
+      "integrity": "sha512-aMQsiCv8VxR8uyZ7EX8sWt46q/rOHeIFiIJ6pBvzKzc1nWaoI149rSxykIGGTpt0puin0L5SwYl6f6Sp3zohzg==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -140,9 +140,9 @@
       }
     },
     "layers/node_modules/aws-cdk": {
-      "version": "2.155.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.155.0.tgz",
-      "integrity": "sha512-AV7Ym/o7/xyDh6sqcGatWD6Bqa7Swe0OWJq+1srVww0MdBiy5yM3zYAA1+ZeqZNjFQThJPA+pYZQFTgojuaVBA==",
+      "version": "2.161.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.161.1.tgz",
+      "integrity": "sha512-aMQsiCv8VxR8uyZ7EX8sWt46q/rOHeIFiIJ6pBvzKzc1nWaoI149rSxykIGGTpt0puin0L5SwYl6f6Sp3zohzg==",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -193,6 +193,14 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
+    },
+    "node_modules/@aws-cdk/cli-lib-alpha": {
+      "version": "2.161.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cli-lib-alpha/-/cli-lib-alpha-2.161.1-alpha.0.tgz",
+      "integrity": "sha512-HCokBr85Msv0tXiKth/3ZJZaQLzMmydk3NNEEA9fD/tzBh1zUcnlsBQnclOBmd0uKMNSZQertrroJmZv3mBOeg==",
+      "engines": {
+        "node": ">= 14.15.0"
+      }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "38.0.1",
@@ -17892,7 +17900,7 @@
       "version": "2.9.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-cdk/cli-lib-alpha": "^2.160.0-alpha.0",
+        "@aws-cdk/cli-lib-alpha": "^2.161.1-alpha.0",
         "@aws-sdk/client-lambda": "^3.664.0",
         "@smithy/util-utf8": "^3.0.0",
         "aws-cdk-lib": "^2.161.1",
@@ -17902,14 +17910,6 @@
       "devDependencies": {
         "@types/promise-retry": "^1.1.6",
         "aws-sdk-client-mock-vitest": "^4.0.0"
-      }
-    },
-    "packages/testing/node_modules/@aws-cdk/cli-lib-alpha": {
-      "version": "2.160.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cli-lib-alpha/-/cli-lib-alpha-2.160.0-alpha.0.tgz",
-      "integrity": "sha512-1SOl12B5/Kvi83T4he7Y9KVucc+VEGCXNs2qoBDOke/df3eLvZy6VqzztfUezNBvP0hkboUG7sMKRgYMdY/sEw==",
-      "engines": {
-        "node": ">= 14.15.0"
       }
     },
     "packages/tracer": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -98,7 +98,7 @@
   },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/testing#readme",
   "dependencies": {
-    "@aws-cdk/cli-lib-alpha": "^2.160.0-alpha.0",
+    "@aws-cdk/cli-lib-alpha": "^2.161.1-alpha.0",
     "@aws-sdk/client-lambda": "^3.664.0",
     "@smithy/util-utf8": "^3.0.0",
     "aws-cdk-lib": "^2.161.1",


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR manually bumps the `aws-cdk` development dependency used in the `layers` package to deploy the layers during a release.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3168

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
