### PR TITLE
fix(parser): event type literal for selfManagedKafka

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -4,5 +4,4 @@ npm t \
 npx vitest --run \
   --exclude tests/unit/layer-publisher.test.ts \
   --coverage --coverage.thresholds.100 \
-  --changed="$(git merge-base HEAD main)" \
   tests/unit

--- a/packages/parser/src/schemas/kafka.ts
+++ b/packages/parser/src/schemas/kafka.ts
@@ -40,7 +40,7 @@ const KafkaBaseEventSchema = z.object({
  * @example
  * ```json
  * {
- *   "eventSource":"aws:SelfManagedKafka",
+ *   "eventSource":"SelfManagedKafka",
  *   "bootstrapServers":"b-2.demo-cluster-1.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092,b-1.demo-cluster-1.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092",
  *   "records":{
  *      "mytopic-0":[
@@ -79,7 +79,7 @@ const KafkaBaseEventSchema = z.object({
  * @see {@link https://docs.aws.amazon.com/lambda/latest/dg/with-kafka.html}
  */
 const KafkaSelfManagedEventSchema = KafkaBaseEventSchema.extend({
-  eventSource: z.literal('aws:SelfManagedKafka'),
+  eventSource: z.literal('SelfManagedKafka'),
 });
 
 /**

--- a/packages/parser/tests/events/kafkaEventSelfManaged.json
+++ b/packages/parser/tests/events/kafkaEventSelfManaged.json
@@ -1,5 +1,5 @@
 {
-  "eventSource": "aws:SelfManagedKafka",
+  "eventSource": "SelfManagedKafka",
   "bootstrapServers": "b-2.demo-cluster-1.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092,b-1.demo-cluster-1.a1bcde.c1.kafka.us-east-1.amazonaws.com:9092",
   "records": {
     "mytopic-0": [


### PR DESCRIPTION
## Summary

This PR fixes the bug for event type literal for self managed kafka events.

### Changes

Beside the literal change I had to remove `--changed` flag, as it prevented me from push due to wrong coverage. When running the pre-push tests the coverage for unrelated files which were not affected by the changes were reporting low coverage. In my case it was SQS envelope, which has nothing to do with the kafka schema changes. 



```

 ✓ |@aws-lambda-powertools/parser| tests/unit/parser.decorator.test.ts (8)
 ✓ |@aws-lambda-powertools/parser| tests/unit/parser.middy.test.ts (13)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/apigw.test.ts (7)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/apigwv2.test.ts (7)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/cloudwatch.test.ts (5)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/dynamodb.test.ts (7)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/eventbridge.test.ts (7)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/kafka.test.ts (6)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/kinesis-firehose.test.ts (11)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/kinesis.test.ts (6)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/lambda.test.ts (7)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/sns.test.ts (12)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/vpc-lattice.test.ts (8)
 ✓ |@aws-lambda-powertools/parser| tests/unit/envelopes/vpc-latticev2.test.ts (8)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/alb.test.ts (3)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/apigw.test.ts (11)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/apigwv2.test.ts (9)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/cloudformation-custom-resource.test.ts (3)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/cloudwatch.test.ts (2)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/dynamodb.test.ts (1)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/eventbridge.test.ts (1)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/kafka.test.ts (5)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/kinesis.test.ts (10)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/lambda.test.ts (2)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/s3.test.ts (10)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/ses.test.ts (2)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/sns.test.ts (4)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/sqs.test.ts (2)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/vpc-lattice.test.ts (2)
 ✓ |@aws-lambda-powertools/parser| tests/unit/schema/vpc-latticev2.test.ts (2)

 Test Files  30 passed (30)
      Tests  181 passed (181)
   Start at  10:18:58
   Duration  3.13s (transform 10ms, setup 477ms, collect 5.53s, tests 296ms, environment 4ms, prepare 2.60s)

 % Coverage report from v8
------------------------------------|---------|----------|---------|---------|-------------------
File                                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------------------------|---------|----------|---------|---------|-------------------
All files                           |      98 |      100 |    97.5 |      98 |                   
 src                                |     100 |      100 |     100 |     100 |                   
  errors.ts                         |     100 |      100 |     100 |     100 |                   
  index.ts                          |     100 |      100 |     100 |     100 |                   
  parser.ts                         |     100 |      100 |     100 |     100 |                   
  parserDecorator.ts                |     100 |      100 |     100 |     100 |                   
 src/envelopes                      |   95.46 |      100 |   96.66 |   95.46 |                   
  apigw.ts                          |     100 |      100 |     100 |     100 |                   
  apigwv2.ts                        |     100 |      100 |     100 |     100 |                   
  cloudwatch.ts                     |     100 |      100 |     100 |     100 |                   
  dynamodb.ts                       |     100 |      100 |     100 |     100 |                   
  envelope.ts                       |     100 |      100 |     100 |     100 |                   
  event-bridge.ts                   |     100 |      100 |     100 |     100 |                   
  index.ts                          |     100 |      100 |     100 |     100 |                   
  kafka.ts                          |     100 |      100 |     100 |     100 |                   
  kinesis-firehose.ts               |     100 |      100 |     100 |     100 |                   
  kinesis.ts                        |     100 |      100 |     100 |     100 |                   
  lambda.ts                         |     100 |      100 |     100 |     100 |                   
  sns.ts                            |     100 |      100 |     100 |     100 |                   
  sqs.ts                            |    27.5 |      100 |      50 |    27.5 | 31-61             
  vpc-lattice.ts                    |     100 |      100 |     100 |     100 |                   
  vpc-latticev2.ts                  |     100 |      100 |     100 |     100 |                   
 src/middleware                     |     100 |      100 |     100 |     100 |                   
  parser.ts                         |     100 |      100 |     100 |     100 |                   
 src/schemas                        |     100 |      100 |     100 |     100 |                   
  alb.ts                            |     100 |      100 |     100 |     100 |                   
  apigw-proxy.ts                    |     100 |      100 |     100 |     100 |                   
  apigw.ts                          |     100 |      100 |     100 |     100 |                   
  apigwv2.ts                        |     100 |      100 |     100 |     100 |                   
  cloudformation-custom-resource.ts |     100 |      100 |     100 |     100 |                   
  cloudwatch.ts                     |     100 |      100 |     100 |     100 |                   
  dynamodb.ts                       |     100 |      100 |     100 |     100 |                   
  eventbridge.ts                    |     100 |      100 |     100 |     100 |                   
  index.ts                          |     100 |      100 |     100 |     100 |                   
  kafka.ts                          |     100 |      100 |     100 |     100 |                   
  kinesis-firehose.ts               |     100 |      100 |     100 |     100 |                   
  kinesis.ts                        |     100 |      100 |     100 |     100 |                   
  lambda.ts                         |     100 |      100 |     100 |     100 |                   
  s3.ts                             |     100 |      100 |     100 |     100 |                   
  ses.ts                            |     100 |      100 |     100 |     100 |                   
  sns.ts                            |     100 |      100 |     100 |     100 |                   
  sqs.ts                            |     100 |      100 |     100 |     100 |                   
  vpc-lattice.ts                    |     100 |      100 |     100 |     100 |                   
  vpc-latticev2.ts                  |     100 |      100 |     100 |     100 |                   
------------------------------------|---------|----------|---------|---------|-------------------
ERROR: Coverage for lines (98%) does not meet global threshold (100%)
ERROR: Coverage for functions (97.5%) does not meet global threshold (100%)
ERROR: Coverage for statements (98%) does not meet global threshold (100%)
```


I like the idea of running only change related files to save time, it was always bothering me. I looked into vites config and probed few solutions but with no results. We should add the flag at some point once we figured out what is causing the wrong coverage. 

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3324 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
