### PR TITLE
fix(logger): handle illegal null/undefined as extra args

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1,6 +1,10 @@
 import { Console } from 'node:console';
 import { randomInt } from 'node:crypto';
-import { Utility } from '@aws-lambda-powertools/commons';
+import {
+  Utility,
+  isNull,
+  isNullOrUndefined,
+} from '@aws-lambda-powertools/commons';
 import type {
   AsyncHandler,
   HandlerMethodDecorator,
@@ -777,6 +781,9 @@ class Logger extends Utility implements LoggerInterface {
     additionalAttributes: LogAttributes
   ): void {
     for (const item of extraInput) {
+      if (isNullOrUndefined(item)) {
+        continue;
+      }
       if (item instanceof Error) {
         additionalAttributes.error = item;
       } else if (typeof item === 'string') {

--- a/packages/logger/tests/unit/workingWithkeys.test.ts
+++ b/packages/logger/tests/unit/workingWithkeys.test.ts
@@ -601,7 +601,7 @@ describe('Working with keys', () => {
 
   it('logs a warning when using both the deprecated persistentLogAttributes and persistentKeys options', () => {
     // Prepare
-    const logger = new Logger({
+    new Logger({
       persistentKeys: {
         foo: 'bar',
       },
@@ -739,4 +739,24 @@ describe('Working with keys', () => {
       })
     );
   });
+
+  it.each([{ value: null }, { value: undefined }])(
+    'handles null and undefined values when passing them to the log method ($value)',
+    ({ value }) => {
+      // Prepare
+      const logger = new Logger();
+
+      // Act
+      // @ts-expect-error - these values are already forbidden by TypeScript, but JavaScript-only customers might pass them
+      logger.info('foo', value);
+
+      // Assess
+      expect(console.info).toHaveLoggedNth(
+        1,
+        expect.objectContaining({
+          message: 'foo',
+        })
+      );
+    }
+  );
 });


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds an extra runtime check to values passed as `extra` arguments to a Logger logging method (i.e. `logger.info('message', extra);`). With the fix added to this PR we are now skipping these values when they are `null` or `undefined` rather than trying to process them, which addresses the bug described in the linked issue.

For the sake of completeness, TypeScript already forbids passing these types to the logger methods, so this case could happen only if:
- customers are using JavaScript with no type hints in their IDE
- customers are passing a value of type `any`
- customers are explicitly turning off type checking for the file / line (i.e. `// @ts-expect-error` or `// @ts-ignore`)
- customers are manually type casting the value to make TS happy

Nevertheless, given the above it's still worth adding a runtime check in this case - especially because this case was handled gracefully in previous versions of Logger.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3613

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
