### PR TITLE
chore(parser): remove faker dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3027,6 +3027,7 @@
           "url": "https://opencollective.com/fakerjs"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=9.0.0"
@@ -17208,8 +17209,7 @@
       "version": "2.13.0",
       "license": "MIT-0",
       "devDependencies": {
-        "@anatine/zod-mock": "^3.13.3",
-        "@faker-js/faker": "^9.0.2"
+        "@anatine/zod-mock": "^3.13.3"
       },
       "peerDependencies": {
         "@aws-sdk/util-dynamodb": ">=3.x",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -379,7 +379,6 @@
     }
   },
   "devDependencies": {
-    "@anatine/zod-mock": "^3.13.3",
-    "@faker-js/faker": "^9.0.2"
+    "@anatine/zod-mock": "^3.13.3"
   }
 }

--- a/packages/parser/tests/unit/schema/appsync.test.ts
+++ b/packages/parser/tests/unit/schema/appsync.test.ts
@@ -2,7 +2,6 @@
  * Test built-in AppSync resolver schemas
  */
 
-import { faker } from '@faker-js/faker';
 import { describe, expect, it } from 'vitest';
 import {
   AppSyncBatchResolverSchema,
@@ -56,7 +55,7 @@ describe('AppSync Resolver Schemas', () => {
           groups: null,
           issuer:
             'https://cognito-idp.us-west-2.amazonaws.com/us-west-xxxxxxxxxxx',
-          sourceIp: [faker.internet.ip()],
+          sourceIp: ['1.1.1.1'],
           sub: '192879fc-a240-4bf1-ab5a-d6a00f3063f9',
           username: 'jdoe',
         },
@@ -88,7 +87,7 @@ describe('AppSync Resolver Schemas', () => {
           cognitoIdentityAuthType: 'cognitoIdentityAuthType',
           cognitoIdentityId: 'cognitoIdentityId',
           cognitoIdentityPoolId: 'cognitoIdentityPoolId',
-          sourceIp: [faker.internet.ip()],
+          sourceIp: ['1.1.1.1'],
           userArn: 'arn:aws:sts::012345678901:assumed-role/role',
           username: 'AROAXYKJUOW6FHGUSK5FA:username',
         },


### PR DESCRIPTION
## Summary

Remove thes `fake-jsr` dependency from the parser package.

### Changes

- Remove `faker` from parser `package.json`
- Update two test cases using the `faker-js` lib.
- Regenerate `pacakge-lcok.json` file

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

Reviewer in #3388 requested we remove library completely.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3480

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
