### PR TITLE
fix(metrics): skip empty string dimension values

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -246,6 +246,7 @@ class Metrics extends Utility implements MetricsInterface {
    * Add multiple dimensions to the metrics.
    *
    * This method is useful when you want to add multiple dimensions to the metrics at once.
+   * Invalid dimension values are skipped and a warning is logged.
    *
    * When calling the {@link Metrics.publishStoredMetrics | `publishStoredMetrics()`} method, the dimensions are cleared. This type of
    * dimension is useful when you want to add request-specific dimensions to your metrics. If you want to add dimensions that are
@@ -256,7 +257,14 @@ class Metrics extends Utility implements MetricsInterface {
   public addDimensions(dimensions: Dimensions): void {
     const newDimensions = { ...this.dimensions };
     for (const dimensionName of Object.keys(dimensions)) {
-      newDimensions[dimensionName] = dimensions[dimensionName];
+      const value = dimensions[dimensionName];
+      if (value) {
+        newDimensions[dimensionName] = value;
+      } else {
+        this.#logger.warn(
+          `Dimension value is invalid for ${dimensionName} and will be skipped.`
+        );
+      }
     }
     if (Object.keys(newDimensions).length > MAX_DIMENSION_COUNT) {
       throw new RangeError(

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -218,6 +218,7 @@ class Metrics extends Utility implements MetricsInterface {
    * Add a dimension to metrics.
    *
    * A dimension is a key-value pair that is used to group metrics, and it is included in all metrics emitted after it is added.
+   * Invalid dimension values are skipped and a warning is logged.
    *
    * When calling the {@link Metrics.publishStoredMetrics | `publishStoredMetrics()`} method, the dimensions are cleared. This type of
    * dimension is useful when you want to add request-specific dimensions to your metrics. If you want to add dimensions that are
@@ -227,6 +228,12 @@ class Metrics extends Utility implements MetricsInterface {
    * @param value - The value of the dimension
    */
   public addDimension(name: string, value: string): void {
+    if (!value) {
+      this.#logger.warn(
+        `Dimension value is invalid for ${name} and will be skipped.`
+      );
+      return;
+    }
     if (MAX_DIMENSION_COUNT <= this.getCurrentDimensionsCount()) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -230,7 +230,7 @@ class Metrics extends Utility implements MetricsInterface {
   public addDimension(name: string, value: string): void {
     if (!value) {
       this.#logger.warn(
-        `Dimension value is invalid for ${name} and will be skipped.`
+        `The dimension ${name} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
       );
       return;
     }
@@ -262,7 +262,7 @@ class Metrics extends Utility implements MetricsInterface {
         newDimensions[dimensionName] = value;
       } else {
         this.#logger.warn(
-          `Dimension value is invalid for ${dimensionName} and will be skipped.`
+          `The dimension ${dimensionName} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
         );
       }
     }

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -460,7 +460,7 @@ describe('Class: Metrics', () => {
 
           // Assess
           expect(consoleWarnSpy).toHaveBeenCalledWith(
-            `Dimension value is invalid for ${testDimensionName} and will be skipped.`
+            `The dimension ${testDimensionName} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
           );
           expect(metrics).toEqual(
             expect.objectContaining({
@@ -593,7 +593,7 @@ describe('Class: Metrics', () => {
 
           // Assess
           expect(consoleWarnSpy).toHaveBeenCalledWith(
-            `Dimension value is invalid for ${testDimensionName} and will be skipped.`
+            `The dimension ${testDimensionName} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
           );
           expect(metrics).toEqual(
             expect.objectContaining({

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -431,6 +431,45 @@ describe('Class: Metrics', () => {
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );
     });
+
+    describe('invalid values should not be added as dimensions', () => {
+      const testCases = [
+        { value: undefined as unknown as string, description: 'undefined' },
+        { value: null as unknown as string, description: 'null' },
+        { value: '', description: 'empty string' },
+      ];
+
+      for (const { value, description } of testCases) {
+        it(`it should not add dimension with ${description} value and log a warning`, () => {
+          // Prepare
+          const customLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            error: jest.fn(),
+            info: jest.fn(),
+          };
+          const metrics: Metrics = new Metrics({
+            namespace: TEST_NAMESPACE,
+            logger: customLogger,
+          });
+          const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+          const testDimensionName = 'test-dimension';
+
+          // Act
+          metrics.addDimension(testDimensionName, value);
+
+          // Assess
+          expect(consoleWarnSpy).toHaveBeenCalledWith(
+            `Dimension value is invalid for ${testDimensionName} and will be skipped.`
+          );
+          expect(metrics).toEqual(
+            expect.objectContaining({
+              dimensions: {},
+            })
+          );
+        });
+      }
+    });
   });
 
   describe('Method: addDimensions', () => {
@@ -519,6 +558,53 @@ describe('Class: Metrics', () => {
       ).toThrowError(
         `Unable to add 1 dimensions: the number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );
+    });
+
+    describe('invalid values should not be added as dimensions', () => {
+      const testCases = [
+        { value: undefined as unknown as string, description: 'undefined' },
+        { value: null as unknown as string, description: 'null' },
+        { value: '', description: 'empty string' },
+      ];
+
+      for (const { value, description } of testCases) {
+        it(`it should not add dimension with ${description} value and log a warning`, () => {
+          // Prepare
+          const customLogger = {
+            warn: jest.fn(),
+            debug: jest.fn(),
+            error: jest.fn(),
+            info: jest.fn(),
+          };
+          const metrics: Metrics = new Metrics({
+            namespace: TEST_NAMESPACE,
+            logger: customLogger,
+          });
+          const consoleWarnSpy = jest.spyOn(customLogger, 'warn');
+          const dimensionsToBeAdded: LooseObject = {
+            'test-dimension-1': 'test-value-1',
+            'test-dimension-2': 'test-value-2',
+          };
+          const testDimensionName = 'test-dimension';
+
+          // Act
+          metrics.addDimensions(dimensionsToBeAdded);
+          metrics.addDimensions({ [testDimensionName]: value });
+
+          // Assess
+          expect(consoleWarnSpy).toHaveBeenCalledWith(
+            `Dimension value is invalid for ${testDimensionName} and will be skipped.`
+          );
+          expect(metrics).toEqual(
+            expect.objectContaining({
+              dimensions: {
+                'test-dimension-1': 'test-value-1',
+                'test-dimension-2': 'test-value-2',
+              },
+            })
+          );
+        });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
When adding a dimension to my metrics, I should get a warning if the dimension value is invalid aka an empty string ("") or undefined/null, and the dimension should not be added to the EMF blobs emitted by the utility.


### Changes

- Check for `empty`, `undefined` & `null` values for dimension and if found log warning
- Skip invalid value dimensions to EMF, do this for `addDimension` & `addDimensions`
- Unit test the fix

**Issue number:** #3302 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
