### PR TITLE
docs: fix env variable name in `logEventIfEnabled()` docstring

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -432,11 +432,11 @@ class Logger extends Utility implements LoggerInterface {
   }
 
   /**
-   * Log the AWS Lambda event payload for the current invocation if the environment variable `POWERTOOLS_LOG_EVENT` is set to `true`.
+   * Log the AWS Lambda event payload for the current invocation if the environment variable `POWERTOOLS_LOGGER_LOG_EVENT` is set to `true`.
    *
    * @example
    * ```ts
-   * process.env.POWERTOOLS_LOG_EVENT = 'true';
+   * process.env.POWERTOOLS_LOGGER_LOG_EVENT = 'true';
    *
    * import { Logger } from '@aws-lambda-powertools/logger';
    *


### PR DESCRIPTION

## Summary
fix typo for env variable POWERTOOLS_LOGGER_LOG_EVENT in logger.logEventIfEnabled

### Changes
> Please provide a summary of what's being changed

Fixed env details on typedoc for `logger.logEventIfEnabled` from `POWERTOOLS_LOG_EVENT` to `POWERTOOLS_LOGGER_LOG_EVENT` per discussion in #3196

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number: #3196**

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
