### PR TITLE
fix(parser): envelope sub-path exports regression

### DIFF
--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -124,7 +124,11 @@
       "require": "./lib/cjs/schemas/vpc-latticev2.js",
       "import": "./lib/esm/schemas/vpc-latticev2.js"
     },
-    "./envelopes/*.ts": {
+    "./envelopes": {
+      "require": "./lib/cjs/envelopes/index.js",
+      "import": "./lib/esm/envelopes/index.js"
+    },
+    "./envelopes/*": {
       "require": "./lib/cjs/envelopes/*.js",
       "import": "./lib/esm/envelopes/*.js"
     },
@@ -227,7 +231,11 @@
         "./lib/cjs/schemas/vpc-latticev2.d.ts",
         "./lib/esm/schemas/vpc-latticev2.d.ts"
       ],
-      "envelopes/*.ts": [
+      "envelopes": [
+        "./lib/cjs/envelopes/index.d.ts",
+        "./lib/esm/envelopes/index.d.ts"
+      ],
+      "envelopes/*": [
         "./lib/cjs/envelopes/*.d.ts",
         "./lib/esm/envelopes/*.d.ts"
       ],


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR fixes the regression introduced in the last release that causes subpath exports for the envelopes in Parser to not work.

The fix restores the barrel export and provides scoped exports for each envelope category.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3666

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
