### PR TITLE
feat(logger): Enable log buffering feature

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -188,7 +188,7 @@ class Logger extends Utility implements LoggerInterface {
    * Max size of the buffer. Additions to the buffer beyond this size will
    * cause older logs to be evicted from the buffer
    */
-  #maxBufferBytesSize = 1024;
+  #maxBufferBytesSize = 20480;
 
   /**
    * Contains buffered logs, grouped by _X_AMZN_TRACE_ID, each group with a max size of `maxBufferBytesSize`
@@ -1284,7 +1284,7 @@ class Logger extends Utility implements LoggerInterface {
    * Flushes all items of the respective _X_AMZN_TRACE_ID within
    * the buffer.
    */
-  flushBuffer(): void {
+  public flushBuffer(): void {
     const traceId = this.envVarsService.getXrayTraceId();
     if (traceId === undefined) {
       return;

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1245,10 +1245,11 @@ class Logger extends Utility implements LoggerInterface {
       maxBytesSize: this.#maxBufferBytesSize,
     });
 
-    if (options.enabled !== undefined) {
-      this.isBufferEnabled = options.enabled;
+    if (options.enabled === false) {
+      this.isBufferEnabled = false;
+    } else {
+      this.isBufferEnabled = true;
     }
-
     const bufferAtLogLevel = options.bufferAtVerbosity?.toUpperCase();
 
     if (this.isValidLogLevel(bufferAtLogLevel)) {

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -172,7 +172,7 @@ class Logger extends Utility implements LoggerInterface {
   /**
    * Represents whether the buffering functionality is enabled in the logger
    */
-  protected isBufferEnabled = true;
+  protected isBufferEnabled = false;
 
   /**
    * Whether the buffer should be flushed when an error is logged

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -172,25 +172,28 @@ class Logger extends Utility implements LoggerInterface {
   /**
    * Represents whether the buffering functionality is enabled in the logger
    */
-  protected isBufferEnabled = false;
+  protected isBufferEnabled = true;
 
+  /**
+   * Whether the buffer should be flushed when an error is logged
+   */
+  protected flushOnErrorLog = true;
   /**
    * Log level threshold for the buffer
    * Logs with a level lower than this threshold will be buffered
+   * Default is DEBUG
    */
-  protected bufferLogThreshold: number = LogLevelThreshold.DEBUG;
+  protected bufferAtVerbosity: number = LogLevelThreshold.DEBUG;
   /**
    * Max size of the buffer. Additions to the buffer beyond this size will
    * cause older logs to be evicted from the buffer
    */
-  readonly #maxBufferBytesSize = 1024;
+  #maxBufferBytesSize = 1024;
 
   /**
    * Contains buffered logs, grouped by _X_AMZN_TRACE_ID, each group with a max size of `maxBufferBytesSize`
    */
-  readonly #buffer: CircularMap<string> = new CircularMap({
-    maxBytesSize: this.#maxBufferBytesSize,
-  });
+  #buffer?: CircularMap<string>;
 
   /**
    * Log level used by the current instance of Logger.
@@ -330,6 +333,9 @@ class Logger extends Utility implements LoggerInterface {
    * @param extraInput - The extra input to log.
    */
   public error(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
+    if (this.isBufferEnabled && this.flushOnErrorLog) {
+      this.flushBuffer();
+    }
     this.processLogItem(LogLevelThreshold.ERROR, input, extraInput);
   }
 
@@ -1167,6 +1173,7 @@ class Logger extends Utility implements LoggerInterface {
       environment,
       jsonReplacerFn,
       logRecordOrder,
+      logBufferOptions,
     } = options;
 
     if (persistentLogAttributes && persistentKeys) {
@@ -1192,6 +1199,10 @@ class Logger extends Utility implements LoggerInterface {
     this.setConsole();
     this.setLogIndentation();
     this.#jsonReplacerFn = jsonReplacerFn;
+
+    if (logBufferOptions !== undefined) {
+      this.#setLogBuffering(logBufferOptions);
+    }
 
     return this;
   }
@@ -1223,6 +1234,30 @@ class Logger extends Utility implements LoggerInterface {
     persistentKeys && this.appendPersistentKeys(persistentKeys);
   }
 
+  #setLogBuffering(
+    options: NonNullable<ConstructorOptions['logBufferOptions']>
+  ) {
+    if (options.maxBytes !== undefined) {
+      this.#maxBufferBytesSize = options.maxBytes;
+    }
+
+    this.#buffer = new CircularMap({
+      maxBytesSize: this.#maxBufferBytesSize,
+    });
+
+    if (options.enabled !== undefined) {
+      this.isBufferEnabled = options.enabled;
+    }
+
+    const bufferAtLogLevel = options.bufferAtVerbosity?.toUpperCase();
+
+    if (this.isValidLogLevel(bufferAtLogLevel)) {
+      this.bufferAtVerbosity = LogLevelThreshold[bufferAtLogLevel];
+
+      return;
+    }
+  }
+
   /**
    * Add a log to the buffer
    * @param xrayTraceId - _X_AMZN_TRACE_ID of the request
@@ -1242,20 +1277,20 @@ class Logger extends Utility implements LoggerInterface {
       this.logIndentation
     );
 
-    this.#buffer.setItem(xrayTraceId, stringified, logLevel);
+    this.#buffer?.setItem(xrayTraceId, stringified, logLevel);
   }
 
   /**
    * Flushes all items of the respective _X_AMZN_TRACE_ID within
    * the buffer.
    */
-  protected flushBuffer(): void {
+  flushBuffer(): void {
     const traceId = this.envVarsService.getXrayTraceId();
     if (traceId === undefined) {
       return;
     }
 
-    const buffer = this.#buffer.get(traceId);
+    const buffer = this.#buffer?.get(traceId);
     if (buffer === undefined) {
       return;
     }
@@ -1280,7 +1315,7 @@ class Logger extends Utility implements LoggerInterface {
       );
     }
 
-    this.#buffer.delete(traceId);
+    this.#buffer?.delete(traceId);
   }
   /**
    * Tests if the log meets the criteria to be buffered
@@ -1294,7 +1329,7 @@ class Logger extends Utility implements LoggerInterface {
     return (
       this.isBufferEnabled &&
       traceId !== undefined &&
-      logLevel <= this.bufferLogThreshold
+      logLevel <= this.bufferAtVerbosity
     );
   }
 }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1250,6 +1250,12 @@ class Logger extends Utility implements LoggerInterface {
     } else {
       this.isBufferEnabled = true;
     }
+
+    if (options.flushOnErrorLog === false) {
+      this.flushOnErrorLog = false;
+    } else {
+      this.flushOnErrorLog = true;
+    }
     const bufferAtLogLevel = options.bufferAtVerbosity?.toUpperCase();
 
     if (this.isValidLogLevel(bufferAtLogLevel)) {

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1253,8 +1253,6 @@ class Logger extends Utility implements LoggerInterface {
 
     if (this.isValidLogLevel(bufferAtLogLevel)) {
       this.bufferAtVerbosity = LogLevelThreshold[bufferAtLogLevel];
-
-      return;
     }
   }
 

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -186,7 +186,8 @@ type LogBufferOption = {
     enabled?: boolean;
 
     /**
-     * Maximum size in bytes of each buffer.
+     * Maximum size of the buffer in bytes
+     * @default `20480`
      */
     maxBytes?: number;
     /**

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -174,11 +174,43 @@ type LogRecordOrderOption = {
 };
 
 /**
+ * Options for the `logBuffer` constructor option.
+ *
+ * Used to configure the log buffer functionality.
+ */
+type LogBufferOption = {
+  logBufferOptions?: {
+    /**
+     * Whether logs should be buffered
+     */
+    enabled?: boolean;
+
+    /**
+     * Maximum size in bytes of each buffer.
+     */
+    maxBytes?: number;
+    /**
+     * Flush the buffer when an error is logged
+     */
+    flushOnErrorLog?: boolean;
+    /**
+     * The threshold to buffer logs. Logs with a level below
+     * this threshold will be buffered
+     */
+    bufferAtVerbosity?: Omit<
+      LogLevel,
+      'ERROR' | 'error' | 'CRITICAL' | 'critical' | 'SILENT' | 'silent'
+    >;
+  };
+};
+
+/**
  * Options to configure the Logger.
  */
 type ConstructorOptions = BaseConstructorOptions &
   (PersistentKeysOption | DeprecatedPersistentKeysOption) &
-  (LogFormatterOption | LogRecordOrderOption);
+  (LogFormatterOption | LogRecordOrderOption) &
+  LogBufferOption;
 
 type LogItemMessage = string | LogAttributesWithMessage;
 type LogItemExtraInput = [Error | string] | LogAttributes[];
@@ -194,6 +226,7 @@ type LoggerInterface = {
   critical(input: LogItemMessage, ...extraInput: LogItemExtraInput): void;
   debug(input: LogItemMessage, ...extraInput: LogItemExtraInput): void;
   error(input: LogItemMessage, ...extraInput: LogItemExtraInput): void;
+  flushBuffer(): void;
   getLevelName(): Uppercase<LogLevel>;
   getLogEvent(): boolean;
   getPersistentLogAttributes(): LogAttributes;

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -184,7 +184,6 @@ type LogBufferOption = {
      * Whether logs should be buffered
      */
     enabled?: boolean;
-
     /**
      * Maximum size of the buffer in bytes
      * @default `20480`
@@ -192,11 +191,13 @@ type LogBufferOption = {
     maxBytes?: number;
     /**
      * Flush the buffer when an error is logged
+     * @default `true`
      */
     flushOnErrorLog?: boolean;
     /**
      * The threshold to buffer logs. Logs with a level below
      * this threshold will be buffered
+     * @default `'DEBUG'`
      */
     bufferAtVerbosity?: Omit<
       LogLevel,

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -36,6 +36,20 @@ describe('Log Buffer', () => {
       expect(console.debug).toBeCalledTimes(0);
     });
 
+    it('buffers logs when the config object is provided, but not specifically enabled', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logLevel: LogLevel.ERROR,
+        logBufferOptions: { maxBytes: 100 },
+      });
+
+      // Act
+      logger.debug('This is a log message');
+      logger.flushBuffer();
+      // Assess
+      expect(console.debug).toBeCalledTimes(1);
+    });
+
     it('sets a max buffer sized when specified', () => {
       // Prepare
       const logger = new TestLogger({

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -39,7 +39,11 @@ describe('Log Buffer', () => {
     it('sets a max buffer sized when specified', () => {
       // Prepare
       const logger = new TestLogger({
-        logBufferOptions: { maxBytes: 250, bufferAtVerbosity: LogLevel.DEBUG },
+        logBufferOptions: {
+          maxBytes: 250,
+          bufferAtVerbosity: LogLevel.DEBUG,
+          enabled: true,
+        },
       });
 
       // Act
@@ -73,7 +77,7 @@ describe('Log Buffer', () => {
     it('outputs a warning when there is an error buffering the log', () => {
       // Prepare
       process.env.POWERTOOLS_DEV = 'true';
-      const logger = new TestLogger();
+      const logger = new TestLogger({ logBufferOptions: { enabled: true } });
       logger.overrideBufferLogItem();
 
       // Act
@@ -88,7 +92,10 @@ describe('Log Buffer', () => {
       // Prepare
       const logger = new TestLogger({
         logLevel: 'SILENT',
-        logBufferOptions: { bufferAtVerbosity: LogLevel.CRITICAL },
+        logBufferOptions: {
+          enabled: true,
+          bufferAtVerbosity: LogLevel.CRITICAL,
+        },
       });
 
       // Act
@@ -110,7 +117,7 @@ describe('Log Buffer', () => {
 
     it('handles an empty buffer', () => {
       // Prepare
-      const logger = new TestLogger();
+      const logger = new TestLogger({ logBufferOptions: { enabled: true } });
 
       // Act
       logger.flushBuffer();
@@ -119,7 +126,7 @@ describe('Log Buffer', () => {
     it('does not output buffered logs when trace id is not set', () => {
       // Prepare
       process.env._X_AMZN_TRACE_ID = undefined;
-      const logger = new TestLogger({});
+      const logger = new TestLogger({ logBufferOptions: { enabled: true } });
 
       // Act
       logger.debug('This is a debug');
@@ -141,7 +148,11 @@ describe('Log Buffer', () => {
       // Prepare
       const logger = new TestLogger({
         logLevel: LogLevel.ERROR,
-        logBufferOptions: { bufferAtVerbosity: LogLevel.INFO },
+        logBufferOptions: {
+          enabled: true,
+          bufferAtVerbosity: LogLevel.INFO,
+          maxBytes: 1024,
+        },
       });
 
       // Act
@@ -172,7 +183,7 @@ describe('Log Buffer', () => {
       // Prepare
       const logger = new TestLogger({
         logLevel: LogLevel.ERROR,
-        logBufferOptions: { bufferAtVerbosity: LogLevel.DEBUG },
+        logBufferOptions: { enabled: true, bufferAtVerbosity: LogLevel.DEBUG },
       });
 
       const spy = vi.spyOn(logger, 'flushBuffer');

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -36,6 +36,21 @@ describe('Log Buffer', () => {
       expect(console.debug).toBeCalledTimes(0);
     });
 
+    it('does not flush on error logs when flushOnErrorLog is disabled ', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logLevel: LogLevel.ERROR,
+        logBufferOptions: { enabled: true, flushOnErrorLog: false },
+      });
+
+      // Act
+      logger.debug('This is a log message');
+      logger.error('This is an error message');
+      // Assess
+      expect(console.debug).toBeCalledTimes(0);
+      expect(console.error).toBeCalledTimes(1);
+    });
+
     it('buffers logs when the config object is provided, but not specifically enabled', () => {
       // Prepare
       const logger = new TestLogger({

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -1,140 +1,191 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Logger } from '../../src/Logger.js';
-import { LogLevelThreshold } from '../../src/constants.js';
+import { LogLevel } from '../../src/constants.js';
 
 class TestLogger extends Logger {
-  public enableBuffering() {
-    this.isBufferEnabled = true;
-  }
-  public disableBuffering() {
-    this.isBufferEnabled = false;
-  }
-
-  public flushBufferWrapper(): void {
-    this.flushBuffer();
-  }
-
   public overrideBufferLogItem(): void {
     this.bufferLogItem = vi.fn().mockImplementation(() => {
       throw new Error('bufferLogItem error');
     });
   }
-
-  public setbufferLevelThreshold(level: number): void {
-    this.bufferLogThreshold = level;
-  }
 }
+describe('Log Buffer', () => {
+  describe('Configuration', () => {
+    const ENVIRONMENT_VARIABLES = process.env;
 
-describe('bufferLog', () => {
-  it('outputs a warning when there is an error buffering the log', () => {
-    // Prepare
-    process.env.POWERTOOLS_DEV = 'true';
-    const logger = new TestLogger();
-    logger.enableBuffering();
-    logger.overrideBufferLogItem();
+    beforeEach(() => {
+      process.env = {
+        ...ENVIRONMENT_VARIABLES,
+        POWERTOOLS_LOGGER_LOG_EVENT: 'true',
+        POWERTOOLS_DEV: 'true',
+      };
+      vi.clearAllMocks();
+    });
 
-    // Act
-    logger.debug('This is a debug');
+    it('does not buffer logs when disabled', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logLevel: LogLevel.ERROR,
+        logBufferOptions: { enabled: false },
+      });
 
-    // Assess
-    expect(console.debug).toBeCalledTimes(1);
-    expect(console.warn).toBeCalledTimes(1);
-  });
-});
+      // Act
+      logger.debug('This is a log message');
+      logger.flushBuffer();
+      // Assess
+      expect(console.debug).toBeCalledTimes(0);
+    });
 
-describe('flushBuffer', () => {
-  const ENVIRONMENT_VARIABLES = process.env;
+    it('sets a max buffer sized when specified', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logBufferOptions: { maxBytes: 250, bufferAtVerbosity: LogLevel.DEBUG },
+      });
 
-  beforeEach(() => {
-    process.env = {
-      ...ENVIRONMENT_VARIABLES,
-      POWERTOOLS_LOGGER_LOG_EVENT: 'true',
-      POWERTOOLS_DEV: 'true',
-    };
-    vi.clearAllMocks();
-  });
+      // Act
+      logger.debug('this is a debug');
+      logger.debug('this is a debug');
+      logger.flushBuffer();
 
-  it('outputs buffered logs', () => {
-    // Prepare
-    const logger = new TestLogger({ logLevel: 'SILENT' });
-    logger.enableBuffering();
-    logger.setbufferLevelThreshold(LogLevelThreshold.CRITICAL);
-
-    // Act
-    logger.debug('This is a debug');
-    logger.warn('This is a warning');
-    logger.critical('this is a critical');
-
-    // Assess
-    expect(console.warn).toHaveBeenCalledTimes(0);
-    expect(console.error).toHaveBeenCalledTimes(0);
-
-    // Act
-    logger.flushBufferWrapper();
-
-    // Assess
-    expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles an empty buffer', () => {
-    // Prepare
-    const logger = new TestLogger();
-    logger.enableBuffering();
-
-    // Act
-    logger.flushBufferWrapper();
-  });
-
-  it('does not output buffered logs when trace id is not set', () => {
-    // Prepare
-    process.env._X_AMZN_TRACE_ID = undefined;
-    const logger = new TestLogger({});
-    logger.enableBuffering();
-
-    // Act
-    logger.debug('This is a debug');
-    logger.warn('this is a warning');
-
-    // Assess
-    expect(console.debug).toHaveBeenCalledTimes(0);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-
-    // Act
-    logger.flushBufferWrapper();
-
-    // Assess
-    expect(console.debug).toHaveBeenCalledTimes(0);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-  });
-
-  it('outputs a warning when buffered logs have been evicted', () => {
-    // Prepare
-    const logger = new TestLogger({ logLevel: 'ERROR' });
-    logger.enableBuffering();
-    logger.setbufferLevelThreshold(LogLevelThreshold.INFO);
-
-    // Act
-    const longMessage = 'blah'.repeat(10);
-
-    let i = 0;
-    while (i < 4) {
-      logger.info(
-        `${i} This is a really long log message intended to exceed the buffer ${longMessage}`
+      // Assess
+      expect(console.debug).toBeCalledTimes(1);
+      expect(console.warn).toHaveLogged(
+        expect.objectContaining({
+          level: 'WARN',
+          message:
+            'Some logs are not displayed because they were evicted from the buffer. Increase buffer size to store more logs in the buffer',
+        })
       );
-      i++;
-    }
+    });
+  });
 
-    // Act
-    logger.flushBufferWrapper();
+  describe('Functionality', () => {
+    const ENVIRONMENT_VARIABLES = process.env;
 
-    // Assess
-    expect(console.warn).toHaveLogged(
-      expect.objectContaining({
-        level: 'WARN',
-        message:
-          'Some logs are not displayed because they were evicted from the buffer. Increase buffer size to store more logs in the buffer',
-      })
-    );
+    beforeEach(() => {
+      process.env = {
+        ...ENVIRONMENT_VARIABLES,
+        POWERTOOLS_LOGGER_LOG_EVENT: 'true',
+        POWERTOOLS_DEV: 'true',
+      };
+      vi.clearAllMocks();
+    });
+    it('outputs a warning when there is an error buffering the log', () => {
+      // Prepare
+      process.env.POWERTOOLS_DEV = 'true';
+      const logger = new TestLogger();
+      logger.overrideBufferLogItem();
+
+      // Act
+      logger.debug('This is a debug');
+
+      // Assess
+      expect(console.debug).toBeCalledTimes(1);
+      expect(console.warn).toBeCalledTimes(1);
+    });
+
+    it('outputs buffered logs', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logLevel: 'SILENT',
+        logBufferOptions: { bufferAtVerbosity: LogLevel.CRITICAL },
+      });
+
+      // Act
+      logger.debug('This is a debug');
+      logger.warn('This is a warning');
+      logger.critical('this is a critical');
+
+      // Assess
+      expect(console.warn).toHaveBeenCalledTimes(0);
+      expect(console.error).toHaveBeenCalledTimes(0);
+
+      // Act
+      logger.flushBuffer();
+
+      // Assess
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles an empty buffer', () => {
+      // Prepare
+      const logger = new TestLogger();
+
+      // Act
+      logger.flushBuffer();
+    });
+
+    it('does not output buffered logs when trace id is not set', () => {
+      // Prepare
+      process.env._X_AMZN_TRACE_ID = undefined;
+      const logger = new TestLogger({});
+
+      // Act
+      logger.debug('This is a debug');
+      logger.warn('this is a warning');
+
+      // Assess
+      expect(console.debug).toHaveBeenCalledTimes(0);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+
+      // Act
+      logger.flushBuffer();
+
+      // Assess
+      expect(console.debug).toHaveBeenCalledTimes(0);
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('outputs a warning when buffered logs have been evicted', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logLevel: LogLevel.ERROR,
+        logBufferOptions: { bufferAtVerbosity: LogLevel.INFO },
+      });
+
+      // Act
+      const longMessage = 'blah'.repeat(10);
+
+      let i = 0;
+      while (i < 4) {
+        logger.info(
+          `${i} This is a really long log message intended to exceed the buffer ${longMessage}`
+        );
+        i++;
+      }
+
+      // Act
+      logger.flushBuffer();
+
+      // Assess
+      expect(console.warn).toHaveLogged(
+        expect.objectContaining({
+          level: LogLevel.WARN,
+          message:
+            'Some logs are not displayed because they were evicted from the buffer. Increase buffer size to store more logs in the buffer',
+        })
+      );
+    });
+
+    it('it flushes the buffer when an error in logged', () => {
+      // Prepare
+      const logger = new TestLogger({
+        logLevel: LogLevel.ERROR,
+        logBufferOptions: { bufferAtVerbosity: LogLevel.DEBUG },
+      });
+
+      const spy = vi.spyOn(logger, 'flushBuffer');
+
+      // Act
+      logger.debug('This is a log message');
+
+      logger.error('This is an error message');
+
+      // Assess
+      expect(spy).toBeCalledTimes(1);
+      expect(console.debug).toBeCalledTimes(1);
+      expect(console.error).toBeCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary
This PR enables the buffering feature for the logger utility.
It allows the user to configure the buffering functionality in the logger constructor.

The core of this PR is adding allow the behaviour of log buffering to be configured.


### Changes

1. Add  `logBufferOptions` object to the Logger config
2. Enable log buffering by default
3. Make `flushBuffer` method public

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3634 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
