### PR TITLE
feat(logger): refresh sample rate calculation per invocation

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -634,7 +634,7 @@ Once a child logger is created, the logger and its parent will act as separate i
 
 ### Sampling debug logs
 
-Use sampling when you want to dynamically change your log level to **DEBUG** based on a **percentage of your concurrent/cold start invocations**.
+Use sampling when you want to dynamically change your log level to **DEBUG** based on a **percentage of your concurrent invocations**.
 
 You can use values ranging from `0` to `1` (100%) when setting the `sampleRateValue` constructor option or `POWERTOOLS_LOGGER_SAMPLE_RATE` env var.
 
@@ -643,10 +643,9 @@ You can use values ranging from `0` to `1` (100%) when setting the `sampleRateVa
 
     This feature takes into account transient issues where additional debugging information can be useful.
 
-Sampling decision happens at the Logger initialization. This means sampling may happen significantly more or less than depending on your traffic patterns, for example a steady low number of invocations and thus few cold starts.
+Sampling decision happens at the Logger initialization. When using the `injectLambdaContext` method either as a decorator or middleware, the sampling decision is refreshed at the beginning of each Lambda invocation for you.
 
-!!! note
-    Open a [feature request](https://github.com/aws-powertools/powertools-lambda-typescript/issues/new?assignees=&labels=type%2Ffeature-request%2Ctriage&projects=aws-powertools%2F7&template=feature_request.yml&title=Feature+request%3A+TITLE) if you want Logger to calculate sampling for every invocation
+If you're not using either of these, you'll need to manually call the `refreshSamplingRate()` function at the start of your handler to refresh the sampling decision for each invocation.
 
 === "handler.ts"
 

--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -634,7 +634,7 @@ Once a child logger is created, the logger and its parent will act as separate i
 
 ### Sampling debug logs
 
-Use sampling when you want to dynamically change your log level to **DEBUG** based on a **percentage of your concurrent invocations**.
+Use sampling when you want to dynamically change your log level to **DEBUG** based on a **percentage of your invocations**.
 
 You can use values ranging from `0` to `1` (100%) when setting the `sampleRateValue` constructor option or `POWERTOOLS_LOGGER_SAMPLE_RATE` env var.
 

--- a/examples/snippets/logger/logSampling.ts
+++ b/examples/snippets/logger/logSampling.ts
@@ -10,6 +10,8 @@ export const handler = async (
   _event: unknown,
   _context: unknown
 ): Promise<void> => {
+  // Refresh sample rate calculation on runtime, only when not using injectLambdaContext
+  logger.refreshSampleRateCalculation();
   // This log item (equal to log level 'ERROR') will be printed to standard output
   // in all Lambda invocations
   logger.error('This is an ERROR log');

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -413,6 +413,7 @@ class Logger extends Utility implements LoggerInterface {
         context,
         callback
       ) {
+        loggerRef.refreshSampleRateCalculation();
         Logger.injectLambdaContextBefore(loggerRef, event, context, options);
 
         let result: unknown;

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -87,6 +87,9 @@ const injectLambdaContext = (
       if (isResetStateEnabled) {
         setCleanupFunction(request);
       }
+
+      logger.refreshSampleRateCalculation();
+
       Logger.injectLambdaContextBefore(
         logger,
         request.event,


### PR DESCRIPTION
…in logger context## Summary

### Changes

> Please provide a summary of what's being changed

This PR modifies the `sampleRate` behaviour for the logger and will now sample per invocation, instead of execution environment. When using `injectLambdaContext` either as decorator or as middleware, we now automatically refresh sample rate.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3278 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
