### PR TITLE
fix(parser): Update S3 Event Schema

### DIFF
--- a/packages/parser/src/schemas/s3.ts
+++ b/packages/parser/src/schemas/s3.ts
@@ -8,7 +8,7 @@ const S3Identity = z.object({
 });
 
 const S3RequestParameters = z.object({
-  sourceIPAddress: z.string().ip(),
+  sourceIPAddress: z.union([z.string().ip(), z.literal('s3.amazonaws.com')]),
 });
 
 const S3ResponseElements = z.object({

--- a/packages/parser/src/schemas/s3.ts
+++ b/packages/parser/src/schemas/s3.ts
@@ -24,7 +24,7 @@ const S3Message = z.object({
     size: z.number().optional(),
     urlDecodedKey: z.string().optional(),
     eTag: z.string().optional(),
-    sequencer: z.string(),
+    sequencer: z.string().optional(), // Only present in PUT and DELETE events
     versionId: z.optional(z.string()),
   }),
   bucket: z.object({

--- a/packages/parser/tests/events/s3/s3-lifecycle-event.json
+++ b/packages/parser/tests/events/s3/s3-lifecycle-event.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "eventVersion": "2.3",
+      "eventSource": "aws:s3",
+      "awsRegion": "us-west-2",
+      "eventTime": "1970-01-01T00:00:00.000Z",
+      "eventName": "LifecycleExpiration:Delete",
+      "userIdentity": {
+        "principalId": "s3.amazonaws.com"
+      },
+      "requestParameters": {
+        "sourceIPAddress": "s3.amazonaws.com"
+      },
+      "responseElements": {
+        "x-amz-request-id": "C3D13FE58DE4C810",
+        "x-amz-id-2": "FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD"
+      },
+      "s3": {
+        "s3SchemaVersion": "1.0",
+        "configurationId": "testConfigRule",
+        "bucket": {
+          "name": "amzn-s3-demo-bucket",
+          "ownerIdentity": {
+            "principalId": "A3NL1KOZZKExample"
+          },
+          "arn": "arn:aws:s3:::amzn-s3-demo-bucket"
+        },
+        "object": {
+          "key": "expiration/delete",
+          "sequencer": "0055AED6DCD90281E5"
+        }
+      }
+    }
+  ]
+}

--- a/packages/parser/tests/unit/schema/s3.test.ts
+++ b/packages/parser/tests/unit/schema/s3.test.ts
@@ -97,6 +97,20 @@ describe('Schema: S3', () => {
     expect(result).toStrictEqual(event);
   });
 
+  it('parses an S3 LifeCycle event with a deleted object', () => {
+    // Prepare
+    const event = getTestEvent<S3Event>({
+      eventsPath,
+      filename: 's3-lifecycle-event',
+    });
+
+    // Act
+    const result = S3Schema.parse(event);
+
+    // Assess
+    expect(result).toStrictEqual(event);
+  });
+
   it('parses an S3 Object Lambda with an IAM user', () => {
     // Prepare
     const event = structuredClone(baseLambdaEvent);


### PR DESCRIPTION
## Summary
Update S3 Event Schema

### Changes

* Allow literal `s3.amazonaws.com` in `sourceIPAddress` field
* Make `sequencer` field optional.

**Issue number:**  closes #3643 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
