### PR TITLE
refactor(logger): align implementation to spec + docs

### DIFF
--- a/docs/core/logger.md
+++ b/docs/core/logger.md
@@ -9,7 +9,8 @@ Logger provides an opinionated logger with output structured as JSON.
 
 * Capturing key fields from the Lambda context, cold starts, and structure logging output as JSON.
 * Logging Lambda invocation events when instructed (disabled by default).
-* Printing all the logs only for a percentage of invocations via log sampling (disabled by default).
+* Switch log level to `DEBUG` for a percentage of invocations (sampling).
+* Buffering logs for a specific request or invocation, and flushing them automatically on error or manually as needed.
 * Appending additional keys to structured logs at any point in time.
 * Providing a custom log formatter (Bring Your Own Formatter) to output logs in a structure compatible with your organization’s Logging RFC.
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -213,7 +213,7 @@ Logger `sampleRateValue` **continues** to determine the percentage of concurrent
 
 ### Custom log formatter
 
-!!! note "Disregard if you are not customizing log output with a [custom log formatter](./core/logger.md#custom-log-formatter-bring-your-own-formatter)."
+!!! note "Disregard if you are not customizing log output with a [custom log formatter](./core/logger.md#custom-log-formatter)."
 
 In v1, `Logger` exposed the [standard](./core/logger.md#standard-structured-keys) as a single argument, _e.g., `formatAttributes(attributes: UnformattedAttributes)`_. It expected a plain object with keys and values you wanted in the final log output.
 

--- a/examples/snippets/logger/logBufferingBufferAtVerbosity.ts
+++ b/examples/snippets/logger/logBufferingBufferAtVerbosity.ts
@@ -1,0 +1,16 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+
+const logger = new Logger({
+  logBufferOptions: {
+    bufferAtVerbosity: 'warn', // (1)!
+  },
+});
+
+export const handler = async () => {
+  // All logs below are buffered
+  logger.debug('This is a debug message');
+  logger.info('This is an info message');
+  logger.warn('This is a warn message');
+
+  logger.clearBuffer(); // (2)!
+};

--- a/examples/snippets/logger/logBufferingFlushOnErrorDecorator.ts
+++ b/examples/snippets/logger/logBufferingFlushOnErrorDecorator.ts
@@ -1,0 +1,23 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { Context } from 'aws-lambda';
+
+const logger = new Logger({
+  logLevel: 'DEBUG',
+  logBufferOptions: { enabled: true },
+});
+
+class Lambda {
+  @logger.injectLambdaContext({
+    flushBufferOnUncaughtError: true,
+  })
+  async handler(_event: unknown, _context: Context) {
+    // Both logs below are buffered
+    logger.debug('a debug log');
+    logger.debug('another debug log');
+
+    throw new Error('an error log'); // This causes the buffer to flush
+  }
+}
+
+const lambda = new Lambda();
+export const handler = lambda.handler.bind(lambda);

--- a/examples/snippets/logger/logBufferingFlushOnErrorMiddy.ts
+++ b/examples/snippets/logger/logBufferingFlushOnErrorMiddy.ts
@@ -1,0 +1,18 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+import { injectLambdaContext } from '@aws-lambda-powertools/logger/middleware';
+import middy from '@middy/core';
+
+const logger = new Logger({
+  logLevel: 'DEBUG',
+  logBufferOptions: { enabled: true },
+});
+
+export const handler = middy()
+  .use(injectLambdaContext(logger, { flushBufferOnUncaughtError: true }))
+  .handler(async (event: unknown) => {
+    // Both logs below are buffered
+    logger.debug('a debug log');
+    logger.debug('another debug log');
+
+    throw new Error('an error log'); // This causes the buffer to flush
+  });

--- a/examples/snippets/logger/logBufferingGettingStarted.ts
+++ b/examples/snippets/logger/logBufferingGettingStarted.ts
@@ -1,0 +1,20 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+
+const logger = new Logger({
+  logBufferOptions: {
+    maxBytes: 20480,
+    flushOnErrorLog: true,
+  },
+});
+
+logger.debug('This is a debug message'); // This is NOT buffered
+
+export const handler = async () => {
+  logger.debug('This is a debug message'); // This is buffered
+  logger.info('This is an info message');
+
+  // your business logic here
+
+  logger.error('This is an error message'); // This also flushes the buffer
+  // or logger.flushBuffer(); // to flush the buffer manually
+};

--- a/examples/snippets/logger/logBufferingflushOnErrorLog.ts
+++ b/examples/snippets/logger/logBufferingflushOnErrorLog.ts
@@ -1,0 +1,27 @@
+import { Logger } from '@aws-lambda-powertools/logger';
+
+const logger = new Logger({
+  logBufferOptions: {
+    maxBytes: 20480,
+    flushOnErrorLog: false, // (1)!
+  },
+});
+
+export const handler = async () => {
+  logger.debug('This is a debug message'); // This is buffered
+
+  try {
+    throw new Error('a non fatal error');
+  } catch (error) {
+    logger.error('A non fatal error occurred', { error }); // This does NOT flush the buffer
+  }
+
+  logger.debug('This is another debug message'); // This is buffered
+
+  try {
+    throw new Error('a fatal error');
+  } catch (error) {
+    logger.error('A fatal error occurred', { error }); // This does NOT flush the buffer
+    logger.flushBuffer();
+  }
+};

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -178,7 +178,7 @@ class Logger extends Utility implements LoggerInterface {
   /**
    * Buffer configuration options.
    */
-  #bufferOptions: {
+  #bufferConfig: {
     /**
      * Whether the buffer should is enabled
      */
@@ -306,13 +306,13 @@ class Logger extends Utility implements LoggerInterface {
           environment: this.powertoolsLogData.environment,
           persistentLogAttributes: this.persistentLogAttributes,
           jsonReplacerFn: this.#jsonReplacerFn,
-          ...(this.#bufferOptions.enabled && {
+          ...(this.#bufferConfig.enabled && {
             logBufferOptions: {
-              maxBytes: this.#bufferOptions.maxBytes,
+              maxBytes: this.#bufferConfig.maxBytes,
               bufferAtVerbosity: this.getLogLevelNameFromNumber(
-                this.#bufferOptions.bufferAtVerbosity
+                this.#bufferConfig.bufferAtVerbosity
               ),
-              flushOnErrorLog: this.#bufferOptions.flushOnErrorLog,
+              flushOnErrorLog: this.#bufferConfig.flushOnErrorLog,
             },
           }),
         },
@@ -360,7 +360,7 @@ class Logger extends Utility implements LoggerInterface {
    * @param extraInput - The extra input to log.
    */
   public error(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
-    if (this.#bufferOptions.enabled && this.#bufferOptions.flushOnErrorLog) {
+    if (this.#bufferConfig.enabled && this.#bufferConfig.flushOnErrorLog) {
       this.flushBuffer();
     }
     this.processLogItem(LogLevelThreshold.ERROR, input, extraInput);
@@ -1294,24 +1294,24 @@ class Logger extends Utility implements LoggerInterface {
       return;
     }
     // `enabled` is a boolean, so we set it to true if it's not explicitly set to false
-    this.#bufferOptions.enabled = options?.enabled !== false;
+    this.#bufferConfig.enabled = options?.enabled !== false;
     // if `enabled` is false, we don't need to set any other options
-    if (this.#bufferOptions.enabled === false) return;
+    if (this.#bufferConfig.enabled === false) return;
 
     if (options?.maxBytes !== undefined) {
-      this.#bufferOptions.maxBytes = options.maxBytes;
+      this.#bufferConfig.maxBytes = options.maxBytes;
     }
     this.#buffer = new CircularMap({
-      maxBytesSize: this.#bufferOptions.maxBytes,
+      maxBytesSize: this.#bufferConfig.maxBytes,
     });
 
     if (options?.flushOnErrorLog === false) {
-      this.#bufferOptions.flushOnErrorLog = false;
+      this.#bufferConfig.flushOnErrorLog = false;
     }
 
     const bufferAtLogLevel = options?.bufferAtVerbosity?.toUpperCase();
     if (this.isValidLogLevel(bufferAtLogLevel)) {
-      this.#bufferOptions.bufferAtVerbosity =
+      this.#bufferConfig.bufferAtVerbosity =
         LogLevelThreshold[bufferAtLogLevel];
     }
   }
@@ -1400,9 +1400,9 @@ class Logger extends Utility implements LoggerInterface {
     logLevel: number
   ): boolean {
     return (
-      this.#bufferOptions.enabled &&
+      this.#bufferConfig.enabled &&
       traceId !== undefined &&
-      logLevel <= this.#bufferOptions.bufferAtVerbosity
+      logLevel <= this.#bufferConfig.bufferAtVerbosity
     );
   }
 }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -41,10 +41,12 @@ import type {
  * The Logger utility provides an opinionated logger with output structured as JSON for AWS Lambda.
  *
  * **Key features**
- * * Capture key fields from AWS Lambda context, cold start, and structure log output as JSON
- * * Append additional keys to one or all log items
- * * Switch log level to `DEBUG` based on a sample rate value for a percentage of invocations
- * * Ability to buffer logs in memory and flush them when there's an error
+ * Capturing key fields from the Lambda context, cold starts, and structure logging output as JSON.
+ * Logging Lambda invocation events when instructed (disabled by default).
+ * Switch log level to `DEBUG` for a percentage of invocations (sampling).
+ * Buffering logs for a specific request or invocation, and flushing them automatically on error or manually as needed.
+ * Appending additional keys to structured logs at any point in time.
+ * Providing a custom log formatter (Bring Your Own Formatter) to output logs in a structure compatible with your organization’s Logging RFC.
  *
  * After initializing the Logger class, you can use the methods to log messages at different levels.
  *

--- a/packages/logger/src/types/Logger.ts
+++ b/packages/logger/src/types/Logger.ts
@@ -201,14 +201,19 @@ type LogBufferOption = {
      */
     flushOnErrorLog?: boolean;
     /**
-     * The threshold to buffer logs. Logs with a level below
-     * this threshold will be buffered
+     * The threshold to buffer logs. Logs with a level more severe than this will be logged immediately.
+     * Only 'DEBUG', 'INFO', 'WARN' or their lowercase variants are allowed.
      * @default `DEBUG`
      */
-    bufferAtVerbosity?: Omit<
-      LogLevel,
-      'ERROR' | 'error' | 'CRITICAL' | 'critical' | 'SILENT' | 'silent'
-    >;
+    bufferAtVerbosity?:
+      | Extract<
+          (typeof LogLevelList)[keyof typeof LogLevelList],
+          'DEBUG' | 'INFO' | 'WARN'
+        >
+      | Extract<
+          Lowercase<(typeof LogLevelList)[keyof typeof LogLevelList]>,
+          'debug' | 'info' | 'warn'
+        >;
   };
 };
 

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -208,6 +208,23 @@ describe('Buffer logs', () => {
     expect(console.error).toBeCalledTimes(1);
   });
 
+  it('passes down the same buffer config to child loggers', () => {
+    // Prepare
+    const logger = new Logger({
+      logLevel: LogLevel.TRACE,
+      logBufferOptions: { enabled: true, bufferAtVerbosity: LogLevel.INFO },
+    });
+    const childLogger = logger.createChild();
+
+    // Assess
+    childLogger.debug('This is a log message');
+    childLogger.info('This is an info message');
+
+    // Assess
+    expect(console.debug).toBeCalledTimes(0);
+    expect(console.info).toBeCalledTimes(0);
+  });
+
   it.each([
     {
       handlerFactory: (logger: Logger) =>


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR aligns the implementation of the log buffering feature in Logger so that it aligns with the spec defined in the RFC. The implementation we got to differed slightly in a couple of important ways, namely:
- it prioritized the log level decision over the buffering decision
- it did not pass buffering configs to child loggers

This PR addresses these two differences and slightly refactors some of the internal props in the Logger related to the new feature so that they are all grouped together.

The PR also adds the documentation for the feature, largely mirroring the version written in aws-powertools/powertools-lambda-python#6060.

Integration tests will be added in a future PR in this iteration.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3700

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
