### PR TITLE
fix(parser): identitySource can be null in APIGatewayRequestAuthorizerEventV2Schema

### DIFF
--- a/packages/parser/src/schemas/apigwv2.ts
+++ b/packages/parser/src/schemas/apigwv2.ts
@@ -230,7 +230,7 @@ const APIGatewayRequestAuthorizerEventV2Schema = z.object({
   version: z.literal('2.0'),
   type: z.literal('REQUEST'),
   routeArn: z.string(),
-  identitySource: APIGatewayStringArray,
+  identitySource: APIGatewayStringArray.nullish(),
   routeKey: z.string(),
   rawPath: z.string(),
   rawQueryString: z.string(),

--- a/packages/parser/tests/unit/schema/apigwv2.test.ts
+++ b/packages/parser/tests/unit/schema/apigwv2.test.ts
@@ -98,6 +98,21 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       // Assess
       expect(parsedEvent).toEqual(event);
     });
+
+    it('should parse the authorizer event with null identitySource', () => {
+      // Prepare
+      const event = getTestEvent({
+        eventsPath,
+        filename: 'authorizer-request',
+      });
+      event.identitySource = null;
+
+      // Act
+      const parsedEvent = APIGatewayRequestAuthorizerEventV2Schema.parse(event);
+
+      // Assess
+      expect(parsedEvent).toEqual(event);
+    });
   });
 
   describe('APIGatewayRequestContextV2Schema', () => {


### PR DESCRIPTION
## Summary

This PR allows to parse `identitySource` with null value in `APIGatewayRequestAuthorizerEventV2Schema`. 

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3483 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
