### PR TITLE
chore(layers): add compatible architecture field

### DIFF
--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { join, resolve, sep } from 'node:path';
 import { CfnOutput, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
 import {
+  Architecture,
   CfnLayerVersionPermission,
   Code,
   LayerVersion,
@@ -42,8 +43,7 @@ export class LayerPublisherStack extends Stack {
         Runtime.NODEJS_22_X,
       ],
       license: 'MIT-0',
-      // This is needed because the following regions do not support the compatibleArchitectures property #1400
-      // ...(![ 'eu-south-2', 'eu-central-2', 'ap-southeast-4' ].includes(Stack.of(this).region) ? { compatibleArchitectures: [Architecture.X86_64] } : {}),
+      compatibleArchitectures: [Architecture.ARM_64, Architecture.X86_64],
       code: Code.fromAsset(resolve(__dirname), {
         bundling: {
           // This is here only because is required by CDK, however it is not used since the bundling is done locally


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds back the `compatibleArchitectures` field to our Lambda layers since all the regions we support today also support the field in their API.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #1400

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
