### PR TITLE
feat: add resetKeys to LoggerInterface type

### DIFF
--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -197,6 +197,7 @@ type LoggerInterface = {
   refreshSampleRateCalculation(): void;
   removeKeys(keys?: string[]): void;
   removePersistentLogAttributes(keys?: string[]): void;
+  resetKeys(): void;
   setLogLevel(logLevel: LogLevel): void;
   setPersistentLogAttributes(attributes?: LogAttributes): void;
   shouldLogEvent(overwriteValue?: boolean): boolean;


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Adding missing function definition `resetKeys()` to the `LoggerInterface` function

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** https://github.com/aws-powertools/powertools-lambda-typescript/issues/3212

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
