### PR TITLE
fix(idempotency): include sk in error msgs when using composite key

### DIFF
--- a/packages/idempotency/src/IdempotencyHandler.ts
+++ b/packages/idempotency/src/IdempotencyHandler.ts
@@ -120,7 +120,11 @@ export class IdempotencyHandler<Func extends AnyFunction> {
         );
       }
       throw new IdempotencyAlreadyInProgressError(
-        `There is already an execution in progress with idempotency key: ${idempotencyRecord.idempotencyKey}`
+        `There is already an execution in progress with idempotency key: ${idempotencyRecord.idempotencyKey}${
+          idempotencyRecord.sortKey
+            ? ` and sort key: ${idempotencyRecord.sortKey}`
+            : ''
+        }`
       );
     }
 

--- a/packages/idempotency/src/persistence/DynamoDBPersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/DynamoDBPersistenceLayer.ts
@@ -122,6 +122,7 @@ class DynamoDBPersistenceLayer extends BasePersistenceLayer {
 
     return new IdempotencyRecord({
       idempotencyKey: item[this.keyAttr],
+      sortKey: this.sortKeyAttr && item[this.sortKeyAttr],
       status: item[this.statusAttr],
       expiryTimestamp: item[this.expiryAttr],
       inProgressExpiryTimestamp: item[this.inProgressExpiryAttr],
@@ -207,6 +208,7 @@ class DynamoDBPersistenceLayer extends BasePersistenceLayer {
           item &&
           new IdempotencyRecord({
             idempotencyKey: item[this.keyAttr],
+            sortKey: this.sortKeyAttr && item[this.sortKeyAttr],
             status: item[this.statusAttr],
             expiryTimestamp: item[this.expiryAttr],
             inProgressExpiryTimestamp: item[this.inProgressExpiryAttr],
@@ -214,7 +216,9 @@ class DynamoDBPersistenceLayer extends BasePersistenceLayer {
             payloadHash: item[this.validationKeyAttr],
           });
         throw new IdempotencyItemAlreadyExistsError(
-          `Failed to put record for already existing idempotency key: ${record.idempotencyKey}`,
+          `Failed to put record for already existing idempotency key: ${record.idempotencyKey}${
+            this.sortKeyAttr ? ` and sort key: ${record.sortKey}` : ''
+          }`,
           idempotencyRecord
         );
       }

--- a/packages/idempotency/src/persistence/IdempotencyRecord.ts
+++ b/packages/idempotency/src/persistence/IdempotencyRecord.ts
@@ -5,6 +5,7 @@ import type {
   IdempotencyRecordOptions,
   IdempotencyRecordStatusValue,
 } from '../types/IdempotencyRecord.js';
+import type { DynamoDBPersistenceLayer } from './DynamoDBPersistenceLayer.js';
 
 /**
  * Class representing an idempotency record.
@@ -19,6 +20,10 @@ class IdempotencyRecord {
    * The idempotency key of the record that is used to identify the record.
    */
   public idempotencyKey: string;
+  /**
+   * An optional sort key that can be used with the {@link DynamoDBPersistenceLayer | `DynamoDBPersistenceLayer`}.
+   */
+  public sortKey?: string;
   /**
    * The expiry timestamp of the in progress record in milliseconds UTC.
    */
@@ -46,6 +51,7 @@ class IdempotencyRecord {
     this.responseData = config.responseData;
     this.payloadHash = config.payloadHash;
     this.status = config.status;
+    this.sortKey = config.sortKey;
   }
 
   /**

--- a/packages/idempotency/src/types/IdempotencyRecord.ts
+++ b/packages/idempotency/src/types/IdempotencyRecord.ts
@@ -11,11 +11,35 @@ type IdempotencyRecordStatusValue =
  * Options for creating a new IdempotencyRecord
  */
 type IdempotencyRecordOptions = {
+  /**
+   * The idempotency key of the record that is used to identify the record.
+   */
   idempotencyKey: string;
+  /**
+   * An optional sort key that can be used with the {@link DynamoDBPersistenceLayer | `DynamoDBPersistenceLayer`}.
+   */
+  sortKey?: string;
+  /**
+   * The idempotency record status can be COMPLETED, IN_PROGRESS or EXPIRED.
+   * We check the status during idempotency processing to make sure we don't process an expired record and handle concurrent requests.
+   * {@link constants.IdempotencyRecordStatusValue | IdempotencyRecordStatusValue}
+   */
   status: IdempotencyRecordStatusValue;
+  /**
+   * The expiry timestamp of the record in milliseconds UTC.
+   */
   expiryTimestamp?: number;
+  /**
+   * The expiry timestamp of the in progress record in milliseconds UTC.
+   */
   inProgressExpiryTimestamp?: number;
+  /**
+   * The response data of the request, this will be returned if the payload hash matches.
+   */
   responseData?: JSONValue;
+  /**
+   * The hash of the payload of the request, used for comparing requests.
+   */
   payloadHash?: string;
 };
 


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the `IdempotencyRecord` class so that it optionally accepts a `sortKey` parameter. This parameter is provided only when using the `DynamoDBPersistenceLayer` and when using a composite key (pk + sk).

This fixes a bug that prevented the `IdempotencyAlreadyInProgressError` and `IdempotencyItemAlreadyExistsError` from constructing the appropriate error message. Both errors now include both keys in the error message, making it easier for customers to detect idempotent requests or troubleshoot issues.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3691

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
