### PR TITLE
feat(metrics): ability to set custom timestamp with `setTimestamp` for metrics

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -229,6 +229,18 @@ You can add default dimensions to your metrics by passing them as parameters in 
 
 If you'd like to remove them at some point, you can use the `clearDefaultDimensions` method.
 
+### Changing default timestamp
+
+When creating metrics, we use the current timestamp. If you want to change the timestamp of all the metrics you create, utilize the `setTimestamp` function. You can specify a datetime object or an integer representing an epoch timestamp in milliseconds.
+
+Note that when specifying the timestamp using an integer, it must adhere to the epoch timezone format in milliseconds.
+
+=== "setTimestamp method"
+
+    ```typescript hl_lines="13"
+    --8<-- "examples/snippets/metrics/setTimestamp.ts"
+    ```
+
 ### Flushing metrics
 
 As you finish adding all your metrics, you need to serialize and "flush them" by calling `publishStoredMetrics()`. This will print the metrics to standard output.

--- a/examples/snippets/metrics/setTimestamp.ts
+++ b/examples/snippets/metrics/setTimestamp.ts
@@ -1,0 +1,15 @@
+import { MetricUnit, Metrics } from '@aws-lambda-powertools/metrics';
+
+const metrics = new Metrics({
+  namespace: 'serverlessAirline',
+  serviceName: 'orders',
+});
+
+export const handler = async (
+  _event: unknown,
+  _context: unknown
+): Promise<void> => {
+  const metricTimestamp = new Date(Date.now() - 24 * 60 * 60 * 1000); // 24 hours ago
+  metrics.setTimestamp(metricTimestamp);
+  metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+};

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -982,7 +982,6 @@ class Metrics extends Utility implements MetricsInterface {
     }
 
     const timestampMs = isDate(timestamp) ? timestamp.getTime() : timestamp;
-
     const currentTime = new Date().getTime();
 
     const minValidTimestamp = currentTime - EMF_MAX_TIMESTAMP_PAST_AGE;
@@ -992,7 +991,7 @@ class Metrics extends Utility implements MetricsInterface {
   }
 
   /**
-   * Converts a given timestamp to EMF (Embedded Metric Format) compatible format.
+   * Converts a given timestamp to EMF compatible format.
    *
    * @param timestamp - The timestamp to convert, which can be either a number (in milliseconds) or a Date object.
    * @returns The timestamp in milliseconds. If the input is invalid, returns 0.
@@ -1004,9 +1003,11 @@ class Metrics extends Utility implements MetricsInterface {
     if (isDate(timestamp)) {
       return timestamp.getTime();
     }
-    // If this point is reached, input was neither a valid number nor Date
-    // Return 0 which represents the initial date of epoch time
-    // This will be skipped by Amazon CloudWatch
+    /**
+     * If this point is reached, it indicates timestamp was neither a valid number nor Date
+     * Returning zero represents the initial date of epoch time,
+     * which will be skipped by Amazon CloudWatch.
+     **/
     return 0;
   }
 }

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -1,4 +1,5 @@
 import { Console } from 'node:console';
+import { isDate } from 'node:util/types';
 import { Utility, isIntegerNumber } from '@aws-lambda-powertools/commons';
 import type {
   GenericLogger,
@@ -977,12 +978,11 @@ class Metrics extends Utility implements MetricsInterface {
     const EMF_MAX_TIMESTAMP_PAST_AGE = 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
     const EMF_MAX_TIMESTAMP_FUTURE_AGE = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
 
-    if (!(timestamp instanceof Date) && !isIntegerNumber(timestamp)) {
+    if (!isDate(timestamp) && !isIntegerNumber(timestamp)) {
       return false;
     }
 
-    const timestampMs =
-      timestamp instanceof Date ? timestamp.getTime() : timestamp;
+    const timestampMs = isDate(timestamp) ? timestamp.getTime() : timestamp;
 
     const currentTime = new Date().getTime();
 
@@ -1002,7 +1002,7 @@ class Metrics extends Utility implements MetricsInterface {
     if (isIntegerNumber(timestamp)) {
       return timestamp;
     }
-    if (timestamp instanceof Date) {
+    if (isDate(timestamp)) {
       return timestamp.getTime();
     }
     // If this point is reached, input was neither a valid number nor Date

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -587,6 +587,13 @@ class Metrics extends Utility implements MetricsInterface {
    * @param timestamp - The timestamp to set, which can be a number or a Date object.
    */
   public setTimestamp(timestamp: number | Date): void {
+    /**
+     * The timestamp must be a Date object or an integer representing an epoch time.
+     * This should not exceed 14 days in the past or be more than 2 hours in the future.
+     * Any metrics failing to meet this criteria will be skipped by Amazon CloudWatch.
+     * See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Specification.html
+     * See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch-Logs-Monitoring-CloudWatch-Metrics.html
+     **/
     if (!this.#validateEmfTimestamp(timestamp)) {
       this.#logger.warn(
         "This metric doesn't meet the requirements and will be skipped by Amazon CloudWatch. " +

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -10,6 +10,8 @@ import { EnvironmentVariablesService } from './config/EnvironmentVariablesServic
 import {
   COLD_START_METRIC,
   DEFAULT_NAMESPACE,
+  EMF_MAX_TIMESTAMP_FUTURE_AGE,
+  EMF_MAX_TIMESTAMP_PAST_AGE,
   MAX_DIMENSION_COUNT,
   MAX_METRICS_SIZE,
   MAX_METRIC_VALUES_SIZE,
@@ -975,9 +977,6 @@ class Metrics extends Utility implements MetricsInterface {
    * @param timestamp - Date object or epoch time in milliseconds representing the timestamp to validate.
    */
   #validateEmfTimestamp(timestamp: number | Date): boolean {
-    const EMF_MAX_TIMESTAMP_PAST_AGE = 14 * 24 * 60 * 60 * 1000; // 14 days in milliseconds
-    const EMF_MAX_TIMESTAMP_FUTURE_AGE = 2 * 60 * 60 * 1000; // 2 hours in milliseconds
-
     if (!isDate(timestamp) && !isIntegerNumber(timestamp)) {
       return false;
     }

--- a/packages/metrics/src/constants.ts
+++ b/packages/metrics/src/constants.ts
@@ -18,6 +18,16 @@ const MAX_METRIC_VALUES_SIZE = 100;
  * The maximum number of dimensions that can be added to a metric (0-indexed).
  */
 const MAX_DIMENSION_COUNT = 29;
+/**
+ * The maximum age of a timestamp in milliseconds that can be emitted in a metric.
+ * This is set to 14 days.
+ */
+const EMF_MAX_TIMESTAMP_PAST_AGE = 14 * 24 * 60 * 60 * 1000;
+/**
+ * The maximum age of a timestamp in milliseconds that can be emitted in a metric.
+ * This is set to 2 hours.
+ */
+const EMF_MAX_TIMESTAMP_FUTURE_AGE = 2 * 60 * 60 * 1000;
 
 /**
  * The unit of the metric.
@@ -73,4 +83,6 @@ export {
   MAX_DIMENSION_COUNT,
   MetricUnit,
   MetricResolution,
+  EMF_MAX_TIMESTAMP_PAST_AGE,
+  EMF_MAX_TIMESTAMP_FUTURE_AGE,
 };

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -2265,7 +2265,7 @@ describe('Class: Metrics', () => {
       },
       {
         format: 'Date object',
-        getTimestamp: (timestamp: number) => new Date(timestamp),
+        getTimestamp: (timestampMs: number) => new Date(timestampMs),
       },
     ];
 
@@ -2313,7 +2313,7 @@ describe('Class: Metrics', () => {
           );
         });
 
-        test('should not log a warning if the timestamp is withing valid future range', () => {
+        test('should not log a warning if the timestamp is within valid future range', () => {
           // Prepare
           const testMetric = 'test-metric';
           const timestampMs = mockDate.getTime() + EMF_MAX_TIMESTAMP_FUTURE_AGE;

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -2269,11 +2269,13 @@ describe('Class: Metrics', () => {
 
     for (const { format, getTimestamp } of testCases) {
       describe(`when timestamp is provided as ${format}`, () => {
+        const twoHours = 2 * 60 * 60 * 1000;
+        const fourteenDays = 14 * 24 * 60 * 60 * 1000;
+
         test('should set the timestamp if provided in the future', () => {
           // Prepare
           const testMetric = 'test-metric';
           const metrics: Metrics = new Metrics();
-          //Add 10 minutes to mockDate object  and still remain as date object
           const timestampMs = mockDate.getTime() + 10 * 60 * 1000; // Add 10 minutes in milliseconds
 
           // Act
@@ -2315,7 +2317,7 @@ describe('Class: Metrics', () => {
         test('should not log a warning if the timestamp exact two hours in the future and set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() + 2 * 60 * 60 * 1000; // Add 2 hours and 1 ms
+          const timestampMs = mockDate.getTime() + twoHours;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),
@@ -2344,7 +2346,7 @@ describe('Class: Metrics', () => {
         test('should log a warning if the timestamp is more than two hours in the future but still set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() + 2 * 60 * 60 * 1000 + 1; // Add 2 hours and 1 ms
+          const timestampMs = mockDate.getTime() + twoHours + 1;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),
@@ -2376,7 +2378,7 @@ describe('Class: Metrics', () => {
         test('should not log a warning if the timestamp is exact 14 days in the past and set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() - 14 * 24 * 60 * 60 * 1000; // Subtract 14 days
+          const timestampMs = mockDate.getTime() - fourteenDays;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),
@@ -2405,7 +2407,7 @@ describe('Class: Metrics', () => {
         test('should log a warning if the timestamp is more than 14 days in the past but still set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() - 14 * 24 * 60 * 60 * 1000 - 1; // Subtract 14 days and 1 ms
+          const timestampMs = mockDate.getTime() - fourteenDays - 1;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -10,6 +10,8 @@ import { EnvironmentVariablesService } from '../../src/config/EnvironmentVariabl
 import {
   COLD_START_METRIC,
   DEFAULT_NAMESPACE,
+  EMF_MAX_TIMESTAMP_FUTURE_AGE,
+  EMF_MAX_TIMESTAMP_PAST_AGE,
   MAX_DIMENSION_COUNT,
   MAX_METRICS_SIZE,
   MAX_METRIC_VALUES_SIZE,
@@ -2269,9 +2271,6 @@ describe('Class: Metrics', () => {
 
     for (const { format, getTimestamp } of testCases) {
       describe(`when timestamp is provided as ${format}`, () => {
-        const twoHours = 2 * 60 * 60 * 1000;
-        const fourteenDays = 14 * 24 * 60 * 60 * 1000;
-
         test('should set the timestamp if provided in the future', () => {
           // Prepare
           const testMetric = 'test-metric';
@@ -2314,10 +2313,10 @@ describe('Class: Metrics', () => {
           );
         });
 
-        test('should not log a warning if the timestamp exact two hours in the future and set the timestamp', () => {
+        test('should not log a warning if the timestamp is withing valid future range', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() + twoHours;
+          const timestampMs = mockDate.getTime() + EMF_MAX_TIMESTAMP_FUTURE_AGE;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),
@@ -2343,10 +2342,11 @@ describe('Class: Metrics', () => {
           );
         });
 
-        test('should log a warning if the timestamp is more than two hours in the future but still set the timestamp', () => {
+        test('should log a warning if the timestamp is more than the future range but still set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() + twoHours + 1;
+          const timestampMs =
+            mockDate.getTime() + EMF_MAX_TIMESTAMP_FUTURE_AGE + 1;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),
@@ -2375,10 +2375,10 @@ describe('Class: Metrics', () => {
           );
         });
 
-        test('should not log a warning if the timestamp is exact 14 days in the past and set the timestamp', () => {
+        test('should not log a warning if the timestamp is within past range and set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() - fourteenDays;
+          const timestampMs = mockDate.getTime() - EMF_MAX_TIMESTAMP_PAST_AGE;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),
@@ -2404,10 +2404,11 @@ describe('Class: Metrics', () => {
           );
         });
 
-        test('should log a warning if the timestamp is more than 14 days in the past but still set the timestamp', () => {
+        test('should log a warning if the timestamp is more than past range but still set the timestamp', () => {
           // Prepare
           const testMetric = 'test-metric';
-          const timestampMs = mockDate.getTime() - fourteenDays - 1;
+          const timestampMs =
+            mockDate.getTime() - EMF_MAX_TIMESTAMP_PAST_AGE - 1;
           const customLogger = {
             warn: jest.fn(),
             debug: jest.fn(),

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -32,8 +32,20 @@ jest.mock('node:console', () => ({
   })),
 }));
 jest.spyOn(console, 'warn').mockImplementation(() => ({}));
+const OriginalDate = Date;
 const mockDate = new Date(1466424490000);
-const dateSpy = jest.spyOn(global, 'Date').mockImplementation(() => mockDate);
+/**
+ * If the constructor is called without arguments, it returns a predefined mock date.
+ * Otherwise, it delegates to the original Date constructor with the provided arguments.
+ */
+const dateSpy = jest
+  .spyOn(global, 'Date')
+  .mockImplementation((...args: ConstructorParameters<typeof Date>) => {
+    if ((args as unknown[]).length === 0) {
+      return mockDate;
+    }
+    return new OriginalDate(...args);
+  });
 jest.spyOn(console, 'log').mockImplementation();
 jest.spyOn(console, 'warn').mockImplementation();
 
@@ -2240,6 +2252,250 @@ describe('Class: Metrics', () => {
       // Act & Assess
       // biome-ignore  lint/complexity/useLiteralKeys: This needs to be accessed with literal key for testing
       expect(metrics['console']).toEqual(console);
+    });
+  });
+
+  describe('Method: setTimestamp', () => {
+    const testCases = [
+      {
+        format: 'milliseconds',
+        getTimestamp: (timestampMs: number) => timestampMs,
+      },
+      {
+        format: 'Date object',
+        getTimestamp: (timestamp: number) => new Date(timestamp),
+      },
+    ];
+
+    for (const { format, getTimestamp } of testCases) {
+      describe(`when timestamp is provided as ${format}`, () => {
+        test('should set the timestamp if provided in the future', () => {
+          // Prepare
+          const testMetric = 'test-metric';
+          const metrics: Metrics = new Metrics();
+          //Add 10 minutes to mockDate object  and still remain as date object
+          const timestampMs = mockDate.getTime() + 10 * 60 * 1000; // Add 10 minutes in milliseconds
+
+          // Act
+          metrics.addMetric(testMetric, MetricUnit.Count, 10);
+          metrics.setTimestamp(getTimestamp(timestampMs));
+          const loggedData = metrics.serializeMetrics();
+
+          // Assess
+          expect(loggedData).toEqual(
+            expect.objectContaining({
+              _aws: expect.objectContaining({
+                Timestamp: timestampMs,
+              }),
+            })
+          );
+        });
+
+        test('should set the timestamp if provided in the past', () => {
+          // Prepare
+          const testMetric = 'test-metric';
+          const metrics: Metrics = new Metrics();
+          const timestampMs = mockDate.getTime() - 10 * 60 * 1000; // Subtract 10 minutes in milliseconds
+
+          // Act
+          metrics.addMetric(testMetric, MetricUnit.Count, 10);
+          metrics.setTimestamp(getTimestamp(timestampMs));
+          const loggedData = metrics.serializeMetrics();
+
+          // Assess
+          expect(loggedData).toEqual(
+            expect.objectContaining({
+              _aws: expect.objectContaining({
+                Timestamp: timestampMs,
+              }),
+            })
+          );
+        });
+
+        test('should not log a warning if the timestamp exact two hours in the future and set the timestamp', () => {
+          // Prepare
+          const testMetric = 'test-metric';
+          const timestampMs = mockDate.getTime() + 2 * 60 * 60 * 1000; // Add 2 hours and 1 ms
+          const customLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            error: jest.fn(),
+            info: jest.fn(),
+          };
+          const metrics: Metrics = new Metrics({ logger: customLogger });
+          const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+
+          // Act
+          metrics.addMetric(testMetric, MetricUnit.Count, 10);
+          metrics.setTimestamp(getTimestamp(timestampMs));
+          const loggedData = metrics.serializeMetrics();
+
+          // Assess
+          expect(consoleWarnSpy).not.toHaveBeenCalled();
+          expect(loggedData).toEqual(
+            expect.objectContaining({
+              _aws: expect.objectContaining({
+                Timestamp: timestampMs,
+              }),
+            })
+          );
+        });
+
+        test('should log a warning if the timestamp is more than two hours in the future but still set the timestamp', () => {
+          // Prepare
+          const testMetric = 'test-metric';
+          const timestampMs = mockDate.getTime() + 2 * 60 * 60 * 1000 + 1; // Add 2 hours and 1 ms
+          const customLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            error: jest.fn(),
+            info: jest.fn(),
+          };
+          const metrics: Metrics = new Metrics({ logger: customLogger });
+          const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+
+          // Act
+          metrics.addMetric(testMetric, MetricUnit.Count, 10);
+          metrics.setTimestamp(getTimestamp(timestampMs));
+          const loggedData = metrics.serializeMetrics();
+
+          // Assess
+          expect(consoleWarnSpy).toHaveBeenCalledWith(
+            "This metric doesn't meet the requirements and will be skipped by Amazon CloudWatch. " +
+              'Ensure the timestamp is within 14 days in the past or up to 2 hours in the future and is also a valid number or Date object.'
+          );
+          expect(loggedData).toEqual(
+            expect.objectContaining({
+              _aws: expect.objectContaining({
+                Timestamp: timestampMs,
+              }),
+            })
+          );
+        });
+
+        test('should not log a warning if the timestamp is exact 14 days in the past and set the timestamp', () => {
+          // Prepare
+          const testMetric = 'test-metric';
+          const timestampMs = mockDate.getTime() - 14 * 24 * 60 * 60 * 1000; // Subtract 14 days
+          const customLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            error: jest.fn(),
+            info: jest.fn(),
+          };
+          const metrics: Metrics = new Metrics({ logger: customLogger });
+          const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+
+          // Act
+          metrics.addMetric(testMetric, MetricUnit.Count, 10);
+          metrics.setTimestamp(getTimestamp(timestampMs));
+          const loggedData = metrics.serializeMetrics();
+
+          // Assess
+          expect(consoleWarnSpy).not.toHaveBeenCalled();
+          expect(loggedData).toEqual(
+            expect.objectContaining({
+              _aws: expect.objectContaining({
+                Timestamp: timestampMs,
+              }),
+            })
+          );
+        });
+
+        test('should log a warning if the timestamp is more than 14 days in the past but still set the timestamp', () => {
+          // Prepare
+          const testMetric = 'test-metric';
+          const timestampMs = mockDate.getTime() - 14 * 24 * 60 * 60 * 1000 - 1; // Subtract 14 days and 1 ms
+          const customLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            error: jest.fn(),
+            info: jest.fn(),
+          };
+          const metrics: Metrics = new Metrics({ logger: customLogger });
+          const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+
+          // Act
+          metrics.addMetric(testMetric, MetricUnit.Count, 10);
+          metrics.setTimestamp(getTimestamp(timestampMs));
+          const loggedData = metrics.serializeMetrics();
+
+          // Assess
+          expect(consoleWarnSpy).toHaveBeenCalledWith(
+            "This metric doesn't meet the requirements and will be skipped by Amazon CloudWatch. " +
+              'Ensure the timestamp is within 14 days in the past or up to 2 hours in the future and is also a valid number or Date object.'
+          );
+          expect(loggedData).toEqual(
+            expect.objectContaining({
+              _aws: expect.objectContaining({
+                Timestamp: timestampMs,
+              }),
+            })
+          );
+        });
+      });
+    }
+
+    test('should log warning and set timestamp to 0 if not a number provided', () => {
+      // Prepare
+      const testMetric = 'test-metric';
+      const customLogger = {
+        warn: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+      };
+      const metrics: Metrics = new Metrics({ logger: customLogger });
+      const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+
+      // Act
+      metrics.addMetric(testMetric, MetricUnit.Count, 10);
+      metrics.setTimestamp(Number.NaN);
+      const loggedData = metrics.serializeMetrics();
+
+      // Assess
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "This metric doesn't meet the requirements and will be skipped by Amazon CloudWatch. " +
+          'Ensure the timestamp is within 14 days in the past or up to 2 hours in the future and is also a valid number or Date object.'
+      );
+      expect(loggedData).toEqual(
+        expect.objectContaining({
+          _aws: expect.objectContaining({
+            Timestamp: 0,
+          }),
+        })
+      );
+    });
+
+    test('should log warning and set timestamp to 0 if not a integer number provided', () => {
+      // Prepare
+      const testMetric = 'test-metric';
+      const customLogger = {
+        warn: jest.fn(),
+        debug: jest.fn(),
+        error: jest.fn(),
+        info: jest.fn(),
+      };
+      const metrics: Metrics = new Metrics({ logger: customLogger });
+      const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+
+      // Act
+      metrics.addMetric(testMetric, MetricUnit.Count, 10);
+      metrics.setTimestamp(1.1);
+      const loggedData = metrics.serializeMetrics();
+
+      // Assess
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "This metric doesn't meet the requirements and will be skipped by Amazon CloudWatch. " +
+          'Ensure the timestamp is within 14 days in the past or up to 2 hours in the future and is also a valid number or Date object.'
+      );
+      expect(loggedData).toEqual(
+        expect.objectContaining({
+          _aws: expect.objectContaining({
+            Timestamp: 0,
+          }),
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
By default, the current timestamp is set while creating metrics. This PR provides an opportunity to provide custom timestamp with metrics
### Changes

- Followed the Python implementation of the same feature for feature parity
- Create `setTimestamp` function to set the timestamp
- Validate the timestamp, if not a valid timestamp then log a warning
- Set the timestamp, if not a valid value set this to `Zero` for Cloudwatch to skip
- Write unit tests for the function, had to slightly change the date mock to test the new feature
- Add a section for the feature inside the doc


**Issue number:** #3153 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
