### PR TITLE
feat(metrics): warn when overwriting dimension

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -244,7 +244,7 @@ class Metrics extends Utility implements MetricsInterface {
       Object.hasOwn(this.defaultDimensions, name)
     ) {
       this.#logger.warn(
-        `Dimension with "${name}" has already been added. The previous value will be overwritten.`
+        `Dimension "${name}" has already been added. The previous value will be overwritten.`
       );
     }
     this.dimensions[name] = value;

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -239,6 +239,14 @@ class Metrics extends Utility implements MetricsInterface {
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );
     }
+    if (
+      Object.hasOwn(this.dimensions, name) ||
+      Object.hasOwn(this.defaultDimensions, name)
+    ) {
+      this.#logger.warn(
+        `Dimension with "${name}" has already been added. The previous value will be overwritten.`
+      );
+    }
     this.dimensions[name] = value;
   }
 
@@ -255,25 +263,9 @@ class Metrics extends Utility implements MetricsInterface {
    * @param dimensions - An object with key-value pairs of dimensions
    */
   public addDimensions(dimensions: Dimensions): void {
-    const newDimensions = { ...this.dimensions };
-    for (const dimensionName of Object.keys(dimensions)) {
-      const value = dimensions[dimensionName];
-      if (value) {
-        newDimensions[dimensionName] = value;
-      } else {
-        this.#logger.warn(
-          `The dimension ${dimensionName} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
-        );
-      }
+    for (const [name, value] of Object.entries(dimensions)) {
+      this.addDimension(name, value);
     }
-    if (Object.keys(newDimensions).length > MAX_DIMENSION_COUNT) {
-      throw new RangeError(
-        `Unable to add ${
-          Object.keys(dimensions).length
-        } dimensions: the number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
-      );
-    }
-    this.dimensions = newDimensions;
   }
 
   /**

--- a/packages/metrics/tests/unit/Metrics.test.ts
+++ b/packages/metrics/tests/unit/Metrics.test.ts
@@ -375,7 +375,7 @@ describe('Class: Metrics', () => {
         })
       );
       expect(logger.warn).toHaveBeenCalledWith(
-        `Dimension with "test-dimension" has already been added. The previous value will be overwritten.`
+        `Dimension "test-dimension" has already been added. The previous value will be overwritten.`
       );
     });
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

When working with dimensions with Metrics, the default behavior is to overwrite existing dimensions when a new one with the same name/key is added. Customers have asked us to add a warning when this happens so that they can more easily troubleshoot issues rather than missing data.

#### Before

```ts
import { Metrics } from '@aws-lambda-powertools/metrics';

const metrics = new Metrics({ singleMetric: true });

metrics.addDimension('test', 'foo');
metrics.addDimension('test', 'bar'); // "bar" silently replaces "foo" as value
```

#### After

```ts
import { Metrics } from '@aws-lambda-powertools/metrics';

const metrics = new Metrics({ singleMetric: true });

metrics.addDimension('test', 'foo');
metrics.addDimension('test', 'bar'); // "bar" replaces "foo"

// warning: Dimension "test" has already been added. The previous value will be overwritten.
```

The PR also consolidates the implementation of `addDimension()` and `addDimensions()` with the latter now iterating through the dimensions and calling the former for each one, instead of bringing its own separate implementation. In doing so, it also fixes a bug in which the `addDimensions()` method didn't consider default dimensions when counting the total of allowed dimensions in EMF (30).

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3350

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
