### PR TITLE
fix(parser): API Gateway Envelopes handle non-JSON

### DIFF
--- a/packages/parser/src/envelopes/apigwv2.ts
+++ b/packages/parser/src/envelopes/apigwv2.ts
@@ -2,7 +2,7 @@ import type { ZodSchema, z } from 'zod';
 import { ParseError } from '../errors.js';
 import { APIGatewayProxyEventV2Schema } from '../schemas/apigwv2.js';
 import type { ParsedResult } from '../types/index.js';
-import { Envelope, envelopeDiscriminator } from './envelope.js';
+import { envelopeDiscriminator } from './envelope.js';
 
 /**
  * API Gateway V2 envelope to extract data within body key
@@ -14,40 +14,38 @@ export const ApiGatewayV2Envelope = {
    */
   [envelopeDiscriminator]: 'object' as const,
   parse<T extends ZodSchema>(data: unknown, schema: T): z.infer<T> {
-    return Envelope.parse(
-      APIGatewayProxyEventV2Schema.parse(data).body,
-      schema
-    );
+    try {
+      return APIGatewayProxyEventV2Schema.extend({
+        body: schema,
+      }).parse(data).body;
+    } catch (error) {
+      throw new ParseError('Failed to parse API Gateway HTTP body', {
+        cause: error as Error,
+      });
+    }
   },
 
   safeParse<T extends ZodSchema>(
     data: unknown,
     schema: T
   ): ParsedResult<unknown, z.infer<T>> {
-    const parsedEnvelope = APIGatewayProxyEventV2Schema.safeParse(data);
-    if (!parsedEnvelope.success) {
+    const result = APIGatewayProxyEventV2Schema.extend({
+      body: schema,
+    }).safeParse(data);
+
+    if (!result.success) {
       return {
         success: false,
-        error: new ParseError('Failed to parse API Gateway V2 envelope', {
-          cause: parsedEnvelope.error,
+        error: new ParseError('Failed to parse API Gateway HTTP body', {
+          cause: result.error,
         }),
         originalEvent: data,
       };
     }
 
-    const parsedBody = Envelope.safeParse(parsedEnvelope.data.body, schema);
-
-    if (!parsedBody.success) {
-      return {
-        success: false,
-        error: new ParseError('Failed to parse API Gateway V2 envelope body', {
-          cause: parsedBody.error,
-        }),
-        originalEvent: data,
-      };
-    }
-
-    // use type assertion to avoid type check, we know it's success here
-    return parsedBody;
+    return {
+      success: true,
+      data: result.data.body,
+    };
   },
 };

--- a/packages/parser/src/envelopes/envelope.ts
+++ b/packages/parser/src/envelopes/envelope.ts
@@ -2,6 +2,7 @@ import type { ZodSchema, z } from 'zod';
 import { ParseError } from '../errors.js';
 import type { ParsedResult } from '../types/parser.js';
 
+/* v8 ignore start */
 const Envelope = {
   /**
    * Abstract function to parse the content of the envelope using provided schema.
@@ -35,7 +36,10 @@ const Envelope = {
    * @param input
    * @param schema
    */
-  safeParse<T extends ZodSchema>(input: unknown, schema: T): ParsedResult<unknown, z.infer<T>> {
+  safeParse<T extends ZodSchema>(
+    input: unknown,
+    schema: T
+  ): ParsedResult<unknown, z.infer<T>> {
     try {
       if (typeof input !== 'object' && typeof input !== 'string') {
         return {
@@ -75,3 +79,4 @@ const Envelope = {
 const envelopeDiscriminator = Symbol.for('returnType');
 
 export { Envelope, envelopeDiscriminator };
+/* v8 ignore stop */

--- a/packages/parser/tests/unit/envelopes/apigw.test.ts
+++ b/packages/parser/tests/unit/envelopes/apigw.test.ts
@@ -1,123 +1,134 @@
 import { describe, expect, it } from 'vitest';
-import { ZodError } from 'zod';
+import { ZodError, z } from 'zod';
 import { ApiGatewayEnvelope } from '../../../src/envelopes/index.js';
 import { ParseError } from '../../../src/errors.js';
+import { JSONStringified } from '../../../src/helpers.js';
 import type { APIGatewayProxyEvent } from '../../../src/types/schema.js';
-import { TestSchema, getTestEvent } from '../schema/utils.js';
+import { getTestEvent, omit } from '../schema/utils.js';
 
-describe('API Gateway REST Envelope', () => {
-  const eventsPath = 'apigw-rest';
-  const eventPrototype = getTestEvent<APIGatewayProxyEvent>({
-    eventsPath,
+describe('Envelope: API Gateway REST', () => {
+  const schema = z
+    .object({
+      message: z.string(),
+    })
+    .strict();
+  const baseEvent = getTestEvent<APIGatewayProxyEvent>({
+    eventsPath: 'apigw-rest',
     filename: 'no-auth',
   });
 
   describe('Method: parse', () => {
-    it('should throw if the payload does not match the schema', () => {
+    it('throws if the payload does not match the schema', () => {
       // Prepare
-      const event = { ...eventPrototype };
-      event.body = JSON.stringify({ name: 'foo' });
+      const event = structuredClone(baseEvent);
 
       // Act & Assess
-      expect(() => ApiGatewayEnvelope.parse(event, TestSchema)).toThrow(
-        ParseError
+      expect(() => ApiGatewayEnvelope.parse(event, schema)).toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining('Failed to parse API Gateway body'),
+          cause: expect.objectContaining({
+            issues: [
+              {
+                code: 'invalid_type',
+                expected: 'object',
+                received: 'null',
+                path: ['body'],
+                message: 'Expected object, received null',
+              },
+            ],
+          }),
+        })
       );
     });
 
-    it('should throw if the body is null', () => {
+    it('parses an API Gateway REST event with plain text', () => {
       // Prepare
-      const event = { ...eventPrototype };
-      event.body = null;
-
-      // Act & Assess
-      expect(() => ApiGatewayEnvelope.parse(event, TestSchema)).toThrow(
-        ParseError
-      );
-    });
-
-    it('should parse and return the inner schema in an envelope', () => {
-      // Prepare
-      const event = { ...eventPrototype };
-      const payload = { name: 'foo', age: 42 };
-      event.body = JSON.stringify(payload);
+      const event = structuredClone(baseEvent);
+      event.body = 'hello world';
 
       // Act
-      const parsedEvent = ApiGatewayEnvelope.parse(event, TestSchema);
+      const result = ApiGatewayEnvelope.parse(event, z.string());
 
       // Assess
-      expect(parsedEvent).toEqual(payload);
+      expect(result).toEqual('hello world');
+    });
+
+    it('parses an API Gateway REST event with JSON-stringified body', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+      event.body = JSON.stringify({ message: 'hello world' });
+
+      // Act
+      const result = ApiGatewayEnvelope.parse(event, JSONStringified(schema));
+
+      // Assess
+      expect(result).toStrictEqual({ message: 'hello world' });
+    });
+
+    it('parses an API Gateway REST event with binary body', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+      event.body = 'aGVsbG8gd29ybGQ='; // base64 encoded 'hello world'
+      // @ts-expect-error - we know the headers exist
+      event.headers['content-type'] = 'application/octet-stream';
+      event.isBase64Encoded = true;
+
+      // Act
+      const result = ApiGatewayEnvelope.parse(event, z.string());
+
+      // Assess
+      expect(result).toEqual('aGVsbG8gd29ybGQ=');
     });
   });
 
   describe('Method: safeParse', () => {
-    it('should not throw if the payload does not match the schema', () => {
+    it('parses an API Gateway REST event', () => {
       // Prepare
-      const event = { ...eventPrototype };
-      event.body = JSON.stringify({ name: 'foo' });
+      const event = structuredClone(baseEvent);
+      event.body = JSON.stringify({ message: 'hello world' });
 
       // Act
-      const parseResult = ApiGatewayEnvelope.safeParse(event, TestSchema);
+      const result = ApiGatewayEnvelope.safeParse(
+        event,
+        JSONStringified(schema)
+      );
 
       // Assess
-      expect(parseResult).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: event,
-      });
-
-      if (!parseResult.success && parseResult.error) {
-        expect(parseResult.error.cause).toBeInstanceOf(ZodError);
-      }
-    });
-
-    it('should not throw if the body is null', () => {
-      // Prepare
-      const event = { ...eventPrototype };
-      event.body = null;
-
-      // Act
-      const parseResult = ApiGatewayEnvelope.safeParse(event, TestSchema);
-
-      // Assess
-      expect(parseResult).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: event,
-      });
-
-      if (!parseResult.success && parseResult.error) {
-        expect(parseResult.error.cause).toBeInstanceOf(ZodError);
-      }
-    });
-
-    it('should not throw if the event is invalid', () => {
-      // Prepare
-      const event = getTestEvent({ eventsPath, filename: 'invalid' });
-
-      // Act
-      const parseResult = ApiGatewayEnvelope.safeParse(event, TestSchema);
-
-      // Assess
-      expect(parseResult).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: event,
-      });
-    });
-
-    it('should parse and return the inner schema in an envelope', () => {
-      // Prepare
-      const event = { ...eventPrototype };
-      const payload = { name: 'foo', age: 42 };
-      event.body = JSON.stringify(payload);
-
-      // Act
-      const parsedEvent = ApiGatewayEnvelope.safeParse(event, TestSchema);
-
-      // Assess
-      expect(parsedEvent).toEqual({
+      expect(result).toEqual({
         success: true,
-        data: payload,
+        data: { message: 'hello world' },
+      });
+    });
+
+    it('returns an error if the event is not a valid API Gateway REST event', () => {
+      // Prepare
+      const event = omit(['path'], structuredClone(baseEvent));
+
+      // Act
+      const result = ApiGatewayEnvelope.safeParse(event, schema);
+
+      // Assess
+      expect(result).toEqual({
+        success: false,
+        error: new ParseError('Failed to parse API Gateway body', {
+          cause: new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              received: 'undefined',
+              path: ['path'],
+              message: 'Required',
+            },
+            {
+              code: 'invalid_type',
+              expected: 'object',
+              received: 'null',
+              path: ['body'],
+              message: 'Expected object, received null',
+            },
+          ]),
+        }),
+        originalEvent: event,
       });
     });
   });

--- a/packages/parser/tests/unit/envelopes/apigwv2.test.ts
+++ b/packages/parser/tests/unit/envelopes/apigwv2.test.ts
@@ -1,119 +1,135 @@
 import { describe, expect, it } from 'vitest';
-import { ZodError } from 'zod';
+import { ZodError, z } from 'zod';
 import { ApiGatewayV2Envelope } from '../../../src/envelopes/index.js';
 import { ParseError } from '../../../src/errors.js';
+import { JSONStringified } from '../../../src/helpers.js';
 import type { APIGatewayProxyEventV2 } from '../../../src/types/schema.js';
-import { TestSchema, getTestEvent } from '../schema/utils.js';
+import { getTestEvent, omit } from '../schema/utils.js';
 
-describe('API Gateway HTTP Envelope', () => {
-  const eventsPath = 'apigw-http';
-  const eventPrototype = getTestEvent<APIGatewayProxyEventV2>({
-    eventsPath,
+describe('Envelope: API Gateway HTTP', () => {
+  const schema = z
+    .object({
+      message: z.string(),
+    })
+    .strict();
+  const baseEvent = getTestEvent<APIGatewayProxyEventV2>({
+    eventsPath: 'apigw-http',
     filename: 'no-auth',
   });
 
   describe('Method: parse', () => {
-    it('should throw if the payload does not match the schema', () => {
+    it('throws if the payload does not match the schema', () => {
       // Prepare
-      const event = { ...eventPrototype };
-      event.body = JSON.stringify({ name: 'foo' });
+      const event = structuredClone(baseEvent);
 
       // Act & Assess
-      expect(() => ApiGatewayV2Envelope.parse(event, TestSchema)).toThrow(
-        ParseError
+      expect(() => ApiGatewayV2Envelope.parse(event, schema)).toThrow(
+        expect.objectContaining({
+          message: expect.stringContaining(
+            'Failed to parse API Gateway HTTP body'
+          ),
+          cause: expect.objectContaining({
+            issues: [
+              {
+                code: 'invalid_type',
+                expected: 'object',
+                received: 'undefined',
+                path: ['body'],
+                message: 'Required',
+              },
+            ],
+          }),
+        })
       );
     });
 
-    it('should throw if the body is undefined', () => {
+    it('parses an API Gateway HTTP event with plain text', () => {
       // Prepare
-      const event = { ...eventPrototype };
-      event.body = undefined;
-
-      // Act & Assess
-      expect(() => ApiGatewayV2Envelope.parse(event, TestSchema)).toThrow(
-        ParseError
-      );
-    });
-
-    it('should parse and return the inner schema in an envelope', () => {
-      // Prepare
-      const event = { ...eventPrototype };
-      const payload = { name: 'foo', age: 42 };
-      event.body = JSON.stringify(payload);
+      const event = structuredClone(baseEvent);
+      event.body = 'hello world';
 
       // Act
-      const parsedEvent = ApiGatewayV2Envelope.parse(event, TestSchema);
+      const result = ApiGatewayV2Envelope.parse(event, z.string());
 
       // Assess
-      expect(parsedEvent).toEqual(payload);
+      expect(result).toEqual('hello world');
+    });
+
+    it('parses an API Gateway HTTP event with JSON-stringified body', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+      event.body = JSON.stringify({ message: 'hello world' });
+
+      // Act
+      const result = ApiGatewayV2Envelope.parse(event, JSONStringified(schema));
+
+      // Assess
+      expect(result).toStrictEqual({ message: 'hello world' });
+    });
+
+    it('parses an API Gateway HTTP event with binary body', () => {
+      // Prepare
+      const event = structuredClone(baseEvent);
+      event.body = 'aGVsbG8gd29ybGQ='; // base64 encoded 'hello world'
+      event.headers['content-type'] = 'application/octet-stream';
+      event.isBase64Encoded = true;
+
+      // Act
+      const result = ApiGatewayV2Envelope.parse(event, z.string());
+
+      // Assess
+      expect(result).toEqual('aGVsbG8gd29ybGQ=');
     });
   });
 
   describe('Method: safeParse', () => {
-    it('should not throw if the payload does not match the schema', () => {
+    it('parses an API Gateway HTTP event', () => {
       // Prepare
-      const event = { ...eventPrototype };
-      event.body = JSON.stringify({ name: 'foo' });
+      const event = structuredClone(baseEvent);
+      event.body = JSON.stringify({ message: 'hello world' });
 
       // Act
-      const parseResult = ApiGatewayV2Envelope.safeParse(event, TestSchema);
+      const result = ApiGatewayV2Envelope.safeParse(
+        event,
+        JSONStringified(schema)
+      );
 
       // Assess
-      expect(parseResult).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: event,
-      });
-
-      if (!parseResult.success && parseResult.error) {
-        expect(parseResult.error.cause).toBeInstanceOf(ZodError);
-      }
-    });
-
-    it('should not throw if the body is undefined', () => {
-      // Prepare
-      const event = { ...eventPrototype };
-      event.body = undefined;
-
-      // Act
-      const parseResult = ApiGatewayV2Envelope.safeParse(event, TestSchema);
-
-      // Assess
-      expect(parseResult).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: event,
-      });
-    });
-
-    it('should not throw if the event is invalid', () => {
-      // Prepare
-      const event = getTestEvent({ eventsPath, filename: 'invalid' });
-
-      // Act
-      const parseResult = ApiGatewayV2Envelope.safeParse(event, TestSchema);
-
-      // Assess
-      expect(parseResult).toEqual({
-        success: false,
-        error: expect.any(ParseError),
-        originalEvent: event,
-      });
-    });
-
-    it('should parse and return the inner schema in an envelope', () => {
-      // Prepare
-      const event = { ...eventPrototype };
-      const payload = { name: 'foo', age: 42 };
-      event.body = JSON.stringify(payload);
-
-      // Act
-      const parsedEvent = ApiGatewayV2Envelope.safeParse(event, TestSchema);
-
-      // Assess
-      expect(parsedEvent).toEqual({
+      expect(result).toEqual({
         success: true,
-        data: payload,
+        data: { message: 'hello world' },
+      });
+    });
+
+    it('returns an error if the event is not a valid API Gateway HTTP event', () => {
+      // Prepare
+      const event = omit(['rawPath'], structuredClone(baseEvent));
+
+      // Act
+      const result = ApiGatewayV2Envelope.safeParse(event, schema);
+
+      // Assess
+      expect(result).toEqual({
+        success: false,
+        error: new ParseError('Failed to parse API Gateway HTTP body', {
+          cause: new ZodError([
+            {
+              code: 'invalid_type',
+              expected: 'string',
+              received: 'undefined',
+              path: ['rawPath'],
+              message: 'Required',
+            },
+            {
+              code: 'invalid_type',
+              expected: 'object',
+              received: 'undefined',
+              path: ['body'],
+              message: 'Required',
+            },
+          ]),
+        }),
+        originalEvent: event,
       });
     });
   });

--- a/packages/parser/tests/unit/schema/apigw.test.ts
+++ b/packages/parser/tests/unit/schema/apigw.test.ts
@@ -6,11 +6,11 @@ import {
 } from '../../../src/schemas/index.js';
 import { getTestEvent } from './utils.js';
 
-describe('API Gateway REST Schemas', () => {
+describe('Schema: API Gateway REST', () => {
   const eventsPath = 'apigw-rest';
 
   describe('APIGatewayProxyEventSchema', () => {
-    it('should throw when the event is invalid', () => {
+    it('throws when the event is invalid', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'invalid' });
 
@@ -18,7 +18,7 @@ describe('API Gateway REST Schemas', () => {
       expect(() => APIGatewayProxyEventSchema.parse(event)).toThrow();
     });
 
-    it('should parse an event with no authorizer', () => {
+    it('parses an event with no authorizer', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'no-auth' });
 
@@ -29,7 +29,7 @@ describe('API Gateway REST Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event with a lambda authorizer', () => {
+    it('parses an event with a lambda authorizer', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -43,7 +43,7 @@ describe('API Gateway REST Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event with a JWT authorizer', () => {
+    it('parses an event with a JWT authorizer', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -57,7 +57,7 @@ describe('API Gateway REST Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event with an IAM authorizer', () => {
+    it('parses an event with an IAM authorizer', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -71,7 +71,7 @@ describe('API Gateway REST Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event sent by the AWS console test UI', () => {
+    it('parses an event sent by the AWS console test UI', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -85,7 +85,7 @@ describe('API Gateway REST Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event sent as a part of a websocket API', () => {
+    it('parses an event sent as a part of a websocket API', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -101,7 +101,7 @@ describe('API Gateway REST Schemas', () => {
   });
 
   describe('APIGatewayRequestAuthorizerEventSchema', () => {
-    it('should throw when the event is invalid', () => {
+    it('throws when the event is invalid', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'invalid' });
 
@@ -111,7 +111,7 @@ describe('API Gateway REST Schemas', () => {
       ).toThrow();
     });
 
-    it('should parse the authorizer event', () => {
+    it('parses the authorizer event', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -127,7 +127,7 @@ describe('API Gateway REST Schemas', () => {
   });
 
   describe('APIGatewayTokenAuthorizerEventSchema', () => {
-    it('should throw when the event is invalid', () => {
+    it('throws when the event is invalid', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'invalid' });
 
@@ -135,7 +135,7 @@ describe('API Gateway REST Schemas', () => {
       expect(() => APIGatewayTokenAuthorizerEventSchema.parse(event)).toThrow();
     });
 
-    it('should parse the event', () => {
+    it('parses the event', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'authorizer-token' });
 

--- a/packages/parser/tests/unit/schema/apigwv2.test.ts
+++ b/packages/parser/tests/unit/schema/apigwv2.test.ts
@@ -8,11 +8,11 @@ import {
 import type { APIGatewayProxyEventV2 } from '../../../src/types/schema.js';
 import { getTestEvent } from './utils.js';
 
-describe('API Gateway HTTP (v2) Schemas', () => {
+describe('Schema: API Gateway HTTP (v2)', () => {
   const eventsPath = 'apigw-http';
 
   describe('APIGatewayProxyEventV2Schema', () => {
-    it('should throw when the event is invalid', () => {
+    it('throws when the event is invalid', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'invalid' });
 
@@ -20,7 +20,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       expect(() => APIGatewayProxyEventV2Schema.parse(event)).toThrow();
     });
 
-    it('should parse an event with no authorizer', () => {
+    it('parses an event with no authorizer', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'no-auth' });
 
@@ -31,7 +31,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event with a lambda authorizer', () => {
+    it('parses an event with a lambda authorizer', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -45,7 +45,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event with a JWT authorizer', () => {
+    it('parses an event with a JWT authorizer', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -59,7 +59,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse an event with an IAM authorizer', () => {
+    it('parses an event with an IAM authorizer', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -75,7 +75,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
   });
 
   describe('APIGatewayRequestAuthorizerEventV2Schema', () => {
-    it('should throw when the event is invalid', () => {
+    it('throws when the event is invalid', () => {
       // Prepare
       const event = getTestEvent({ eventsPath, filename: 'invalid' });
 
@@ -85,7 +85,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       ).toThrow();
     });
 
-    it('should parse the authorizer event', () => {
+    it('parses the authorizer event', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,
@@ -99,7 +99,7 @@ describe('API Gateway HTTP (v2) Schemas', () => {
       expect(parsedEvent).toEqual(event);
     });
 
-    it('should parse the authorizer event with null identitySource', () => {
+    it('parses the authorizer event with null identitySource', () => {
       // Prepare
       const event = getTestEvent({
         eventsPath,


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR refactors the API Gateway (REST) & API Gateway v2 (HTTP) envelopes so that they don't force the transform of the `body` field and thus can handle plain text and base64 binary-encoded bodies.

The body is now left as a string and it's up to the caller to set the appropriate transform in the Zod schema passed to the envelope, for example to 

```ts
import { z } from 'zod';
import { JSONStringified } from '@aws-lambda-powertools/parser/helpers';

const schema = z.object({
  message: z.string()
});

ApiGatewayEnvelope.parse(event, JSONStringified(schema));
```

If there's demand for it, in the future we can consider adding an helper for base64 decoding.

Additionally I standardized the error structure by always throwing a `ParseError` with the original error as cause:

```ts
new ParseError('Failed to parse API Gateway body', {
  cause: new ZodError([
    {
      code: 'invalid_type',
      expected: 'string',
      received: 'undefined',
      path: ['path'],
      message: 'Required',
    },
    {
      code: 'invalid_type',
      expected: 'object',
      received: 'null',
      path: ['body'],
      message: 'Expected object, received null',
    },
  ]),
})
```

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3512

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
