### PR TITLE
fix(batch): clear message group references after request

### DIFF
--- a/packages/batch/src/SqsFifoPartialProcessor.ts
+++ b/packages/batch/src/SqsFifoPartialProcessor.ts
@@ -92,6 +92,7 @@ class SqsFifoPartialProcessor extends BatchProcessorSync {
    */
   public processSync(): (SuccessResponse | FailureResponse)[] {
     this.prepare();
+    this.#processor.prepare();
 
     const processedRecords: (SuccessResponse | FailureResponse)[] = [];
     let currentIndex = 0;

--- a/packages/batch/src/SqsFifoPartialProcessorAsync.ts
+++ b/packages/batch/src/SqsFifoPartialProcessorAsync.ts
@@ -91,6 +91,7 @@ class SqsFifoPartialProcessorAsync extends BatchProcessor {
    */
   public async process(): Promise<(SuccessResponse | FailureResponse)[]> {
     this.prepare();
+    this.#processor.prepare();
 
     const processedRecords: (SuccessResponse | FailureResponse)[] = [];
     let currentIndex = 0;

--- a/packages/batch/src/SqsFifoProcessor.ts
+++ b/packages/batch/src/SqsFifoProcessor.ts
@@ -33,6 +33,14 @@ class SqsFifoProcessor {
   }
 
   /**
+   * Prepares the processor for a new batch of messages.
+   */
+  public prepare(): void {
+    this.#currentGroupId = undefined;
+    this.#failedGroupIds.clear();
+  }
+
+  /**
    * Sets the current group ID for the message being processed.
    *
    * @param group - The group ID of the current message being processed.


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR fixes a bug in Batch Processing where the internal state of the processor would not get reset after each invocation, causing messages from group ids that had previously failed to get skipped.

The PR updates the processor by clearing the state before processing the next batch.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3673

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
