### PR TITLE
fix(ci): Add permissions to jobs

### DIFF
--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -38,6 +38,7 @@ jobs:
     name: Bootstrap Region
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:
@@ -74,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bootstrap
     permissions:
+      contents: write
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:

--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -38,7 +38,7 @@ jobs:
     name: Bootstrap Region
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bootstrap
     permissions:
-      contents: write
+      contents: read
       id-token: write
     environment: layer-${{ inputs.environment }}
     steps:


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

Adds `contents: read` permission to jobs in region build to enable the workflow to "release".

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3200 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
