### PR TITLE
refactor(metrics): swap `isDate` for `instanceof Date`

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -1,5 +1,4 @@
 import { Console } from 'node:console';
-import { isDate } from 'node:util/types';
 import { Utility, isIntegerNumber } from '@aws-lambda-powertools/commons';
 import type {
   GenericLogger,
@@ -1033,11 +1032,12 @@ class Metrics extends Utility implements MetricsInterface {
    * @param timestamp - Date object or epoch time in milliseconds representing the timestamp to validate.
    */
   #validateEmfTimestamp(timestamp: number | Date): boolean {
-    if (!isDate(timestamp) && !isIntegerNumber(timestamp)) {
+    const isDate = timestamp instanceof Date;
+    if (!isDate && !isIntegerNumber(timestamp)) {
       return false;
     }
 
-    const timestampMs = isDate(timestamp) ? timestamp.getTime() : timestamp;
+    const timestampMs = isDate ? timestamp.getTime() : timestamp;
     const currentTime = new Date().getTime();
 
     const minValidTimestamp = currentTime - EMF_MAX_TIMESTAMP_PAST_AGE;
@@ -1056,7 +1056,7 @@ class Metrics extends Utility implements MetricsInterface {
     if (isIntegerNumber(timestamp)) {
       return timestamp;
     }
-    if (isDate(timestamp)) {
+    if (timestamp instanceof Date) {
       return timestamp.getTime();
     }
     /**


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR replaces the internal usage of the [`isDate`](https://nodejs.org/api/util.html#utiltypesisdatevalue) utility function from the standard Node.js library in favor of a more widely supported `instanceof Date` check.

The two methods are functionally equivalent and this change improves compatibility of the Metrics utility with alternative experimental runtimes such as LLRT.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3461

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
