### PR TITLE
chore(maintenance): set app sdk ua env variable when none is set

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,5 +1,7 @@
 import { PT_VERSION } from './version.js';
-process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}`;
+if (!process.env.AWS_SDK_UA_APP_ID) {
+  process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}`;
+}
 export { PT_VERSION } from './version.js';
 export {
   isRecord,

--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,3 +1,6 @@
+import { PT_VERSION } from './version.js';
+process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}`;
+export { PT_VERSION } from './version.js';
 export {
   isRecord,
   isString,
@@ -19,4 +22,3 @@ export {
   METRICS_KEY,
   IDEMPOTENCY_KEY,
 } from './middleware/constants.js';
-export { PT_VERSION } from './version.js';

--- a/packages/commons/tests/unit/awsSdkUtils.test.ts
+++ b/packages/commons/tests/unit/awsSdkUtils.test.ts
@@ -96,11 +96,11 @@ describe('Helpers: awsSdk', () => {
       expect(middleware).toBeInstanceOf(Function);
     });
 
+    const feature = 'my-feature';
+    const middleware = customUserAgentMiddleware(feature);
+
     it('adds the Powertools UA to the request headers when no user agent is present', async () => {
       // Prepare
-      const feature = 'my-feature';
-      const middleware = customUserAgentMiddleware(feature);
-      const next = vi.fn();
       const args = {
         request: {
           headers: {},
@@ -112,7 +112,7 @@ describe('Helpers: awsSdk', () => {
       };
 
       // Act
-      await middleware(next)(args);
+      await middleware(vi.fn())(args);
 
       // Assess
       expect(args.request.headers['user-agent']).toEqual(
@@ -122,9 +122,6 @@ describe('Helpers: awsSdk', () => {
 
     it('adds the Powertools UA to the request headers when no Powertools UA is present', async () => {
       // Prepare
-      const feature = 'my-feature';
-      const middleware = customUserAgentMiddleware(feature);
-      const next = vi.fn();
       const args = {
         request: {
           headers: {
@@ -134,7 +131,7 @@ describe('Helpers: awsSdk', () => {
       };
 
       // Act
-      await middleware(next)(args);
+      await middleware(vi.fn())(args);
 
       // Assess
       expect(args.request.headers['user-agent']).toEqual(
@@ -144,9 +141,6 @@ describe('Helpers: awsSdk', () => {
 
     it('replaces the no-op Powertools UA with the the feature-specific one', async () => {
       // Prepare
-      const feature = 'my-feature';
-      const middleware = customUserAgentMiddleware(feature);
-      const next = vi.fn();
       const args = {
         request: {
           headers: {
@@ -156,7 +150,7 @@ describe('Helpers: awsSdk', () => {
       };
 
       // Act
-      await middleware(next)(args);
+      await middleware(vi.fn())(args);
 
       // Assess
       expect(args.request.headers['user-agent']).toEqual(
@@ -166,9 +160,6 @@ describe('Helpers: awsSdk', () => {
 
     it('does not add the Powertools feature-specific UA if it is already present', async () => {
       // Prepare
-      const feature = 'my-feature';
-      const middleware = customUserAgentMiddleware(feature);
-      const next = vi.fn();
       const args = {
         request: {
           headers: {
@@ -178,7 +169,7 @@ describe('Helpers: awsSdk', () => {
       };
 
       // Act
-      await middleware(next)(args);
+      await middleware(vi.fn())(args);
 
       // Assess
       expect(args.request.headers['user-agent']).toEqual(

--- a/packages/commons/tests/unit/awsSdkUtils.test.ts
+++ b/packages/commons/tests/unit/awsSdkUtils.test.ts
@@ -100,7 +100,7 @@ describe('Helpers: awsSdk', () => {
       // Prepare
       const feature = 'my-feature';
       const middleware = customUserAgentMiddleware(feature);
-      const next = jest.fn();
+      const next = vi.fn();
       const args = {
         request: {
           headers: {},
@@ -146,7 +146,7 @@ describe('Helpers: awsSdk', () => {
       // Prepare
       const feature = 'my-feature';
       const middleware = customUserAgentMiddleware(feature);
-      const next = jest.fn();
+      const next = vi.fn();
       const args = {
         request: {
           headers: {
@@ -168,7 +168,7 @@ describe('Helpers: awsSdk', () => {
       // Prepare
       const feature = 'my-feature';
       const middleware = customUserAgentMiddleware(feature);
-      const next = jest.fn();
+      const next = vi.fn();
       const args = {
         request: {
           headers: {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds a mechanism to set the `AWS_SDK_UA_APP_ID` env variable when one is set so that AWS SDK clients include the value when making requests. The env variable is set when importing Powertools and allows us to send our user agent along with requests. 

This new mechanism appends a `NO-OP` user agent, and the PR also implements new logic to add feature-specific user agents only when the `NO-OP` is not present. The UA attached to requests looks like this `app/PT/NO-OP/2.14.0`.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3650

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
