### PR TITLE
chore(parser): bump parser to 2.10.0

### DIFF
--- a/examples/snippets/package.json
+++ b/examples/snippets/package.json
@@ -30,7 +30,7 @@
     "@aws-lambda-powertools/logger": "^2.10.0",
     "@aws-lambda-powertools/metrics": "^2.10.0",
     "@aws-lambda-powertools/parameters": "^2.10.0",
-    "@aws-lambda-powertools/parser": "^2.9.0",
+    "@aws-lambda-powertools/parser": "^2.10.0",
     "@aws-lambda-powertools/tracer": "^2.10.0",
     "@aws-sdk/client-appconfigdata": "^3.675.0",
     "@aws-sdk/client-dynamodb": "^3.675.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
         "@aws-lambda-powertools/logger": "^2.10.0",
         "@aws-lambda-powertools/metrics": "^2.10.0",
         "@aws-lambda-powertools/parameters": "^2.10.0",
-        "@aws-lambda-powertools/parser": "^2.9.0",
+        "@aws-lambda-powertools/parser": "^2.10.0",
         "@aws-lambda-powertools/tracer": "^2.10.0",
         "@aws-sdk/client-appconfigdata": "^3.675.0",
         "@aws-sdk/client-dynamodb": "^3.675.0",
@@ -17898,7 +17898,7 @@
     },
     "packages/parser": {
       "name": "@aws-lambda-powertools/parser",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT-0",
       "devDependencies": {
         "@anatine/zod-mock": "^3.13.3",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aws-lambda-powertools/parser",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "The parser package for the Powertools for AWS Lambda (TypeScript) library.",
   "author": {
     "name": "Amazon Web Services",


### PR DESCRIPTION
## Summary

This PR bumps parser to 2.10.0 version for the release, because lerna ignored it.

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
