### PR TITLE
chore(ci): fix double `@` in action hash

### DIFF
--- a/.github/workflows/bootstrap_region.yml
+++ b/.github/workflows/bootstrap_region.yml
@@ -96,7 +96,7 @@ jobs:
         run: go env
       - id: go-install-pkg
         name: Install
-        run: go install github.com/aws-powertools/actions/layer-balancer/cmd/balance@@29979bc5339bf54f76a11ac36ff67701986bb0f0
+        run: go install github.com/aws-powertools/actions/layer-balancer/cmd/balance@29979bc5339bf54f76a11ac36ff67701986bb0f0
       - id: run-balance
         name: Run Balance
         run: balance -read-region us-east-1 -write-region ${{ inputs.region }} -write-role ${{ secrets.BALANCE_ROLE_ARN }} -layer-name AWSLambdaPowertoolsTypeScriptV2 -dry-run=false


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR removes an extra `@` character from the version/hash of a shared action.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3573

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
