### PR TITLE
feat(logger): Flush buffer on uncaught error in Middy middleware

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -449,13 +449,12 @@ class Logger extends Utility implements LoggerInterface {
               message: UncaughtErrorLogMessage,
               error,
             });
-          } else {
-            loggerRef.clearBuffer();
           }
           throw error;
           /* v8 ignore next */
         } finally {
           if (options?.clearState || options?.resetKeys) loggerRef.resetKeys();
+          loggerRef.clearBuffer();
         }
       };
     };

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -449,6 +449,8 @@ class Logger extends Utility implements LoggerInterface {
               message: UncaughtErrorLogMessage,
               error,
             });
+          } else {
+            loggerRef.clearBuffer();
           }
           throw error;
           /* v8 ignore next */

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1361,6 +1361,21 @@ class Logger extends Utility implements LoggerInterface {
 
     this.#buffer?.delete(traceId);
   }
+
+  /**
+   * Empties the buffer for the current request
+   *
+   */
+  public clearBuffer(): void {
+    const traceId = this.envVarsService.getXrayTraceId();
+
+    if (traceId === undefined) {
+      return;
+    }
+
+    this.#buffer?.delete(traceId);
+  }
+
   /**
    * Test if the log meets the criteria to be buffered.
    *

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -77,11 +77,11 @@ const injectLambdaContext = (
   const setCleanupFunction = (request: MiddyLikeRequest): void => {
     request.internal = {
       ...request.internal,
-      [LOGGER_KEY]: onAfter,
+      [LOGGER_KEY]: after,
     };
   };
 
-  const onBefore = async (request: MiddyLikeRequest): Promise<void> => {
+  const before = async (request: MiddyLikeRequest): Promise<void> => {
     for (const logger of loggers) {
       if (isResetStateEnabled) {
         setCleanupFunction(request);
@@ -98,18 +98,17 @@ const injectLambdaContext = (
     }
   };
 
-  const onAfter = async (): Promise<void> => {
-    if (isResetStateEnabled) {
-      for (const logger of loggers) {
+  const after = async (): Promise<void> => {
+    for (const logger of loggers) {
+      logger.clearBuffer();
+
+      if (isResetStateEnabled) {
         logger.resetKeys();
       }
     }
-
-    for (const logger of loggers) {
-      logger.clearBuffer();
-    }
   };
-  const onError = async ({ error }): Promise<void> => {
+
+  const onError = async ({ error }: { error: unknown }): Promise<void> => {
     if (options?.flushBufferOnUncaughtError) {
       for (const logger of loggers) {
         logger.flushBuffer();
@@ -122,8 +121,8 @@ const injectLambdaContext = (
   };
 
   return {
-    before: onBefore,
-    after: onAfter,
+    before,
+    after,
     onError,
   };
 };

--- a/packages/logger/src/middleware/middy.ts
+++ b/packages/logger/src/middleware/middy.ts
@@ -109,13 +109,15 @@ const injectLambdaContext = (
   };
 
   const onError = async ({ error }: { error: unknown }): Promise<void> => {
-    if (options?.flushBufferOnUncaughtError) {
-      for (const logger of loggers) {
+    for (const logger of loggers) {
+      if (options?.flushBufferOnUncaughtError) {
         logger.flushBuffer();
         logger.error({
           message: UncaughtErrorLogMessage,
           error,
         });
+      } else {
+        logger.clearBuffer();
       }
     }
   };

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -208,6 +208,23 @@ describe('Buffer logs', () => {
     // Assess
     expect(() => logger.clearBuffer()).not.toThrow();
   });
+
+  it('it clears the buffer', () => {
+    // Prepare
+    const logger = new Logger({
+      logLevel: LogLevel.ERROR,
+      logBufferOptions: { enabled: true, bufferAtVerbosity: LogLevel.DEBUG },
+    });
+
+    // Arrange
+    logger.debug('This is a log message');
+    logger.clearBuffer();
+
+    logger.flushBuffer();
+
+    // Assess
+    expect(console.debug).not.toBeCalled;
+  });
   it('it flushes the buffer when an error in logged', () => {
     // Prepare
     const logger = new Logger({

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -197,6 +197,17 @@ describe('Buffer logs', () => {
     );
   });
 
+  it('it safely short circuits when clearBuffer is called without a trace id', () => {
+    // Prepare
+    process.env._X_AMZN_TRACE_ID = undefined;
+    const logger = new Logger({
+      logLevel: LogLevel.ERROR,
+      logBufferOptions: { enabled: true, bufferAtVerbosity: LogLevel.DEBUG },
+    });
+
+    // Assess
+    expect(() => logger.clearBuffer()).not.toThrow();
+  });
   it('it flushes the buffer when an error in logged', () => {
     // Prepare
     const logger = new Logger({


### PR DESCRIPTION
## Summary
This PR adds support for flushing the log buffer when an uncaught error is encountered using middy middleware.

### Changes

> Please provide a summary of what's being changed

* Add `flushBufferOnUncaughtError` option to middy `injectLambdaContext` options
* Add `clearBuffer` method to the logger. This is needed to clear the buffer in the `onAfter` handler. An alternative I considered was changing the logic of the buffer to only handle one trace id at a time. If a log is buffered with a new trace ID, then the buffer could be reset. 
* Split the `injectLambdaContextAfterOrOnError` into separate handlers . Simplify the names all the handlers.

### Notes

* The `target` parameter of `injectLambdaContext` can be an array of loggers. I wasn't clear on the correct behaviour if there are multiple loggers provided. At the moment it will flush each logger.

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3633 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
