### PR TITLE
chore(ci): remove pinned actions & pkg versions

### DIFF
--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -63,12 +63,12 @@ jobs:
         name: Create Workdir
         run: |
           mkdir -p build/project
-          - id: cdk-project
-          name: CDK Project
-          working-directory: build/project
-          run: |
-            npx cdk init app --language=typescript
-            AWS_REGION="${{ inputs.region }}" npx cdk bootstrap
+      - id: cdk-project
+        name: CDK Project
+        working-directory: build/project
+        run: |
+          npx cdk init app --language=typescript
+          AWS_REGION="${{ inputs.region }}" npx cdk bootstrap
 
   copy_layers:
     name: Copy Layers

--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -38,7 +38,6 @@ jobs:
     name: Bootstrap Region
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:
@@ -75,7 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: bootstrap
     permissions:
-      contents: write
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:

--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -34,14 +34,24 @@ permissions:
   contents: read
 
 jobs:
-  cdk:
-    name: Install CDK
+  bootstrap:
+    name: Bootstrap Region
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "22"
+      - name: Setup dependencies
+        uses: aws-powertools/actions/.github/actions/cached-node-modules@29979bc5339bf54f76a11ac36ff67701986bb0f0
       - id: credentials
         name: AWS Credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
@@ -53,26 +63,17 @@ jobs:
         name: Create Workdir
         run: |
           mkdir -p build/project
-      - name: checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          ref: ${{ github.sha }}
-      - name: Setup Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
-        with:
-          node-version: "22"
-      - name: Setup dependencies
-        uses: aws-powertools/actions/.github/actions/cached-node-modules@29979bc5339bf54f76a11ac36ff67701986bb0f0
-      - id: cdk-project
-        name: CDK Project
-        working-directory: build/project
-        run: |
-          npx cdk init app --language=typescript
-          AWS_REGION="${{ inputs.region }}" npx cdk bootstrap
+          - id: cdk-project
+          name: CDK Project
+          working-directory: build/project
+          run: |
+            npx cdk init app --language=typescript
+            AWS_REGION="${{ inputs.region }}" npx cdk bootstrap
 
   copy_layers:
     name: Copy Layers
     runs-on: ubuntu-latest
+    needs: bootstrap
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -53,11 +53,16 @@ jobs:
         name: Create Workdir
         run: |
           mkdir -p build/project
-      - id: cdk-install
-        name: Install CDK
-        working-directory: build
-        run: |
-          npm i aws-cdk@2.178.0
+      - name: checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: "22"
+      - name: Setup dependencies
+        uses: aws-powertools/actions/.github/actions/cached-node-modules@29979bc5339bf54f76a11ac36ff67701986bb0f0
       - id: cdk-project
         name: CDK Project
         working-directory: build/project
@@ -90,7 +95,7 @@ jobs:
         run: go env
       - id: go-install-pkg
         name: Install
-        run: go install github.com/aws-powertools/actions/layer-balancer/cmd/balance@latest
+        run: go install github.com/aws-powertools/actions/layer-balancer/cmd/balance@@29979bc5339bf54f76a11ac36ff67701986bb0f0
       - id: run-balance
         name: Run Balance
         run: balance -read-region us-east-1 -write-region ${{ inputs.region }} -write-role ${{ secrets.BALANCE_ROLE_ARN }} -layer-name AWSLambdaPowertoolsTypeScriptV2 -dry-run=false


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the `bootstrap_region.yml` workflow with three changes:
- The `copy_layers` step is now dependant on the `bootstrap` one
- The  `bootstrap` step checks out the repo and uses the CDK version present - this avoids pinning the CDK version
- The `copy_layers` step uses a specific version of the shared action identified by its commit hash, rather than the `latest` one

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3573

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
