### PR TITLE
chore(layers): remove schema parsing from layer canary

### DIFF
--- a/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
+++ b/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
@@ -8,7 +8,6 @@ import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
 import { DynamoDBProvider } from '@aws-lambda-powertools/parameters/dynamodb';
 import { SecretsProvider } from '@aws-lambda-powertools/parameters/secrets';
 import { SSMProvider } from '@aws-lambda-powertools/parameters/ssm';
-import { EventBridgeSchema } from '@aws-lambda-powertools/parser/schemas';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 import { AppConfigDataClient } from '@aws-sdk/client-appconfigdata';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -49,9 +48,6 @@ new DynamoDBProvider({ tableName: 'foo', awsSdkV3Client: ddbClient });
 
 // Instantiating the BatchProcessor will confirm that the utility can be used
 new BatchProcessor(EventType.SQS);
-
-const testPayload = { name: 'John', age: 42 };
-const testSchema = z.object({ name: z.string(), age: z.number() });
 
 const layerPath = process.env.LAYERS_PATH || '/opt/nodejs/node_modules';
 const expectedVersion = process.env.POWERTOOLS_PACKAGE_VERSION || '0.0.0';
@@ -121,7 +117,4 @@ export const handler = async (event: unknown): Promise<void> => {
   // the presence of a log will indicate that the logger is working
   // while the content of the log will indicate that the tracer is working
   logger.debug('subsegment', { subsegment: subsegment.format() });
-
-  // Check that the parser is working
-  testEventSchema.parse(event);
 };

--- a/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
+++ b/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
@@ -13,7 +13,6 @@ import { AppConfigDataClient } from '@aws-sdk/client-appconfigdata';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { SSMClient } from '@aws-sdk/client-ssm';
-import { z } from 'zod';
 
 const logger = new Logger({
   logLevel: 'DEBUG',

--- a/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
+++ b/layers/tests/e2e/layerPublisher.class.test.functionCode.ts
@@ -50,9 +50,8 @@ new DynamoDBProvider({ tableName: 'foo', awsSdkV3Client: ddbClient });
 // Instantiating the BatchProcessor will confirm that the utility can be used
 new BatchProcessor(EventType.SQS);
 
-const testSchema = z.object({ instance_id: z.string(), state: z.string() });
-
-const testEventSchema = EventBridgeSchema.extend({ detail: testSchema });
+const testPayload = { name: 'John', age: 42 };
+const testSchema = z.object({ name: z.string(), age: z.number() });
 
 const layerPath = process.env.LAYERS_PATH || '/opt/nodejs/node_modules';
 const expectedVersion = process.env.POWERTOOLS_PACKAGE_VERSION || '0.0.0';

--- a/layers/tests/e2e/layerPublisher.test.ts
+++ b/layers/tests/e2e/layerPublisher.test.ts
@@ -133,24 +133,6 @@ describe('Layers E2E tests', () => {
           functionName: testStack.findAndGetStackOutputValue(
             `test${outputFormat}Fn`
           ),
-          // Uses an EventBridge event payload to test parser functionality
-          payload: {
-            version: '0',
-            id: '6a7e8feb-b491-4cf7-a9f1-bf3703467718',
-            'detail-type': 'EC2 Instance State-change Notification',
-            source: 'aws.ec2',
-            account: '111122223333',
-            time: '2017-12-22T18:43:48Z',
-            region: 'us-west-1',
-            resources: [
-              'arn:aws:ec2:us-west-1:123456789012:instance/i-1234567890abcdef0',
-            ],
-            detail: {
-              instance_id: 'i-1234567890abcdef0',
-              state: 'terminated',
-            },
-            'replay-name': 'replay_archive',
-          } satisfies EventBridgeEvent<string, unknown>,
         })
       );
     }

--- a/layers/tests/e2e/layerPublisher.test.ts
+++ b/layers/tests/e2e/layerPublisher.test.ts
@@ -13,7 +13,6 @@ import {
 import { TestNodejsFunction } from '@aws-lambda-powertools/testing-utils/resources/lambda';
 import { App } from 'aws-cdk-lib';
 import { LayerVersion } from 'aws-cdk-lib/aws-lambda';
-import type { EventBridgeEvent } from 'aws-lambda';
 import packageJson from '../../package.json';
 import { LayerPublisherStack } from '../../src/layer-publisher-stack';
 import {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR removes the schema parsing portion of the test from the canary test of the Lambda layer. As discussed more in depth in the linked issue, with this parsing the canary test expects a payload that is not being sent thus making the canary fail.

While this PR only removes the parsing, we plan on reintroducing a different test in a future PR. For now we are focused on publishing the Lambda layers for the 2.9.0 version that is already on npm.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3170

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
