### PR TITLE
chore(deps): bump @aws-cdk/cli-lib-alpha to 2.174.1-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -190,14 +190,6 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A=="
     },
-    "node_modules/@aws-cdk/cli-lib-alpha": {
-      "version": "2.161.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cli-lib-alpha/-/cli-lib-alpha-2.161.1-alpha.0.tgz",
-      "integrity": "sha512-HCokBr85Msv0tXiKth/3ZJZaQLzMmydk3NNEEA9fD/tzBh1zUcnlsBQnclOBmd0uKMNSZQertrroJmZv3mBOeg==",
-      "engines": {
-        "node": ">= 14.15.0"
-      }
-    },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
       "version": "39.1.38",
       "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.1.38.tgz",
@@ -16163,7 +16155,7 @@
       "version": "2.12.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-cdk/cli-lib-alpha": "^2.161.1-alpha.0",
+        "@aws-cdk/cli-lib-alpha": "^2.174.1-alpha.0",
         "@aws-sdk/client-lambda": "^3.721.0",
         "@smithy/util-utf8": "^3.0.0",
         "aws-cdk-lib": "^2.174.1",
@@ -16173,6 +16165,15 @@
       "devDependencies": {
         "@types/promise-retry": "^1.1.6",
         "aws-sdk-client-mock-vitest": "^5.0.0"
+      }
+    },
+    "packages/testing/node_modules/@aws-cdk/cli-lib-alpha": {
+      "version": "2.174.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cli-lib-alpha/-/cli-lib-alpha-2.174.1-alpha.0.tgz",
+      "integrity": "sha512-Z7ZRFEiKxkRxuq6dB07+7NaMmVXv2H3nHp0vnqmkHt0XzZiD1/4LyM2VCRKGmWU0q1ptHz6Ne7SwUawA5g+KlQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "packages/tracer": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -97,7 +97,7 @@
   },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/testing#readme",
   "dependencies": {
-    "@aws-cdk/cli-lib-alpha": "^2.161.1-alpha.0",
+    "@aws-cdk/cli-lib-alpha": "^2.174.1-alpha.0",
     "@aws-sdk/client-lambda": "^3.721.0",
     "@smithy/util-utf8": "^3.0.0",
     "aws-cdk-lib": "^2.174.1",


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR manually updates the `@aws-cdk/cli-lib-alpha` dependency since it's being excluded by Dependabot updates.

For more info, check the linked issue.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3117

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
