### PR TITLE
improv(logger): switch key order for better readability

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -148,15 +148,15 @@ In each case, the printed log will look like this:
 
     ```json hl_lines="2-6"
     {
+        "level": "INFO",
+        "message": "This is an INFO log with some context",
+        "timestamp": "2021-12-12T21:21:08.921Z",
+        "service": "serverlessAirline",
         "cold_start": true,
         "function_arn": "arn:aws:lambda:eu-west-1:123456789012:function:shopping-cart-api-lambda-prod-eu-west-1",
         "function_memory_size": 128,
         "function_request_id": "c6af9ac6-7b61-11e6-9a41-93e812345678",
         "function_name": "shopping-cart-api-lambda-prod-eu-west-1",
-        "level": "INFO",
-        "message": "This is an INFO log with some context",
-        "service": "serverlessAirline",
-        "timestamp": "2021-12-12T21:21:08.921Z",
         "xray_trace_id": "abcdef123456abcdef123456abcdef123456"
     }
     ```

--- a/examples/snippets/logger/customTimezoneOutput.json
+++ b/examples/snippets/logger/customTimezoneOutput.json
@@ -2,17 +2,17 @@
   {
     "level": "INFO",
     "message": "Hello, World!",
-    "sampling_rate": 0,
-    "service": "serverlessAirline",
     "timestamp": "2024-07-01T11:00:37.886Z",
+    "service": "serverlessAirline",
+    "sampling_rate": 0,
     "xray_trace_id": "1-66828c55-2bb635c65eb609c820ebe7bc"
   },
   {
     "level": "INFO",
     "message": "Ciao, Mondo!",
-    "sampling_rate": 0,
-    "service": "serverlessAirline",
     "timestamp": "2024-07-01T13:00:37.934+02:00",
+    "service": "serverlessAirline",
+    "sampling_rate": 0,
     "xray_trace_id": "1-66828c55-2bb635c65eb609c820ebe7bc"
   }
 ]

--- a/examples/snippets/logger/reorderLogKeysOutput.json
+++ b/examples/snippets/logger/reorderLogKeysOutput.json
@@ -1,9 +1,9 @@
 {
-  "timestamp": "2024-09-03T02:59:06.603Z",
-  "additionalKey": "additionalValue",
   "level": "INFO",
   "message": "Hello, World!",
-  "sampling_rate": 0,
+  "timestamp": "2024-09-03T02:59:06.603Z",
   "service": "serverlessAirline",
+  "additionalKey": "additionalValue",
+  "sampling_rate": 0,
   "xray_trace_id": "1-66d67b7a-79bc7b2346b32af01b437cf8"
 }

--- a/examples/snippets/logger/unserializableValues.json
+++ b/examples/snippets/logger/unserializableValues.json
@@ -1,9 +1,13 @@
 {
   "level": "INFO",
   "message": "Serialize with custom serializer",
-  "sampling_rate": 0,
-  "service": "serverlessAirline",
   "timestamp": "2024-07-07T09:52:14.212Z",
+  "service": "serverlessAirline",
+  "sampling_rate": 0,
   "xray_trace_id": "1-668a654d-396c646b760ee7d067f32f18",
-  "serializedValue": [1, 2, 3]
+  "serializedValue": [
+    1,
+    2,
+    3
+  ]
 }

--- a/packages/logger/src/formatter/PowertoolsLogFormatter.ts
+++ b/packages/logger/src/formatter/PowertoolsLogFormatter.ts
@@ -44,16 +44,16 @@ class PowertoolsLogFormatter extends LogFormatter {
     const baseAttributes: Partial<PowertoolsStandardKeys> &
       Partial<PowertoolsLambdaContextKeys> &
       LogAttributes = {
+      level: attributes.logLevel,
+      message: attributes.message,
+      timestamp: this.formatTimestamp(attributes.timestamp),
+      service: attributes.serviceName,
       cold_start: attributes.lambdaContext?.coldStart,
       function_arn: attributes.lambdaContext?.invokedFunctionArn,
       function_memory_size: attributes.lambdaContext?.memoryLimitInMB,
       function_name: attributes.lambdaContext?.functionName,
       function_request_id: attributes.lambdaContext?.awsRequestId,
-      level: attributes.logLevel,
-      message: attributes.message,
       sampling_rate: attributes.sampleRateValue,
-      service: attributes.serviceName,
-      timestamp: this.formatTimestamp(attributes.timestamp),
       xray_trace_id: attributes.xRayTraceId,
     };
 

--- a/packages/logger/tests/unit/formatters.test.ts
+++ b/packages/logger/tests/unit/formatters.test.ts
@@ -185,7 +185,7 @@ describe('Formatters', () => {
   it('when `logRecordOrder` is set, it orders the attributes in the log item', () => {
     // Prepare
     const formatter = new PowertoolsLogFormatter({
-      logRecordOrder: ['message', 'timestamp', 'serviceName', 'environment'],
+      logRecordOrder: ['message', 'timestamp', 'service'],
     });
     const additionalLogAttributes: LogAttributes = {};
 
@@ -198,21 +198,19 @@ describe('Formatters', () => {
     const response = value.getAttributes();
 
     // Assess
-    expect(JSON.stringify(response)).toEqual(
-      JSON.stringify({
-        message: 'This is a WARN log',
-        timestamp: '2016-06-20T12:08:10.000Z',
-        cold_start: true,
-        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
-        function_memory_size: '123',
-        function_name: 'my-lambda-function',
-        function_request_id: 'abcdefg123456789',
-        level: 'WARN',
-        sampling_rate: 0.25,
-        service: 'hello-world',
-        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
-      })
-    );
+    expect(response).toStrictEqual({
+      message: 'This is a WARN log',
+      timestamp: '2016-06-20T12:08:10.000Z',
+      service: 'hello-world',
+      level: 'WARN',
+      cold_start: true,
+      function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
+      function_memory_size: '123',
+      function_name: 'my-lambda-function',
+      function_request_id: 'abcdefg123456789',
+      sampling_rate: 0.25,
+      xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+    });
   });
 
   it('when `logRecordOrder` is set, it orders the attributes in the log item taking `additionalLogAttributes` into consideration', () => {
@@ -222,8 +220,8 @@ describe('Formatters', () => {
         'message',
         'additional_key',
         'timestamp',
-        'serviceName',
-        'environment',
+        'level',
+        'service',
       ]),
     });
     const additionalLogAttributes: LogAttributes = {
@@ -240,23 +238,21 @@ describe('Formatters', () => {
     const response = value.getAttributes();
 
     // Assess
-    expect(JSON.stringify(response)).toEqual(
-      JSON.stringify({
-        message: 'This is a WARN log',
-        additional_key: 'additional_value',
-        timestamp: '2016-06-20T12:08:10.000Z',
-        cold_start: true,
-        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
-        function_memory_size: '123',
-        function_name: 'my-lambda-function',
-        function_request_id: 'abcdefg123456789',
-        level: 'WARN',
-        sampling_rate: 0.25,
-        service: 'hello-world',
-        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
-        another_key: 'another_value',
-      })
-    );
+    expect(response).toStrictEqual({
+      message: 'This is a WARN log',
+      additional_key: 'additional_value',
+      timestamp: '2016-06-20T12:08:10.000Z',
+      level: 'WARN',
+      service: 'hello-world',
+      cold_start: true,
+      function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
+      function_memory_size: '123',
+      function_name: 'my-lambda-function',
+      function_request_id: 'abcdefg123456789',
+      sampling_rate: 0.25,
+      xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+      another_key: 'another_value',
+    });
   });
 
   it('when `logRecordOrder` is set, even if a key does not exist in attributes, it orders the attributes correctly', () => {
@@ -267,8 +263,7 @@ describe('Formatters', () => {
         'additional_key',
         'not_present',
         'timestamp',
-        'serviceName',
-        'environment',
+        'level',
       ],
     });
     const additionalLogAttributes: LogAttributes = {
@@ -284,22 +279,20 @@ describe('Formatters', () => {
     const response = value.getAttributes();
 
     // Assess
-    expect(JSON.stringify(response)).toEqual(
-      JSON.stringify({
-        message: 'This is a WARN log',
-        additional_key: 'additional_value',
-        timestamp: '2016-06-20T12:08:10.000Z',
-        cold_start: true,
-        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
-        function_memory_size: '123',
-        function_name: 'my-lambda-function',
-        function_request_id: 'abcdefg123456789',
-        level: 'WARN',
-        sampling_rate: 0.25,
-        service: 'hello-world',
-        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
-      })
-    );
+    expect(response).toStrictEqual({
+      message: 'This is a WARN log',
+      additional_key: 'additional_value',
+      timestamp: '2016-06-20T12:08:10.000Z',
+      level: 'WARN',
+      service: 'hello-world',
+      cold_start: true,
+      function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
+      function_memory_size: '123',
+      function_name: 'my-lambda-function',
+      function_request_id: 'abcdefg123456789',
+      sampling_rate: 0.25,
+      xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+    });
   });
 
   it('when logRecordOrder is not set, it will not order the attributes in the log item', () => {
@@ -318,22 +311,20 @@ describe('Formatters', () => {
     const response = value.getAttributes();
 
     // Assess
-    expect(JSON.stringify(response)).toEqual(
-      JSON.stringify({
-        cold_start: true,
-        function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
-        function_memory_size: '123',
-        function_name: 'my-lambda-function',
-        function_request_id: 'abcdefg123456789',
-        level: 'WARN',
-        message: 'This is a WARN log',
-        sampling_rate: 0.25,
-        service: 'hello-world',
-        timestamp: '2016-06-20T12:08:10.000Z',
-        xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
-        additional_key: 'additional_value',
-      })
-    );
+    expect(response).toStrictEqual({
+      level: 'WARN',
+      message: 'This is a WARN log',
+      timestamp: '2016-06-20T12:08:10.000Z',
+      service: 'hello-world',
+      cold_start: true,
+      function_arn: 'arn:aws:lambda:eu-west-1:123456789012:function:Example',
+      function_memory_size: '123',
+      function_name: 'my-lambda-function',
+      function_request_id: 'abcdefg123456789',
+      sampling_rate: 0.25,
+      xray_trace_id: '1-5759e988-bd862e3fe1be46a994272793',
+      additional_key: 'additional_value',
+    });
   });
 
   // #region format errors

--- a/packages/logger/tests/unit/initializeLogger.test.ts
+++ b/packages/logger/tests/unit/initializeLogger.test.ts
@@ -151,9 +151,9 @@ describe('Log levels', () => {
         {
           level: 'INFO',
           message: 'Hello, world!',
-          sampling_rate: 0,
-          service: 'hello-world',
           timestamp: '2016-06-20T12:08:10.000Z',
+          service: 'hello-world',
+          sampling_rate: 0,
           xray_trace_id: '1-abcdef12-3456abcdef123456abcdef12',
         },
         null,


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the order of the keys in the default log formatter of Logger so that the most important information about the log entry are surfaced first. Specifically, we are now prioritizing the placement of the `level`, `message`, `timestamp`, and `service` rather than lower cardinality data such as `cold_start`, `function_arn` and others.

Since we are dealing with JSON-structured logs that are expected to be queried once parsed, changing the order should not constitute a breaking change.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3091

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
