### PR TITLE
fix(tracer): forward `X-Amzn-Trace-Id` header when instrumenting fetch

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -19,7 +19,10 @@ import type {
 import type { Handler } from 'aws-lambda';
 import type { Segment, Subsegment } from 'aws-xray-sdk-core';
 import xraySdk from 'aws-xray-sdk-core';
-import { EnvironmentVariablesService } from './config/EnvironmentVariablesService.js';
+import {
+  type EnvironmentVariablesService,
+  environmentVariablesService,
+} from './config/EnvironmentVariablesService.js';
 import { ProviderService } from './provider/ProviderService.js';
 import type { ConfigServiceInterface } from './types/ConfigServiceInterface.js';
 import type { ProviderServiceInterface } from './types/ProviderService.js';
@@ -862,14 +865,6 @@ class Tracer extends Utility implements TracerInterface {
   }
 
   /**
-   * Set and initialize `envVarsService`.
-   * Used internally during initialization.
-   */
-  private setEnvVarsService(): void {
-    this.envVarsService = new EnvironmentVariablesService();
-  }
-
-  /**
    * Method that reconciles the configuration passed with the environment variables.
    * Used internally during initialization.
    *
@@ -879,7 +874,7 @@ class Tracer extends Utility implements TracerInterface {
     const { enabled, serviceName, captureHTTPsRequests, customConfigService } =
       options;
 
-    this.setEnvVarsService();
+    this.envVarsService = environmentVariablesService;
     this.setCustomConfigService(customConfigService);
     this.setTracingEnabled(enabled);
     this.setCaptureResponse();

--- a/packages/tracer/src/config/EnvironmentVariablesService.ts
+++ b/packages/tracer/src/config/EnvironmentVariablesService.ts
@@ -69,4 +69,6 @@ class EnvironmentVariablesService
   }
 }
 
-export { EnvironmentVariablesService };
+const environmentVariablesService = new EnvironmentVariablesService();
+
+export { EnvironmentVariablesService, environmentVariablesService };

--- a/packages/tracer/tests/helpers/mockRequests.ts
+++ b/packages/tracer/tests/helpers/mockRequests.ts
@@ -1,5 +1,6 @@
 import { channel } from 'node:diagnostics_channel';
 import type { URL } from 'node:url';
+import { vi } from 'vitest';
 
 type MockFetchOptions = {
   origin?: string | URL;
@@ -31,7 +32,7 @@ const mockFetch = ({
   statusCode,
   headers,
   throwError,
-}: MockFetchOptions): void => {
+}: MockFetchOptions) => {
   const requestCreateChannel = channel('undici:request:create');
   const responseHeadersChannel = channel('undici:request:headers');
   const errorChannel = channel('undici:request:error');
@@ -40,6 +41,7 @@ const mockFetch = ({
     origin,
     method: method ?? 'GET',
     path,
+    addHeader: vi.fn(),
   };
 
   requestCreateChannel.publish({
@@ -70,6 +72,8 @@ const mockFetch = ({
       headers: encodedHeaders,
     },
   });
+
+  return request;
 };
 
 export { mockFetch };


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the implementation of the global fetch instrumentation in Tracer so that the `X-Amzn-Trace-Id` header is automatically populated and added to requests when Tracer is enabled.

This allows X-Ray to attribute the segment/span to the correct parent and build the correct service map for a request.

Prior to this PR the header was not added and this resulted in disjointed traces. This happened only when using the Fetch API, but not when using the `https` module - which is why this is considered a bug.

The linked issue contains more info on why we did not add this in the first place and what was missing.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3467

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
