### PR TITLE
docs(logger): add notice about mutating attributes in log formatter

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -588,7 +588,7 @@ If you prefer to log in a specific timezone, you can configure it by setting the
 
 ### Using multiple Logger instances across your code
 
-The `createChild` method allows you to create a child instance of the Logger, which inherits all of the attributes from its parent. You have the option to override any of the settings and attributes from the parent logger, including [its settings](#utility-settings), any [extra keys](#appending-additional-keys), and [the log formatter](#custom-log-formatter-bring-your-own-formatter).
+The `createChild` method allows you to create a child instance of the Logger, which inherits all of the attributes from its parent. You have the option to override any of the settings and attributes from the parent logger, including [its settings](#utility-settings), any [extra keys](#appending-additional-keys), and [the log formatter](#custom-log-formatter).
 
 Once a child logger is created, the logger and its parent will act as separate instances of the Logger class, and as such any change to one won't be applied to the other.
 
@@ -754,9 +754,11 @@ Sampling decision happens at the Logger initialization. This means sampling may 
     }
     ```
 
-### Custom Log formatter (Bring Your Own Formatter)
+### Custom Log formatter
 
-You can customize the structure (keys and values) of your log items by passing a custom log formatter, an object that implements the `LogFormatter` abstract class.
+You can customize the structure (keys and values) of your logs by passing a custom log formatter, a class that implements the `LogFormatter` interface, to the `Logger` constructor.
+
+When working with custom log formatters, you take full control over the structure of your logs. This allows you to optionally drop or transform keys, add new ones, or change the format to suit your company's logging standards or use Logger with a third-party logging service.
 
 === "handler.ts"
 
@@ -764,15 +766,11 @@ You can customize the structure (keys and values) of your log items by passing a
     --8<-- "examples/snippets/logger/bringYourOwnFormatterHandler.ts"
     ```
 
-This is how the `MyCompanyLogFormatter` (dummy name) would look like:
-
 === "utils/formatters/MyCompanyLogFormatter.ts"
 
     ```typescript
     --8<-- "examples/snippets/logger/bringYourOwnFormatterClass.ts"
     ```
-
-This is how the printed log would look:
 
 === "Example CloudWatch Logs excerpt"
 
@@ -804,8 +802,7 @@ This is how the printed log would look:
     }
     ```
 
-!!! tip "Custom Log formatter and Child loggers"
-    It is not necessary to pass the `LogFormatter` each time a [child logger](#using-multiple-logger-instances-across-your-code) is created. The parent's LogFormatter will be inherited by the child logger.
+Note that when implementing this method, you should avoid mutating the `attributes` and `additionalLogAttributes` objects directly. Instead, create a new object with the desired structure and return it. If mutation is necessary, you can create a [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone) of the object to avoid side effects.
 
 ### Bring your own JSON serializer
 

--- a/packages/logger/src/formatter/LogFormatter.ts
+++ b/packages/logger/src/formatter/LogFormatter.ts
@@ -25,7 +25,14 @@ abstract class LogFormatter {
   /**
    * Format key-value pairs of log attributes.
    *
-   * You should implement this method in a subclass to define the structure of the log item.
+   * You should implement this method in a subclass to define the structure of the log item
+   * and instantiate a new {@link LogItem} object with the formatted attributes.
+   *
+   * Note that when implementing this method, you should avoid mutating the `attributes` and
+   * `additionalLogAttributes` objects directly. Instead, create a new object with the desired
+   * structure and return it.
+   *
+   * If mutation is necessary, you can create a `structuredClone` of the object to avoid side effects.
    *
    * @example
    * ```typescript
@@ -40,7 +47,7 @@ abstract class LogFormatter {
    *     attributes: UnformattedAttributes,
    *     additionalLogAttributes: LogAttributes
    *   ): LogItem {
-   *     const baseAttributes: MyCompanyLog = {
+   *     const baseAttributes = {
    *       message: attributes.message,
    *       service: attributes.serviceName,
    *       environment: attributes.environment,
@@ -116,8 +123,11 @@ abstract class LogFormatter {
           : error.cause,
     };
     for (const key in error) {
-      if (typeof key === 'string' && !['name', 'message', 'stack', 'cause'].includes(key)) {
-          formattedError[key] = (errorAttributes as Record<string, unknown>)[key];
+      if (
+        typeof key === 'string' &&
+        !['name', 'message', 'stack', 'cause'].includes(key)
+      ) {
+        formattedError[key] = (errorAttributes as Record<string, unknown>)[key];
       }
     }
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds a notice to both docs and API docs for Logger to let customers know that they should avoid directly mutating attributes when formatting a log entry, but rather they should make deep copies if mutation is necessary.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3588

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
