### PR TITLE
chore: replace close-issue-message action

### DIFF
--- a/.github/workflows/on_closed_issues.yml
+++ b/.github/workflows/on_closed_issues.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       issues: write  # comment on issues
     steps:
-      - uses: aws-actions/closed-issue-message@37548691e7cc75ba58f85c9f873f9eee43590449 # v1.0.0
+      - uses: aws-powertools/actions/.github/actions/close-issue-message@428c1934f4b22c0984ff4a39b66c2f70765bbed6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           message: |


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the workflow that runs when an issue is closed to use an action from our own shared repository (aws-powertools/actions) rather than a 3rd party one.

The new action uses the `gh` CLI to perform the action rather than a custom script. You can see it in action [here](https://github.com/dreamorosi/repro-3077/issues/1).

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3353

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
