### PR TITLE
chore(maintenance): add force-publish to bump all packages

### DIFF
--- a/.github/workflows/make-version.yml
+++ b/.github/workflows/make-version.yml
@@ -31,7 +31,7 @@ jobs:
         uses: aws-powertools/actions/.github/actions/cached-node-modules@d406bac5563f1d8c793519a3eedfe620f6a14872
       - name: Version
         id: bump-version
-        run: npx lerna version --conventional-commits --no-git-tag-version --no-push --no-commit-hooks --yes
+        run: npx lerna version --conventional-commits --force-publish --no-git-tag-version --no-push --no-commit-hooks --yes
       - name: Update user agent version
         run: |
           VERSION=$(cat lerna.json | jq .version -r)


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds `--force-publish` flag to `make-version` workflow. This ensures that all packages are bumped during the version to ensure consistency during release.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3229 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
