### PR TITLE
fix(parser): Firehose SQS should fail for invalid SQS message

### DIFF
--- a/packages/parser/src/schemas/kinesis-firehose.ts
+++ b/packages/parser/src/schemas/kinesis-firehose.ts
@@ -35,13 +35,19 @@ const KinesisFirehoseRecordSchema = KinesisFireHoseRecordBase.extend({
  * Zod schema for a SQS record from an Kinesis Firehose event.
  */
 const KinesisFirehoseSqsRecordSchema = KinesisFireHoseRecordBase.extend({
-  data: z.string().transform((data) => {
+  data: z.string().transform((data, ctx) => {
     try {
       return SqsRecordSchema.parse(
         JSON.parse(Buffer.from(data, 'base64').toString('utf8'))
       );
     } catch (e) {
-      return data;
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Failed to parse SQS record',
+        fatal: true,
+      });
+
+      return z.NEVER;
     }
   }),
 });

--- a/packages/parser/tests/events/kinesis/firehose-sqs-invalid.json
+++ b/packages/parser/tests/events/kinesis/firehose-sqs-invalid.json
@@ -1,0 +1,12 @@
+{
+  "invocationId": "556b67a3-48fc-4385-af49-e133aade9cb9",
+  "deliveryStreamArn": "arn:aws:firehose:us-east-1:123456789012:deliverystream/PUT-S3-tdyyE",
+  "region": "us-east-1",
+  "records": [
+    {
+      "recordId": "49640912821178817833517986466168945147170627572855734274000000",
+      "approximateArrivalTimestamp": 1684864917398,
+      "data": "bm90IGEgdmFsaWQgamFzb24="
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

This PR fixes a bug, where KinesisFirehoseSQSSchema would return original data, when SQS message is invalid. 

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3249 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
