### PR TITLE
fix(parser): DynamoDBStream schema & envelope

### DIFF
--- a/packages/commons/package.json
+++ b/packages/commons/package.json
@@ -49,6 +49,10 @@
       "import": "./lib/esm/LRUCache.js",
       "require": "./lib/cjs/LRUCache.js"
     },
+    "./utils/unmarshallDynamoDB": {
+      "import": "./lib/esm/unmarshallDynamoDB.js",
+      "require": "./lib/cjs/unmarshallDynamoDB.js"
+    },
     "./types": {
       "import": "./lib/esm/types/index.js",
       "require": "./lib/cjs/types/index.js"
@@ -67,6 +71,10 @@
       "utils/lru-cache": [
         "lib/cjs/LRUCache.d.ts",
         "lib/esm/LRUCache.d.ts"
+      ],
+      "utils/unmarshallDynamoDB": [
+        "lib/cjs/unmarshallDynamoDB.d.ts",
+        "lib/esm/unmarshallDynamoDB.d.ts"
       ],
       "types": [
         "lib/cjs/types/index.d.ts",

--- a/packages/commons/src/unmarshallDynamoDB.ts
+++ b/packages/commons/src/unmarshallDynamoDB.ts
@@ -1,0 +1,92 @@
+import type { AttributeValue } from '@aws-sdk/client-dynamodb';
+
+class UnmarshallDynamoDBAttributeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnmarshallDynamoDBAttributeError';
+  }
+}
+
+const convertAttributeValue = (
+  data: AttributeValue | Record<string, AttributeValue>
+): unknown => {
+  for (const [key, value] of Object.entries(data)) {
+    if (value !== undefined) {
+      if (key === 'NULL') {
+        return null;
+      }
+      if (key === 'S' || key === 'B') {
+        return value;
+      }
+      if (key === 'BS' || key === 'SS') {
+        return new Set(value);
+      }
+      if (key === 'BOOL') {
+        return Boolean(value);
+      }
+      if (key === 'N') {
+        return convertNumber(value);
+      }
+      if (key === 'NS') {
+        return new Set(
+          (value as Array<string>).map((item) => convertNumber(item))
+        );
+      }
+      if (key === 'L') {
+        return (value as Array<AttributeValue>).map((item) =>
+          convertAttributeValue(item)
+        );
+      }
+      if (key === 'M') {
+        return Object.entries(value).reduce(
+          (acc, [key, value]) =>
+            (
+              // biome-ignore lint/suspicious/noAssignInExpressions: we are intentionally assigning the value to the accumulator
+              // biome-ignore lint/style/noCommaOperator: required for the reduce function
+              (acc[key] = convertAttributeValue(value as AttributeValue)), acc
+            ),
+          {} as Record<string, unknown>
+        );
+      }
+
+      throw new UnmarshallDynamoDBAttributeError(
+        `Unsupported type passed: ${key}`
+      );
+    }
+    /* v8 ignore next */
+  }
+  /* v8 ignore next */
+};
+
+const convertNumber = (numString: string) => {
+  const num = Number(numString);
+  const infinityValues = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
+  const isLargeFiniteNumber =
+    (num > Number.MAX_SAFE_INTEGER || num < Number.MIN_SAFE_INTEGER) &&
+    !infinityValues.includes(num);
+  if (isLargeFiniteNumber) {
+    try {
+      return BigInt(numString);
+    } catch (error) {
+      throw new UnmarshallDynamoDBAttributeError(
+        `${numString} can't be converted to BigInt`
+      );
+    }
+  }
+  return num;
+};
+
+/**
+ * Unmarshalls a DynamoDB AttributeValue to a JavaScript object.
+ *
+ * The implementation is loosely based on the official AWS SDK v3 unmarshall function but
+ * without support the customization options and with assumed support for BigInt.
+ *
+ * @param data - The DynamoDB AttributeValue to unmarshall
+ */
+const unmarshallDynamoDB = (
+  data: AttributeValue | Record<string, AttributeValue>
+  // @ts-expect-error - We intentionally wrap the data into a Map to allow for nested structures
+) => convertAttributeValue({ M: data });
+
+export { unmarshallDynamoDB, UnmarshallDynamoDBAttributeError };

--- a/packages/commons/tests/unit/unmarshallDynamoDB.test.ts
+++ b/packages/commons/tests/unit/unmarshallDynamoDB.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'vitest';
+import {
+  UnmarshallDynamoDBAttributeError,
+  unmarshallDynamoDB,
+} from '../../src/unmarshallDynamoDB.js';
+
+describe('Function: unmarshallDynamoDB', () => {
+  it('unmarshalls a DynamoDB string attribute', () => {
+    // Prepare
+    const value = { Message: { S: 'test string' } };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Message: 'test string' });
+  });
+
+  it('unmarshalls a DynamoDB number attribute', () => {
+    // Prepare
+    const value = { Id: { N: '123' } };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Id: 123 });
+  });
+
+  it('unmarshalls a DynamoDB boolean attribute', () => {
+    // Prepare
+    const value = { Message: { BOOL: true } };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Message: true });
+  });
+
+  it('unmarshalls a DynamoDB null attribute', () => {
+    // Prepare
+    const value = { Message: { NULL: true } };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Message: null });
+  });
+
+  it('unmarshalls a DynamoDB list attribute', () => {
+    // Prepare
+    const value = {
+      Messages: {
+        L: [{ S: 'string' }, { N: '123' }, { BOOL: true }, { NULL: true }],
+      },
+    };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Messages: ['string', 123, true, null] });
+  });
+
+  it('unmarshalls a DynamoDB map attribute', () => {
+    // Prepare
+    const value = {
+      Settings: {
+        M: {
+          string: { S: 'test' },
+          number: { N: '123' },
+          boolean: { BOOL: true },
+          null: { NULL: true },
+        },
+      },
+    };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({
+      Settings: {
+        string: 'test',
+        number: 123,
+        boolean: true,
+        null: null,
+      },
+    });
+  });
+
+  it('unmarshalls a DynamoDB string set attribute', () => {
+    // Prepare
+    const value = { Messages: { SS: ['a', 'b', 'c'] } };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Messages: new Set(['a', 'b', 'c']) });
+  });
+
+  it('unmarshalls a DynamoDB number set attribute', () => {
+    // Prepare
+    const value = { Ids: { NS: ['1', '2', '3'] } };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Ids: new Set([1, 2, 3]) });
+  });
+
+  it('unmarshalls nested DynamoDB structures', () => {
+    // Prepare
+    const value = {
+      Messages: {
+        M: {
+          nested: {
+            M: {
+              list: {
+                L: [
+                  { S: 'string' },
+                  {
+                    M: {
+                      key: { S: 'value' },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({
+      Messages: {
+        nested: {
+          list: ['string', { key: 'value' }],
+        },
+      },
+    });
+  });
+
+  it('throws if an unsupported type is passed', () => {
+    // Prepare
+    const value = { Message: { NNN: '123' } };
+
+    // Act & Assess
+    // @ts-expect-error - Intentionally invalid value
+    expect(() => unmarshallDynamoDB(value)).toThrow(
+      UnmarshallDynamoDBAttributeError
+    );
+  });
+
+  it('unmarshalls a DynamoDB large number attribute to BigInt', () => {
+    // Prepare
+    const value = { Balance: { N: '9007199254740992' } }; // Number.MAX_SAFE_INTEGER + 1
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Balance: BigInt('9007199254740992') });
+  });
+
+  it('unmarshalls a DynamoDB negative large number attribute to BigInt', () => {
+    // Prepare
+    const value = { Balance: { N: '-9007199254740992' } }; // Number.MIN_SAFE_INTEGER - 1
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Balance: BigInt('-9007199254740992') });
+  });
+
+  it('throws when trying to convert an invalid number string to BigInt', () => {
+    // Prepare
+    const value = { Balance: { N: '9007199254740992.5' } }; // Invalid BigInt string (decimals not allowed)
+
+    // Act & Assess
+    expect(() => unmarshallDynamoDB(value)).toThrow(
+      new UnmarshallDynamoDBAttributeError(
+        "9007199254740992.5 can't be converted to BigInt"
+      )
+    );
+  });
+
+  /* it('throws when no data is found', () => {
+    // Prepare
+    const value = {};
+
+    // Act & Assess
+    expect(() => unmarshallDynamoDB(value)).toThrow(
+      UnmarshallDynamoDBAttributeError
+    );
+    expect(() => unmarshallDynamoDB(value)).toThrow('No data found');
+  }); */
+});

--- a/packages/commons/tests/unit/unmarshallDynamoDB.test.ts
+++ b/packages/commons/tests/unit/unmarshallDynamoDB.test.ts
@@ -149,6 +149,45 @@ describe('Function: unmarshallDynamoDB', () => {
     });
   });
 
+  it('unmarshalls a DynamoDB binary attribute', () => {
+    // Prepare
+    const value = {
+      Data: {
+        B: new Uint8Array(
+          Buffer.from('dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk', 'base64')
+        ),
+      },
+    };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Data: expect.any(Uint8Array) });
+  });
+
+  it('unmarshalls a DynamoDB binary set attribute', () => {
+    // Prepare
+    const value = {
+      Data: {
+        BS: [
+          new Uint8Array(
+            Buffer.from('dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk', 'base64')
+          ),
+          new Uint8Array(
+            Buffer.from('dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk', 'base64')
+          ),
+        ],
+      },
+    };
+
+    // Act
+    const result = unmarshallDynamoDB(value);
+
+    // Assess
+    expect(result).toStrictEqual({ Data: expect.any(Set) });
+  });
+
   it('throws if an unsupported type is passed', () => {
     // Prepare
     const value = { Message: { NNN: '123' } };

--- a/packages/commons/tests/unit/unmarshallDynamoDB.test.ts
+++ b/packages/commons/tests/unit/unmarshallDynamoDB.test.ts
@@ -194,14 +194,14 @@ describe('Function: unmarshallDynamoDB', () => {
     );
   });
 
-  /* it('throws when no data is found', () => {
+  it('throws when no data is found', () => {
     // Prepare
-    const value = {};
+    const value = undefined;
 
     // Act & Assess
+    // @ts-expect-error - Intentionally invalid value
     expect(() => unmarshallDynamoDB(value)).toThrow(
       UnmarshallDynamoDBAttributeError
     );
-    expect(() => unmarshallDynamoDB(value)).toThrow('No data found');
-  }); */
+  });
 });

--- a/packages/parser/src/envelopes/dynamodb.ts
+++ b/packages/parser/src/envelopes/dynamodb.ts
@@ -3,7 +3,7 @@ import { ParseError } from '../errors.js';
 import { DynamoDBStreamSchema } from '../schemas/index.js';
 import type { DynamoDBStreamEnvelopeResponse } from '../types/envelope.js';
 import type { ParsedResult } from '../types/index.js';
-import { Envelope, envelopeDiscriminator } from './envelope.js';
+import { envelopeDiscriminator } from './envelope.js';
 
 /**
  * DynamoDB Stream Envelope to extract data within NewImage/OldImage
@@ -35,7 +35,7 @@ export const DynamoDBStreamEnvelope = {
           `Failed to parse DynamoDB record at index ${recordIndex}`,
           {
             cause: new ZodError(
-              ((error as Error).cause as ZodError).issues.map((issue) => ({
+              (error as ZodError).issues.map((issue) => ({
                 ...issue,
                 path: [
                   'Records',

--- a/packages/parser/src/envelopes/dynamodb.ts
+++ b/packages/parser/src/envelopes/dynamodb.ts
@@ -1,4 +1,3 @@
-import { unmarshallDynamoDB } from '@aws-lambda-powertools/commons/utils/unmarshallDynamoDB';
 import { ZodError, type ZodIssue, type ZodSchema, type z } from 'zod';
 import { ParseError } from '../errors.js';
 import { DynamoDBStreamSchema } from '../schemas/index.js';
@@ -30,10 +29,7 @@ export const DynamoDBStreamEnvelope = {
       recordIndex: number
     ) => {
       try {
-        return image
-          ? // @ts-expect-error - unmarshallDynamoDB expects AttributeValue but we are passing unknown
-            Envelope.parse(unmarshallDynamoDB(image), schema)
-          : undefined;
+        return image ? Envelope.parse(image, schema) : undefined;
       } catch (error) {
         throw new ParseError(
           `Failed to parse DynamoDB record at index ${recordIndex}`,
@@ -77,8 +73,7 @@ export const DynamoDBStreamEnvelope = {
     }
 
     const processImage = (image: unknown) =>
-      // @ts-expect-error - unmarshallDynamoDB expects AttributeValue but we are passing unknown
-      image ? Envelope.safeParse(unmarshallDynamoDB(image), schema) : undefined;
+      image ? Envelope.safeParse(image, schema) : undefined;
 
     const result = parsedEnvelope.data.Records.reduce<{
       success: boolean;

--- a/packages/parser/src/envelopes/dynamodb.ts
+++ b/packages/parser/src/envelopes/dynamodb.ts
@@ -29,7 +29,7 @@ export const DynamoDBStreamEnvelope = {
       recordIndex: number
     ) => {
       try {
-        return image ? Envelope.parse(image, schema) : undefined;
+        return image ? schema.parse(image) : undefined;
       } catch (error) {
         throw new ParseError(
           `Failed to parse DynamoDB record at index ${recordIndex}`,
@@ -73,7 +73,7 @@ export const DynamoDBStreamEnvelope = {
     }
 
     const processImage = (image: unknown) =>
-      image ? Envelope.safeParse(image, schema) : undefined;
+      image ? schema.safeParse(image) : undefined;
 
     const result = parsedEnvelope.data.Records.reduce<{
       success: boolean;

--- a/packages/parser/src/envelopes/dynamodb.ts
+++ b/packages/parser/src/envelopes/dynamodb.ts
@@ -1,8 +1,9 @@
-import type { ZodSchema, z } from 'zod';
+import { unmarshallDynamoDB } from '@aws-lambda-powertools/commons/utils/unmarshallDynamoDB';
+import { ZodError, type ZodIssue, type ZodSchema, type z } from 'zod';
 import { ParseError } from '../errors.js';
 import { DynamoDBStreamSchema } from '../schemas/index.js';
 import type { DynamoDBStreamEnvelopeResponse } from '../types/envelope.js';
-import type { ParsedResult, ParsedResultError } from '../types/index.js';
+import type { ParsedResult } from '../types/index.js';
 import { Envelope, envelopeDiscriminator } from './envelope.js';
 
 /**
@@ -23,12 +24,41 @@ export const DynamoDBStreamEnvelope = {
   ): DynamoDBStreamEnvelopeResponse<z.infer<T>>[] {
     const parsedEnvelope = DynamoDBStreamSchema.parse(data);
 
-    return parsedEnvelope.Records.map((record) => {
-      return {
-        NewImage: Envelope.parse(record.dynamodb.NewImage, schema),
-        OldImage: Envelope.parse(record.dynamodb.OldImage, schema),
-      };
-    });
+    const processImage = (
+      image: unknown,
+      imageType: 'NewImage' | 'OldImage',
+      recordIndex: number
+    ) => {
+      try {
+        return image
+          ? // @ts-expect-error - unmarshallDynamoDB expects AttributeValue but we are passing unknown
+            Envelope.parse(unmarshallDynamoDB(image), schema)
+          : undefined;
+      } catch (error) {
+        throw new ParseError(
+          `Failed to parse DynamoDB record at index ${recordIndex}`,
+          {
+            cause: new ZodError(
+              ((error as Error).cause as ZodError).issues.map((issue) => ({
+                ...issue,
+                path: [
+                  'Records',
+                  recordIndex,
+                  'dynamodb',
+                  imageType,
+                  ...issue.path,
+                ],
+              }))
+            ),
+          }
+        );
+      }
+    };
+
+    return parsedEnvelope.Records.map((record, index) => ({
+      NewImage: processImage(record.dynamodb.NewImage, 'NewImage', index),
+      OldImage: processImage(record.dynamodb.OldImage, 'OldImage', index),
+    }));
   },
 
   safeParse<T extends ZodSchema>(
@@ -36,7 +66,6 @@ export const DynamoDBStreamEnvelope = {
     schema: T
   ): ParsedResult<unknown, DynamoDBStreamEnvelopeResponse<z.infer<T>>[]> {
     const parsedEnvelope = DynamoDBStreamSchema.safeParse(data);
-
     if (!parsedEnvelope.success) {
       return {
         success: false,
@@ -46,39 +75,56 @@ export const DynamoDBStreamEnvelope = {
         originalEvent: data,
       };
     }
-    const parsedLogEvents: DynamoDBStreamEnvelopeResponse<z.infer<T>>[] = [];
 
-    for (const record of parsedEnvelope.data.Records) {
-      const parsedNewImage = Envelope.safeParse(
-        record.dynamodb.NewImage,
-        schema
-      );
-      const parsedOldImage = Envelope.safeParse(
-        record.dynamodb.OldImage,
-        schema
-      );
-      if (!parsedNewImage.success || !parsedOldImage.success) {
-        return {
+    const processImage = (image: unknown) =>
+      // @ts-expect-error - unmarshallDynamoDB expects AttributeValue but we are passing unknown
+      image ? Envelope.safeParse(unmarshallDynamoDB(image), schema) : undefined;
+
+    const result = parsedEnvelope.data.Records.reduce<{
+      success: boolean;
+      records: DynamoDBStreamEnvelopeResponse<z.infer<T>>[];
+      errors: { index: number; issues: ZodIssue[] };
+    }>(
+      (acc, record, index) => {
+        const newImage = processImage(record.dynamodb.NewImage);
+        const oldImage = processImage(record.dynamodb.OldImage);
+
+        if (newImage?.success === false || oldImage?.success === false) {
+          const issues: ZodIssue[] = [];
+          for (const key of ['NewImage', 'OldImage']) {
+            const image = key === 'NewImage' ? newImage : oldImage;
+            if (image?.success === false) {
+              issues.push(
+                ...(image.error as ZodError).issues.map((issue) => ({
+                  ...issue,
+                  path: ['Records', index, 'dynamodb', key, ...issue.path],
+                }))
+              );
+            }
+          }
+          acc.success = false;
+          acc.errors = { index, issues };
+          return acc;
+        }
+
+        acc.records.push({
+          NewImage: newImage?.data,
+          OldImage: oldImage?.data,
+        });
+        return acc;
+      },
+      { success: true, records: [], errors: { index: 0, issues: [] } }
+    );
+
+    return result.success
+      ? { success: true, data: result.records }
+      : {
           success: false,
-          error: !parsedNewImage.success
-            ? new ParseError('Failed to parse NewImage', {
-                cause: parsedNewImage.error,
-              })
-            : new ParseError('Failed to parse OldImage', {
-                cause: (parsedOldImage as ParsedResultError<unknown>).error,
-              }),
+          error: new ParseError(
+            `Failed to parse record at index ${result.errors.index}`,
+            { cause: new ZodError(result.errors.issues) }
+          ),
           originalEvent: data,
         };
-      }
-      parsedLogEvents.push({
-        NewImage: parsedNewImage.data,
-        OldImage: parsedOldImage.data,
-      });
-    }
-
-    return {
-      success: true,
-      data: parsedLogEvents,
-    };
   },
 };

--- a/packages/parser/src/schemas/dynamodb.ts
+++ b/packages/parser/src/schemas/dynamodb.ts
@@ -1,19 +1,67 @@
+import { unmarshallDynamoDB } from '@aws-lambda-powertools/commons/utils/unmarshallDynamoDB';
 import { z } from 'zod';
 
-const DynamoDBStreamChangeRecord = z.object({
-  ApproximateCreationDateTime: z.number().optional(),
-  Keys: z.record(z.string(), z.record(z.string(), z.any())),
-  NewImage: z.record(z.string(), z.any()).optional(),
-  OldImage: z.record(z.string(), z.any()).optional(),
-  SequenceNumber: z.string(),
-  SizeBytes: z.number(),
-  StreamViewType: z.enum([
-    'NEW_IMAGE',
-    'OLD_IMAGE',
-    'NEW_AND_OLD_IMAGES',
-    'KEYS_ONLY',
-  ]),
-});
+const DynamoDBStreamChangeRecord = z
+  .object({
+    ApproximateCreationDateTime: z.number().optional(),
+    Keys: z.record(z.string(), z.record(z.string(), z.any())),
+    NewImage: z.record(z.string(), z.any()).optional(),
+    OldImage: z.record(z.string(), z.any()).optional(),
+    SequenceNumber: z.string(),
+    SizeBytes: z.number(),
+    StreamViewType: z.enum([
+      'NEW_IMAGE',
+      'OLD_IMAGE',
+      'NEW_AND_OLD_IMAGES',
+      'KEYS_ONLY',
+    ]),
+  })
+  .transform((object, ctx) => {
+    const result = { ...object };
+
+    const unmarshallAttributeValue = (
+      imageName: 'NewImage' | 'OldImage' | 'Keys',
+      image: Record<string, unknown>
+    ) => {
+      try {
+        // @ts-expect-error
+        return unmarshallDynamoDB(image) as Record<string, unknown>;
+      } catch (err) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Could not unmarshall ${imageName} in DynamoDB stream record`,
+          fatal: true,
+          path: [imageName],
+        });
+        return z.NEVER;
+      }
+    };
+
+    const unmarshalledKeys = unmarshallAttributeValue('Keys', object.Keys);
+    if (unmarshalledKeys === z.NEVER) return z.NEVER;
+    // @ts-expect-error - We are intentionally mutating the object
+    result.Keys = unmarshalledKeys;
+
+    if (object.NewImage) {
+      const unmarshalled = unmarshallAttributeValue(
+        'NewImage',
+        object.NewImage
+      );
+      if (unmarshalled === z.NEVER) return z.NEVER;
+      result.NewImage = unmarshalled;
+    }
+
+    if (object.OldImage) {
+      const unmarshalled = unmarshallAttributeValue(
+        'OldImage',
+        object.OldImage
+      );
+      if (unmarshalled === z.NEVER) return z.NEVER;
+      result.OldImage = unmarshalled;
+    }
+
+    return result;
+  });
 
 const UserIdentity = z.object({
   type: z.enum(['Service']),
@@ -35,10 +83,25 @@ const DynamoDBStreamToKinesisRecord = DynamoDBStreamRecord.extend({
   recordFormat: z.literal('application/json'),
   tableName: z.string(),
   userIdentity: UserIdentity.nullish(),
-  dynamodb: DynamoDBStreamChangeRecord.omit({
-    SequenceNumber: true,
-    StreamViewType: true,
-  }),
+  dynamodb: z
+    .object({
+      ApproximateCreationDateTime: z.number().optional(),
+      Keys: z.record(z.string(), z.record(z.string(), z.any())),
+      NewImage: z.record(z.string(), z.any()).optional(),
+      OldImage: z.record(z.string(), z.any()).optional(),
+      SequenceNumber: z.string(),
+      SizeBytes: z.number(),
+      StreamViewType: z.enum([
+        'NEW_IMAGE',
+        'OLD_IMAGE',
+        'NEW_AND_OLD_IMAGES',
+        'KEYS_ONLY',
+      ]),
+    })
+    .omit({
+      SequenceNumber: true,
+      StreamViewType: true,
+    }),
 }).omit({
   eventVersion: true,
   eventSourceARN: true,

--- a/packages/parser/src/schemas/dynamodb.ts
+++ b/packages/parser/src/schemas/dynamodb.ts
@@ -120,7 +120,7 @@ const DynamoDBStreamToKinesisRecord = DynamoDBStreamRecord.extend({
  * @see {@link https://docs.aws.amazon.com/lambda/latest/dg/with-ddb.html}
  */
 const DynamoDBStreamSchema = z.object({
-  Records: z.array(DynamoDBStreamRecord),
+  Records: z.array(DynamoDBStreamRecord).min(1),
 });
 
 export {

--- a/packages/parser/src/types/envelope.ts
+++ b/packages/parser/src/types/envelope.ts
@@ -3,8 +3,8 @@ import type { envelopeDiscriminator } from '../envelopes/envelope.js';
 import type { ParsedResult } from './parser.js';
 
 type DynamoDBStreamEnvelopeResponse<Schema extends ZodSchema> = {
-  NewImage: z.infer<Schema>;
-  OldImage: z.infer<Schema>;
+  NewImage?: z.infer<Schema>;
+  OldImage?: z.infer<Schema>;
 };
 
 interface ArrayEnvelope {

--- a/packages/parser/tests/events/dynamodb/base.json
+++ b/packages/parser/tests/events/dynamodb/base.json
@@ -18,7 +18,7 @@
             "N": "101"
           }
         },
-        "StreamViewType": "NEW_AND_OLD_IMAGES",
+        "StreamViewType": "NEW_IMAGE",
         "SequenceNumber": "111",
         "SizeBytes": 26
       },

--- a/packages/parser/tests/unit/envelopes/dynamodb.test.ts
+++ b/packages/parser/tests/unit/envelopes/dynamodb.test.ts
@@ -1,141 +1,142 @@
-import { generateMock } from '@anatine/zod-mock';
-import type { AttributeValue, DynamoDBStreamEvent } from 'aws-lambda';
+import { marshall } from '@aws-sdk/util-dynamodb';
 import { describe, expect, it } from 'vitest';
 import { ZodError, z } from 'zod';
 import { DynamoDBStreamEnvelope } from '../../../src/envelopes/index.js';
 import { ParseError } from '../../../src/errors.js';
-import { TestEvents } from '../schema/utils.js';
+import type { DynamoDBStreamEvent } from '../../../src/types/schema.js';
+import { getTestEvent } from '../schema/utils.js';
 
-describe('DynamoDB', () => {
+describe('Envelope: DynamoDB Stream', () => {
   const schema = z.object({
-    Message: z.record(z.literal('S'), z.string()),
-    Id: z.record(z.literal('N'), z.number().min(0).max(100)),
+    Message: z.string(),
+    Id: z.number(),
   });
-  const mockOldImage = generateMock(schema);
-  const mockNewImage = generateMock(schema);
-  const dynamodbEvent = TestEvents.dynamoStreamEvent as DynamoDBStreamEvent;
-  // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-  (dynamodbEvent.Records[0].dynamodb!.NewImage as typeof mockNewImage) =
-    mockNewImage;
-  // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-  (dynamodbEvent.Records[1].dynamodb!.NewImage as typeof mockNewImage) =
-    mockNewImage;
-  // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-  (dynamodbEvent.Records[0].dynamodb!.OldImage as typeof mockOldImage) =
-    mockOldImage;
-  // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-  (dynamodbEvent.Records[1].dynamodb!.OldImage as typeof mockOldImage) =
-    mockOldImage;
-  describe('parse', () => {
+  const baseEvent = getTestEvent<DynamoDBStreamEvent>({
+    eventsPath: 'dynamodb',
+    filename: 'base',
+  });
+
+  describe('Method: parse', () => {
+    it('throws if one of the payloads does not match the schema', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+
+      // Act & Assess
+      expect(() => DynamoDBStreamEnvelope.parse(event, z.number())).toThrow();
+    });
+
     it('parse should parse dynamodb envelope', () => {
-      const parsed = DynamoDBStreamEnvelope.parse(dynamodbEvent, schema);
+      // Prepare
+      const testEvent = structuredClone(baseEvent);
+
+      // Act
+      const parsed = DynamoDBStreamEnvelope.parse(testEvent, schema);
+
+      // Assess
       expect(parsed[0]).toEqual({
-        OldImage: mockOldImage,
-        NewImage: mockNewImage,
+        NewImage: {
+          Message: 'New item!',
+          Id: 101,
+        },
       });
       expect(parsed[1]).toEqual({
-        OldImage: mockOldImage,
-        NewImage: mockNewImage,
+        OldImage: {
+          Message: 'New item!',
+          Id: 101,
+        },
+        NewImage: {
+          Message: 'This item has changed',
+          Id: 101,
+        },
       });
-    });
-    it('parse should throw error if envelope invalid', () => {
-      expect(() =>
-        DynamoDBStreamEnvelope.parse({ foo: 'bar' }, schema)
-      ).toThrow();
-    });
-    it('parse should throw error if new or old image is invalid', () => {
-      const ddbEvent = TestEvents.dynamoStreamEvent as DynamoDBStreamEvent;
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      ddbEvent.Records[0].dynamodb!.NewImage!.Id = 'foo' as AttributeValue;
-      expect(() => DynamoDBStreamEnvelope.parse(ddbEvent, schema)).toThrow();
     });
   });
 
-  describe('safeParse', () => {
-    it('safeParse should parse dynamodb envelope', () => {
-      const parsed = DynamoDBStreamEnvelope.safeParse(dynamodbEvent, schema);
-      expect(parsed.success).toBe(true);
-      expect(parsed).toEqual({
+  describe('Method: safeParse', () => {
+    it('parses a DynamoDB Stream event', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+
+      // Act
+      const parsedEvent = DynamoDBStreamEnvelope.safeParse(event, schema);
+
+      // Assess
+      expect(parsedEvent).toEqual({
         success: true,
         data: [
           {
-            OldImage: mockOldImage,
-            NewImage: mockNewImage,
+            NewImage: {
+              Message: 'New item!',
+              Id: 101,
+            },
           },
           {
-            OldImage: mockOldImage,
-            NewImage: mockNewImage,
+            OldImage: {
+              Message: 'New item!',
+              Id: 101,
+            },
+            NewImage: {
+              Message: 'This item has changed',
+              Id: 101,
+            },
           },
         ],
       });
     });
-    it('safeParse should return error if NewImage is invalid', () => {
-      const invalidDDBEvent =
-        TestEvents.dynamoStreamEvent as DynamoDBStreamEvent;
 
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[0].dynamodb!.NewImage as typeof mockNewImage) = {
-        Id: { N: 101 },
-        Message: { S: 'foo' },
-      };
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[1].dynamodb!.NewImage as typeof mockNewImage) =
-        mockNewImage;
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[0].dynamodb!.OldImage as typeof mockOldImage) =
-        mockOldImage;
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[1].dynamodb!.OldImage as typeof mockOldImage) =
-        mockOldImage;
+    it('returns an error if the event is not a valid DynamoDB Stream event', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+      // @ts-expect-error - Intentionally invalid event
+      event.Records[0].dynamodb = undefined;
 
-      const parseResult = DynamoDBStreamEnvelope.safeParse(
-        invalidDDBEvent,
-        schema
-      );
-      expect(parseResult).toEqual({
+      // Act
+      const parsedEvent = DynamoDBStreamEnvelope.safeParse(event, schema);
+
+      // Assess
+      expect(parsedEvent).toEqual({
         success: false,
-        error: expect.any(ParseError),
-        originalEvent: invalidDDBEvent,
-      });
-
-      if (!parseResult.success && parseResult.error) {
-        expect(parseResult.error.cause).toBeInstanceOf(ZodError);
-      }
-    });
-
-    it('safeParse should return error if OldImage is invalid', () => {
-      const invalidDDBEvent =
-        TestEvents.dynamoStreamEvent as DynamoDBStreamEvent;
-
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[0].dynamodb!.OldImage as typeof mockNewImage) = {
-        Id: { N: 101 },
-        Message: { S: 'foo' },
-      };
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[1].dynamodb!.NewImage as typeof mockNewImage) =
-        mockNewImage;
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[0].dynamodb!.OldImage as typeof mockOldImage) =
-        mockOldImage;
-      // biome-ignore lint/style/noNonNullAssertion: it is ensured that this event has these properties
-      (invalidDDBEvent.Records[0].dynamodb!.NewImage as typeof mockNewImage) =
-        mockNewImage;
-
-      const parsed = DynamoDBStreamEnvelope.safeParse(invalidDDBEvent, schema);
-      expect(parsed).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: invalidDDBEvent,
+        error: new ParseError('Failed to parse DynamoDB Stream envelope', {
+          cause: new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'object',
+              received: 'undefined',
+              path: ['Records', 0, 'dynamodb'],
+              message: 'Required',
+            },
+          ]),
+        }),
+        originalEvent: event,
       });
     });
 
-    it('safeParse should return error if envelope is invalid', () => {
-      const parsed = DynamoDBStreamEnvelope.safeParse({ foo: 'bar' }, schema);
-      expect(parsed).toEqual({
+    it('returns an error if any of the records fail to parse', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+      event.Records[1].dynamodb.NewImage = marshall({
+        Message: 42,
+        Id: 101,
+      });
+
+      // Act
+      const parsedEvent = DynamoDBStreamEnvelope.safeParse(event, schema);
+
+      // Assess
+      expect(parsedEvent).toEqual({
         success: false,
-        error: expect.any(ParseError),
-        originalEvent: { foo: 'bar' },
+        error: new ParseError('Failed to parse record at index 1', {
+          cause: new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              received: 'number',
+              path: ['Records', 1, 'dynamodb', 'NewImage', 'Message'],
+              message: 'Expected string, received number',
+            },
+          ]),
+        }),
+        originalEvent: event,
       });
     });
   });

--- a/packages/parser/tests/unit/envelopes/dynamodb.test.ts
+++ b/packages/parser/tests/unit/envelopes/dynamodb.test.ts
@@ -22,7 +22,24 @@ describe('Envelope: DynamoDB Stream', () => {
       const event = structuredClone(baseEvent);
 
       // Act & Assess
-      expect(() => DynamoDBStreamEnvelope.parse(event, z.number())).toThrow();
+      expect(() => DynamoDBStreamEnvelope.parse(event, z.number())).toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Failed to parse DynamoDB record at index 0'
+          ),
+          cause: expect.objectContaining({
+            issues: [
+              {
+                code: 'invalid_type',
+                expected: 'number',
+                received: 'object',
+                message: 'Expected number, received object',
+                path: ['Records', 0, 'dynamodb', 'NewImage'],
+              },
+            ],
+          }),
+        })
+      );
     });
 
     it('parses a DynamoDB Stream event', () => {

--- a/packages/parser/tests/unit/envelopes/dynamodb.test.ts
+++ b/packages/parser/tests/unit/envelopes/dynamodb.test.ts
@@ -25,21 +25,21 @@ describe('Envelope: DynamoDB Stream', () => {
       expect(() => DynamoDBStreamEnvelope.parse(event, z.number())).toThrow();
     });
 
-    it('parse should parse dynamodb envelope', () => {
+    it('parses a DynamoDB Stream event', () => {
       // Prepare
       const testEvent = structuredClone(baseEvent);
 
       // Act
-      const parsed = DynamoDBStreamEnvelope.parse(testEvent, schema);
+      const result = DynamoDBStreamEnvelope.parse(testEvent, schema);
 
       // Assess
-      expect(parsed[0]).toEqual({
+      expect(result[0]).toEqual({
         NewImage: {
           Message: 'New item!',
           Id: 101,
         },
       });
-      expect(parsed[1]).toEqual({
+      expect(result[1]).toEqual({
         OldImage: {
           Message: 'New item!',
           Id: 101,
@@ -58,10 +58,10 @@ describe('Envelope: DynamoDB Stream', () => {
       const event = structuredClone(baseEvent);
 
       // Act
-      const parsedEvent = DynamoDBStreamEnvelope.safeParse(event, schema);
+      const result = DynamoDBStreamEnvelope.safeParse(event, schema);
 
       // Assess
-      expect(parsedEvent).toEqual({
+      expect(result).toEqual({
         success: true,
         data: [
           {
@@ -91,10 +91,10 @@ describe('Envelope: DynamoDB Stream', () => {
       event.Records[0].dynamodb = undefined;
 
       // Act
-      const parsedEvent = DynamoDBStreamEnvelope.safeParse(event, schema);
+      const result = DynamoDBStreamEnvelope.safeParse(event, schema);
 
       // Assess
-      expect(parsedEvent).toEqual({
+      expect(result).toEqual({
         success: false,
         error: new ParseError('Failed to parse DynamoDB Stream envelope', {
           cause: new ZodError([
@@ -120,10 +120,10 @@ describe('Envelope: DynamoDB Stream', () => {
       });
 
       // Act
-      const parsedEvent = DynamoDBStreamEnvelope.safeParse(event, schema);
+      const result = DynamoDBStreamEnvelope.safeParse(event, schema);
 
       // Assess
-      expect(parsedEvent).toEqual({
+      expect(result).toEqual({
         success: false,
         error: new ParseError('Failed to parse record at index 1', {
           cause: new ZodError([

--- a/packages/parser/tests/unit/helpers.test.ts
+++ b/packages/parser/tests/unit/helpers.test.ts
@@ -169,6 +169,11 @@ describe('DynamoDBMarshalled', () => {
     Id: z.number(),
   });
 
+  const baseEvent = getTestEvent<DynamoDBStreamEvent>({
+    eventsPath: 'dynamodb',
+    filename: 'base',
+  });
+
   const extendedSchema = DynamoDBStreamSchema.extend({
     Records: z.array(
       DynamoDBStreamRecord.extend({
@@ -210,11 +215,7 @@ describe('DynamoDBMarshalled', () => {
       },
     ];
 
-    const testEvent = getTestEvent<DynamoDBStreamEvent>({
-      eventsPath: '.',
-      filename: 'dynamoStreamEvent',
-    });
-
+    const testEvent = structuredClone(baseEvent);
     testEvent.Records[0].dynamodb.NewImage = testInput[0];
     testEvent.Records[1].dynamodb.NewImage = testInput[1];
 
@@ -258,11 +259,7 @@ describe('DynamoDBMarshalled', () => {
       },
     ];
 
-    const testEvent = getTestEvent<DynamoDBStreamEvent>({
-      eventsPath: '.',
-      filename: 'dynamoStreamEvent',
-    });
-
+    const testEvent = structuredClone(baseEvent);
     testEvent.Records[0].dynamodb.NewImage = testInput[0];
     testEvent.Records[1].dynamodb.NewImage = testInput[1];
 
@@ -291,11 +288,7 @@ describe('DynamoDBMarshalled', () => {
       },
     ];
 
-    const testEvent = getTestEvent<DynamoDBStreamEvent>({
-      eventsPath: '.',
-      filename: 'dynamoStreamEvent',
-    });
-
+    const testEvent = structuredClone(baseEvent);
     testEvent.Records[0].dynamodb.NewImage = testInput[0];
     testEvent.Records[1].dynamodb.NewImage = testInput[1];
 

--- a/packages/parser/tests/unit/schema/dynamodb.test.ts
+++ b/packages/parser/tests/unit/schema/dynamodb.test.ts
@@ -17,13 +17,67 @@ describe('Schema: DynamoDB ', () => {
     const parsedEvent = DynamoDBStreamSchema.parse(event);
 
     // Assess
-    expect(parsedEvent).toEqual(event);
+    const expectedResult = structuredClone(event);
+    expectedResult.Records[0].dynamodb.Keys = {
+      Id: 101,
+    };
+    expectedResult.Records[0].dynamodb.NewImage = {
+      Message: 'New item!',
+      Id: 101,
+    };
+    expectedResult.Records[1].dynamodb.Keys = {
+      Id: 101,
+    };
+    expectedResult.Records[1].dynamodb.OldImage = {
+      Message: 'New item!',
+      Id: 101,
+    };
+    expectedResult.Records[1].dynamodb.NewImage = {
+      Message: 'This item has changed',
+      Id: 101,
+    };
+    expect(parsedEvent).toStrictEqual(expectedResult);
   });
 
   it('throws if event is not a DynamoDB Stream event', () => {
     // Prepare
     const event = {
       Records: [],
+    };
+
+    // Act & Assess
+    expect(() => DynamoDBStreamSchema.parse(event)).toThrow();
+  });
+
+  it('throws if the Keys DynamoDB AttributeValues cannot be unmarshalled', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.Records[0].dynamodb.Keys = {
+      Id: { L: 'invalid' },
+    };
+
+    // Act & Assess
+    expect(() => DynamoDBStreamSchema.parse(event)).toThrow();
+  });
+
+  it('throws if the NewImage DynamoDB AttributeValues cannot be unmarshalled', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.Records[0].dynamodb.NewImage = {
+      Message: { S: 'New item!' },
+      Id: { L: 'invalid' },
+    };
+
+    // Act & Assess
+    expect(() => DynamoDBStreamSchema.parse(event)).toThrow();
+  });
+
+  it('throws if the OldImage DynamoDB AttributeValues cannot be unmarshalled', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.Records[1].dynamodb.OldImage = {
+      Message: { S: 'New item!' },
+      Id: { L: 'invalid' },
     };
 
     // Act & Assess

--- a/packages/parser/tests/unit/schema/dynamodb.test.ts
+++ b/packages/parser/tests/unit/schema/dynamodb.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { DynamoDBStreamSchema } from '../../../src/schemas/';
-import { TestEvents } from './utils.js';
+import { DynamoDBStreamSchema } from '../../../src/schemas/dynamodb.js';
+import type { DynamoDBStreamEvent } from '../../../src/types/schema.js';
+import { getTestEvent } from '../schema/utils.js';
 
-describe('DynamoDB ', () => {
-  const dynamoStreamEvent = TestEvents.dynamoStreamEvent;
-  it('should parse a stream of records', () => {
-    expect(DynamoDBStreamSchema.parse(dynamoStreamEvent)).toEqual(
-      dynamoStreamEvent
-    );
+describe('Schema: DynamoDB ', () => {
+  const baseEvent = getTestEvent<DynamoDBStreamEvent>({
+    eventsPath: 'dynamodb',
+    filename: 'base',
+  });
+
+  it('parses a DynamoDB Stream event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+
+    // Act
+    const parsedEvent = DynamoDBStreamSchema.parse(event);
+
+    // Assess
+    expect(parsedEvent).toEqual(event);
+  });
+
+  it('throws if event is not a DynamoDB Stream event', () => {
+    // Prepare
+    const event = {
+      Records: [],
+    };
+
+    // Act & Assess
+    expect(() => DynamoDBStreamSchema.parse(event)).toThrow();
   });
 });

--- a/packages/parser/tests/unit/schema/dynamodb.test.ts
+++ b/packages/parser/tests/unit/schema/dynamodb.test.ts
@@ -3,7 +3,7 @@ import { DynamoDBStreamSchema } from '../../../src/schemas/dynamodb.js';
 import type { DynamoDBStreamEvent } from '../../../src/types/schema.js';
 import { getTestEvent } from '../schema/utils.js';
 
-describe('Schema: DynamoDB ', () => {
+describe('Schema: DynamoDB', () => {
   const baseEvent = getTestEvent<DynamoDBStreamEvent>({
     eventsPath: 'dynamodb',
     filename: 'base',
@@ -14,10 +14,10 @@ describe('Schema: DynamoDB ', () => {
     const event = structuredClone(baseEvent);
 
     // Act
-    const parsedEvent = DynamoDBStreamSchema.parse(event);
+    const result = DynamoDBStreamSchema.parse(event);
 
     // Assess
-    expect(parsedEvent).toStrictEqual({
+    expect(result).toStrictEqual({
       Records: [
         {
           eventID: '1',
@@ -68,7 +68,7 @@ describe('Schema: DynamoDB ', () => {
     });
   });
 
-  it('throws if event is not a DynamoDB Stream event', () => {
+  it('throws if the event is not a DynamoDB Stream event', () => {
     // Prepare
     const event = {
       Records: [],

--- a/packages/parser/tests/unit/schema/dynamodb.test.ts
+++ b/packages/parser/tests/unit/schema/dynamodb.test.ts
@@ -17,26 +17,55 @@ describe('Schema: DynamoDB ', () => {
     const parsedEvent = DynamoDBStreamSchema.parse(event);
 
     // Assess
-    const expectedResult = structuredClone(event);
-    expectedResult.Records[0].dynamodb.Keys = {
-      Id: 101,
-    };
-    expectedResult.Records[0].dynamodb.NewImage = {
-      Message: 'New item!',
-      Id: 101,
-    };
-    expectedResult.Records[1].dynamodb.Keys = {
-      Id: 101,
-    };
-    expectedResult.Records[1].dynamodb.OldImage = {
-      Message: 'New item!',
-      Id: 101,
-    };
-    expectedResult.Records[1].dynamodb.NewImage = {
-      Message: 'This item has changed',
-      Id: 101,
-    };
-    expect(parsedEvent).toStrictEqual(expectedResult);
+    expect(parsedEvent).toStrictEqual({
+      Records: [
+        {
+          eventID: '1',
+          eventVersion: '1.0',
+          dynamodb: {
+            ApproximateCreationDateTime: 1693997155.0,
+            Keys: {
+              Id: 101,
+            },
+            NewImage: {
+              Message: 'New item!',
+              Id: 101,
+            },
+            StreamViewType: 'NEW_IMAGE',
+            SequenceNumber: '111',
+            SizeBytes: 26,
+          },
+          awsRegion: 'us-west-2',
+          eventName: 'INSERT',
+          eventSourceARN: 'eventsource_arn',
+          eventSource: 'aws:dynamodb',
+        },
+        {
+          eventID: '2',
+          eventVersion: '1.0',
+          dynamodb: {
+            OldImage: {
+              Message: 'New item!',
+              Id: 101,
+            },
+            SequenceNumber: '222',
+            Keys: {
+              Id: 101,
+            },
+            SizeBytes: 59,
+            NewImage: {
+              Message: 'This item has changed',
+              Id: 101,
+            },
+            StreamViewType: 'NEW_AND_OLD_IMAGES',
+          },
+          awsRegion: 'us-west-2',
+          eventName: 'MODIFY',
+          eventSourceARN: 'source_arn',
+          eventSource: 'aws:dynamodb',
+        },
+      ],
+    });
   });
 
   it('throws if event is not a DynamoDB Stream event', () => {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the logic of the `DynamoDBStreamSchema` and `DynamoDBStreamEnvelope` built-in schemas so that they automatically handle DynamoDB attribute values for the customer and convert them to JavaScript native objects during the parsing and validation.

As part of the PR, I have also improved the error messages in the parser to include the index of the record being processed as well as the full path of the issue when parsing fails. For example, now the error would be something like:

```ts
new ParseError('Failed to parse DynamoDB Stream envelope', {
  cause: new ZodError([
    {
      code: 'invalid_type',
      expected: 'object',
      received: 'undefined',
      path: ['Records', 0, 'dynamodb'],
      message: 'Required',
    }
  ]),
})
```

and like this for failed parsing of `Keys`, `NewImage`, and `OldImage`:

```ts
new ParseError('Failed to parse DynamoDB Stream envelope', {
  cause: new ZodError([
    {
      code: 'invalid_type',
      expected: 'number',
      received: 'object',
      path: ['Records', 0, 'dynamodb', 'NewImage'],
      message: 'Expected number, received object',
    }
  ]),
})
```

Likewise, when parsing an envelope using `safeParse`, the errors can also be combined when multiple records have issues:

```ts
new ParseError('Failed to parse records at indexes 0, 1', {
    cause: new ZodError([
      {
        code: 'invalid_type',
        expected: 'string',
        received: 'undefined',
        path: ['Records', 0, 'dynamodb', 'NewImage', 'Message'],
        message: 'Required',
      },
      {
        code: 'invalid_type',
        expected: 'string',
        received: 'number',
        path: ['Records', 1, 'dynamodb', 'NewImage', 'Message'],
        message: 'Expected string, received number',
      },
    ]),
  }),
  originalEvent: event,
})
```

Note that in all cases the full path of the object is preserved even though we are performing multiple Zod validations under the hood.

While working on this PR, I also brought into the `commons` package an implementation of the unmarshall function inspired by the one in the AWS SDK. This is similar to what Powertools for AWS Lambda (Python) does, and allows us to provide this behavior without forcing an extra dependency. Our implementation also differs from the reference one in a couple minor ways since we don't have to support old Node.js versions.

This new behavior is compatible with the `DynamoDBHelper` introduced in the previous release. This is because in order for customers to use the helper they will have to extend & replace the schema, thus bypassing the transform introduced in this PR.

Finally, we're treating this change as a fix because this should've been the default behavior all along.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3481

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
