### PR TITLE
feat(validation): Add @validator decorator for JSON Schema validation

### DIFF
--- a/packages/validation/src/decorator.ts
+++ b/packages/validation/src/decorator.ts
@@ -1,0 +1,79 @@
+import type { Ajv } from 'ajv';
+import { SchemaValidationError } from './errors.js';
+import { validate } from './validate.js';
+export interface ValidatorOptions {
+  inboundSchema?: object;
+  outboundSchema?: object;
+  envelope?: string;
+  formats?: Record<
+    string,
+    | string
+    | RegExp
+    | {
+        type?: 'string' | 'number';
+        validate: (data: string) => boolean;
+        async?: boolean;
+      }
+  >;
+  externalRefs?: object[];
+  ajv?: Ajv;
+}
+
+type AsyncMethod = (...args: unknown[]) => Promise<unknown>;
+
+export function validator(options: ValidatorOptions): MethodDecorator {
+  return (
+    _target,
+    _propertyKey,
+    descriptor: TypedPropertyDescriptor<AsyncMethod>
+  ) => {
+    if (!descriptor.value) {
+      return descriptor;
+    }
+
+    if (!options.inboundSchema && !options.outboundSchema) {
+      return descriptor;
+    }
+
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (...args: unknown[]): Promise<unknown> {
+      let validatedInput = args[0];
+
+      if (options.inboundSchema) {
+        try {
+          validatedInput = validate({
+            payload: args[0],
+            schema: options.inboundSchema,
+            envelope: options.envelope,
+            formats: options.formats,
+            externalRefs: options.externalRefs,
+            ajv: options.ajv,
+          });
+        } catch (error) {
+          throw new SchemaValidationError('Inbound validation failed', error);
+        }
+      }
+
+      const result = await originalMethod.apply(this, [
+        validatedInput,
+        ...args.slice(1),
+      ]);
+      if (options.outboundSchema) {
+        try {
+          return validate({
+            payload: result,
+            schema: options.outboundSchema,
+            formats: options.formats,
+            externalRefs: options.externalRefs,
+            ajv: options.ajv,
+          });
+        } catch (error) {
+          throw new SchemaValidationError('Outbound Validation failed', error);
+        }
+      }
+      return result;
+    };
+    return descriptor;
+  };
+}

--- a/packages/validation/tests/unit/decorator.test.ts
+++ b/packages/validation/tests/unit/decorator.test.ts
@@ -99,4 +99,36 @@ describe('validator decorator', () => {
     // Assess
     expect(result).toEqual(descriptor);
   });
+
+  it('should validate inbound only', async () => {
+    // Prepare
+    class TestClassInbound {
+      @validator({ inboundSchema })
+      async process(input: { value: number }): Promise<{ data: string }> {
+        return { data: JSON.stringify(input) };
+      }
+    }
+    const instance = new TestClassInbound();
+    const input = { value: 10 };
+    // Act
+    const output = await instance.process(input);
+    // Assess
+    expect(output).toEqual({ data: JSON.stringify(input) });
+  });
+
+  it('should validate outbound only', async () => {
+    // Prepare
+    class TestClassOutbound {
+      @validator({ outboundSchema })
+      async process(input: { text: string }): Promise<{ result: number }> {
+        return { result: 42 };
+      }
+    }
+    const instance = new TestClassOutbound();
+    const input = { text: 'hello' };
+    // Act
+    const output = await instance.process(input);
+    // Assess
+    expect(output).toEqual({ result: 42 });
+  });
 });

--- a/packages/validation/tests/unit/decorator.test.ts
+++ b/packages/validation/tests/unit/decorator.test.ts
@@ -20,33 +20,35 @@ const outboundSchema = {
   additionalProperties: false,
 };
 
-class TestClass {
-  @validator({ inboundSchema, outboundSchema })
-  async multiply(input: { value: number }): Promise<{ result: number }> {
-    return { result: input.value * 2 };
-  }
-}
-
 describe('validator decorator', () => {
   it('should validate inbound and outbound successfully', async () => {
     // Prepare
+    class TestClass {
+      @validator({ inboundSchema, outboundSchema })
+      async multiply(input: { value: number }): Promise<{ result: number }> {
+        return { result: input.value * 2 };
+      }
+    }
     const instance = new TestClass();
     const input = { value: 5 };
-
     // Act
     const output = await instance.multiply(input);
-
     // Assess
     expect(output).toEqual({ result: 10 });
   });
 
   it('should throw error on inbound validation failure', async () => {
     // Prepare
+    class TestClass {
+      @validator({ inboundSchema, outboundSchema })
+      async multiply(input: { value: number }): Promise<{ result: number }> {
+        return { result: input.value * 2 };
+      }
+    }
     const instance = new TestClass();
     const invalidInput = { value: 'not a number' } as unknown as {
       value: number;
     };
-
     // Act & Assess
     await expect(instance.multiply(invalidInput)).rejects.toThrow(
       SchemaValidationError
@@ -63,7 +65,6 @@ describe('validator decorator', () => {
     }
     const instance = new TestClassInvalid();
     const input = { value: 5 };
-
     // Act & Assess
     await expect(instance.multiply(input)).rejects.toThrow(
       SchemaValidationError
@@ -80,11 +81,22 @@ describe('validator decorator', () => {
     }
     const instance = new TestClassNoOp();
     const data = { foo: 'bar' };
-
     // Act
     const result = await instance.echo(data);
-
     // Assess
     expect(result).toEqual(data);
+  });
+
+  it('should return descriptor unmodified if descriptor.value is undefined', () => {
+    // Prepare
+    const descriptor: PropertyDescriptor = {};
+    // Act
+    const result = validator({ inboundSchema })(
+      null as unknown,
+      'testMethod',
+      descriptor
+    );
+    // Assess
+    expect(result).toEqual(descriptor);
   });
 });

--- a/packages/validation/tests/unit/decorator.test.ts
+++ b/packages/validation/tests/unit/decorator.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { validator } from '../../src/decorator.js';
+import { SchemaValidationError } from '../../src/errors.js';
+
+const inboundSchema = {
+  type: 'object',
+  properties: {
+    value: { type: 'number' },
+  },
+  required: ['value'],
+  additionalProperties: false,
+};
+
+const outboundSchema = {
+  type: 'object',
+  properties: {
+    result: { type: 'number' },
+  },
+  required: ['result'],
+  additionalProperties: false,
+};
+
+class TestClass {
+  @validator({ inboundSchema, outboundSchema })
+  async multiply(input: { value: number }): Promise<{ result: number }> {
+    return { result: input.value * 2 };
+  }
+}
+
+describe('validator decorator', () => {
+  it('should validate inbound and outbound successfully', async () => {
+    // Prepare
+    const instance = new TestClass();
+    const input = { value: 5 };
+
+    // Act
+    const output = await instance.multiply(input);
+
+    // Assess
+    expect(output).toEqual({ result: 10 });
+  });
+
+  it('should throw error on inbound validation failure', async () => {
+    // Prepare
+    const instance = new TestClass();
+    const invalidInput = { value: 'not a number' } as unknown as {
+      value: number;
+    };
+
+    // Act & Assess
+    await expect(instance.multiply(invalidInput)).rejects.toThrow(
+      SchemaValidationError
+    );
+  });
+
+  it('should throw error on outbound validation failure', async () => {
+    // Prepare
+    class TestClassInvalid {
+      @validator({ inboundSchema, outboundSchema })
+      async multiply(input: { value: number }): Promise<{ result: number }> {
+        return { result: 'invalid' } as unknown as { result: number };
+      }
+    }
+    const instance = new TestClassInvalid();
+    const input = { value: 5 };
+
+    // Act & Assess
+    await expect(instance.multiply(input)).rejects.toThrow(
+      SchemaValidationError
+    );
+  });
+
+  it('should no-op when no schemas are provided', async () => {
+    // Prepare
+    class TestClassNoOp {
+      @validator({})
+      async echo(input: unknown): Promise<unknown> {
+        return input;
+      }
+    }
+    const instance = new TestClassNoOp();
+    const data = { foo: 'bar' };
+
+    // Act
+    const result = await instance.echo(data);
+
+    // Assess
+    expect(result).toEqual(data);
+  });
+});


### PR DESCRIPTION
Changes

This PR introduces a @validator method decorator that enables JSON Schema validation for both input (inbound) and output (outbound) parameters of class methods. It is built using the existing validate function and follows the Powertools for AWS Lambda (TypeScript) validation utility standards.

Key Features
✅ Validates method arguments using inbound schemas
✅ Validates method returns values using outbound schemas
✅ Supports optional parameters like envelope, formats, and external references
✅ Allows custom AJV instances for extended schema validation
✅ Includes unit tests with 100% coverage

Implementation
Created validator.ts, a TypeScript decorator that validates the input and output of methods based on JSON Schema definitions.
Integrated the decorator with the existing validate function to ensure consistency.
Added unit tests to verify:
Successful validation for both inbound and outbound payloads.
Errors for invalid inbound and outbound payloads.
Proper handling when no schema is provided (no-op behavior).
Coverage for edge cases such as undefined method descriptors.

Issue Number
Closes #3608 (Feature request: Validator class method decorator for JSON Schema validation)

By submitting this pull request, I confirm that I have read and followed the Powertools for AWS Lambda (TypeScript) contributing guidelines. I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.