### PR TITLE
fix(parser) identitySource to allow null values in parser

### DIFF
--- a/packages/parser/src/schemas/apigwv2.ts
+++ b/packages/parser/src/schemas/apigwv2.ts
@@ -230,7 +230,7 @@ const APIGatewayRequestAuthorizerEventV2Schema = z.object({
   version: z.literal('2.0'),
   type: z.literal('REQUEST'),
   routeArn: z.string(),
-  identitySource: APIGatewayStringArray,
+  identitySource: APIGatewayStringArray.nullish(),
   routeKey: z.string(),
   rawPath: z.string(),
   rawQueryString: z.string(),

--- a/packages/parser/tests/unit/schema/apigwv2.test.ts
+++ b/packages/parser/tests/unit/schema/apigwv2.test.ts
@@ -98,6 +98,21 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       // Assess
       expect(parsedEvent).toEqual(event);
     });
+
+    it('should parse the authorizer event with null identitySource', () => {
+      // Prepare
+      const event = getTestEvent({
+        eventsPath,
+        filename: 'authorizer-request',
+      });
+      event.identitySource = null;
+
+      // Act
+      const parsedEvent = APIGatewayRequestAuthorizerEventV2Schema.parse(event);
+
+      // Assess
+      expect(parsedEvent).toEqual(event);
+    });
   });
 
   describe('APIGatewayRequestContextV2Schema', () => {


### PR DESCRIPTION
Update the schema to permit null values for identitySource and add a test case to validate this behavior.