### PR TITLE
feat(parser): add Cognito pre-signup trigger schema

### DIFF
--- a/docs/utilities/parser.md
+++ b/docs/utilities/parser.md
@@ -69,6 +69,18 @@ Parser comes with the following built-in schemas:
 | **CloudFormationCustomResourceUpdateSchema** | Lambda Event Source payload for AWS CloudFormation `UPDATE` operation                 |
 | **CloudFormationCustomResourceDeleteSchema** | Lambda Event Source payload for AWS CloudFormation `DELETE` operation                 |
 | **CloudwatchLogsSchema**                     | Lambda Event Source payload for Amazon CloudWatch Logs                                |
+| **PreSignupTriggerSchema**                   | Lambda Event Source payload for Amazon Cognito Pre Sign-up trigger                      |
+| **PostConfirmationTriggerSchema**            | Lambda Event Source payload for Amazon Cognito Post Confirmation trigger               |
+| **PreTokenGenerationTriggerSchema**          | Lambda Event Source payload for Amazon Cognito Pre Token Generation trigger            |
+| **CustomMessageTriggerSchema**               | Lambda Event Source payload for Amazon Cognito Custom Message trigger                  |
+| **MigrateUserTriggerSchema**                 | Lambda Event Source payload for Amazon Cognito User Migration trigger                  |
+| **CustomSMSTriggerSchema**                   | Lambda Event Source payload for Amazon Cognito Custom SMS trigger                      |
+| **CustomEmailTriggerSchema**                 | Lambda Event Source payload for Amazon Cognito Custom Email trigger                    |
+| **DefineAuthChallengeTriggerSchema**         | Lambda Event Source payload for Amazon Cognito Define Auth Challenge trigger           |
+| **CreateAuthChallengeTriggerSchema**         | Lambda Event Source payload for Amazon Cognito Create Auth Challenge trigger           |
+| **VerifyAuthChallengeResponseTriggerSchema** | Lambda Event Source payload for Amazon Cognito Verify Auth Challenge Response trigger   |
+| **PreTokenGenerationTriggerSchemaV1**        | Lambda Event Source payload for Amazon Cognito Pre Token Generation trigger v1          |
+| **PreTokenGenerationTriggerSchemaV2AndV3**   | Lambda Event Source payload for Amazon Cognito Pre Token Generation trigger v2 and v3       |
 | **DynamoDBStreamSchema**                     | Lambda Event Source payload for Amazon DynamoDB Streams                               |
 | **EventBridgeSchema**                        | Lambda Event Source payload for Amazon EventBridge                                    |
 | **KafkaMskEventSchema**                      | Lambda Event Source payload for AWS MSK payload                                       |

--- a/packages/parser/src/schemas/cognito.ts
+++ b/packages/parser/src/schemas/cognito.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const PreSignupTriggerSchema = z.object({
+  version: z.string(),
+  region: z.string(),
+  userPoolId: z.string(),
+  userName: z.string(),
+  callerContext: z.object({
+    awsSdkVersion: z.string(),
+    clientId: z.string(),
+  }),
+  triggerSource: z.string(),
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    validationData: z.record(z.string(), z.string()).nullable().optional(),
+    userNotFound: z.boolean().optional(),
+  }),
+  response: z
+    .object({
+      autoConfirmUser: z.boolean().optional(),
+      autoVerifyEmail: z.boolean().optional(),
+      autoVerifyPhone: z.boolean().optional(),
+    })
+    .optional(),
+});

--- a/packages/parser/src/schemas/cognito.ts
+++ b/packages/parser/src/schemas/cognito.ts
@@ -1,5 +1,39 @@
 import { z } from 'zod';
 
+/**
+ * A zod schema for a Cognito Pre-Signup trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "version": "1",
+ *   "region": "us-east-1",
+ *   "userPoolId": "us-east-1_ABC123",
+ *   "userName": "johndoe",
+ *   "callerContext": {
+ *     "awsSdkVersion": "2.814.0",
+ *     "clientId": "client123"
+ *   },
+ *   "triggerSource": "PreSignUp_SignUp",
+ *   "request": {
+ *     "userAttributes": {
+ *       "email": "johndoe@example.com",
+ *       "name": "John Doe"
+ *     },
+ *     "validationData": null,
+ *     "clientMetadata": {
+ *       "someKey": "someValue"
+ *     }
+ *   },
+ *   "response": {
+ *     "autoConfirmUser": true,
+ *     "autoVerifyEmail": false,
+ *     "autoVerifyPhone": false
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-sign-up.html}
+ */
 export const PreSignupTriggerSchema = z.object({
   version: z.string(),
   region: z.string(),
@@ -13,6 +47,7 @@ export const PreSignupTriggerSchema = z.object({
   request: z.object({
     userAttributes: z.record(z.string(), z.string()),
     validationData: z.record(z.string(), z.string()).nullable().optional(),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
     userNotFound: z.boolean().optional(),
   }),
   response: z
@@ -22,4 +57,462 @@ export const PreSignupTriggerSchema = z.object({
       autoVerifyPhone: z.boolean().optional(),
     })
     .optional(),
+});
+
+/**
+ * A zod schema for a Cognito Post-Confirmation trigger event.
+ *
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-confirmation.html}
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": {
+ *       "email": "user@example.com",
+ *       "name": "John Doe"
+ *     },
+ *     "clientMetadata": {
+ *       "customKey": "customValue"
+ *     }
+ *   },
+ *   "response": {}
+ * }
+ * ```
+ */
+export const PostConfirmationTriggerSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    clientMetadata: z.record(z.string(), z.string().optional()),
+  }),
+  response: z.object({}),
+});
+
+/**
+ * A zod schema for a Cognito Pre-Authentication trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": {
+ *       "email": "user@example.com",
+ *       "name": "John Doe"
+ *     },
+ *     "validationData": {
+ *       "someKey": "someValue"
+ *     },
+ *     "userNotFound": false
+ *   },
+ *   "response": {}
+ * }
+ * ```
+ *  * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-authentication.html}
+ */
+export const PreAuthenticationTriggerSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    validationData: z.record(z.string(), z.string()),
+    userNotFound: z.boolean(),
+  }),
+  response: z.object({}),
+});
+
+/**
+ * A zod schema for a Cognito Post-Authentication trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": {
+ *       "email": "user@example.com",
+ *       "name": "John Doe"
+ *     },
+ *     "newDeviceUsed": true,
+ *     "clientMetadata": {
+ *       "customKey": "customValue"
+ *     }
+ *   },
+ *   "response": {}
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-post-authentication.html}
+ */
+export const PostAuthenticationTriggerSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    newDeviceUsed: z.boolean(),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+  }),
+  response: z.object({}),
+});
+
+/**
+ * A zod schema for a Cognito Pre-Token Generation trigger event (version 1).
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": { "string": "string" },
+ *     "groupConfiguration": {
+ *       "groupsToOverride": [ "string", "string" ],
+ *       "iamRolesToOverride": [ "string", "string" ],
+ *       "preferredRole": "string"
+ *     },
+ *     "clientMetadata": { "string": "string" }
+ *   },
+ *   "response": {
+ *     "claimsOverrideDetails": {
+ *       "claimsToAddOrOverride": { "string": "string" },
+ *       "claimsToSuppress": [ "string", "string" ],
+ *       "groupOverrideDetails": {
+ *         "groupsToOverride": [ "string", "string" ],
+ *         "iamRolesToOverride": [ "string", "string" ],
+ *         "preferredRole": "string"
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html}
+ */
+export const PreTokenGenerationTriggerSchemaV1 = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    groupConfiguration: z.object({
+      groupsToOverride: z.array(z.string()),
+      iamRolesToOverride: z.array(z.string()),
+      preferredRole: z.string(),
+    }),
+    clientMetadata: z.record(z.string(), z.string()),
+  }),
+  response: z.object({
+    claimsOverrideDetails: z.object({
+      claimsToAddOrOverride: z.record(z.string(), z.string()),
+      claimsToSuppress: z.array(z.string()),
+      groupOverrideDetails: z.object({
+        groupsToOverride: z.array(z.string()),
+        iamRolesToOverride: z.array(z.string()),
+        preferredRole: z.string(),
+      }),
+    }),
+  }),
+});
+
+/**
+ * A zod schema for a Cognito Pre-Token Generation trigger event (version 2).
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": { "string": "string" },
+ *     "scopes": [ "string", "string" ],
+ *     "groupConfiguration": {
+ *       "groupsToOverride": [ "string", "string" ],
+ *       "iamRolesToOverride": [ "string", "string" ],
+ *       "preferredRole": "string"
+ *     },
+ *     "clientMetadata": { "string": "string" }
+ *   },
+ *   "response": {
+ *     "claimsAndScopeOverrideDetails": {
+ *       "idTokenGeneration": {
+ *         "claimsToAddOrOverride": { "string": "string" },
+ *         "claimsToSuppress": [ "string", "string" ]
+ *       },
+ *       "accessTokenGeneration": {
+ *         "claimsToAddOrOverride": { "string": "string" },
+ *         "claimsToSuppress": [ "string", "string" ],
+ *         "scopesToAdd": [ "string", "string" ],
+ *         "scopesToSuppress": [ "string", "string" ]
+ *       },
+ *       "groupOverrideDetails": {
+ *         "groupsToOverride": [ "string", "string" ],
+ *         "iamRolesToOverride": [ "string", "string" ],
+ *         "preferredRole": "string"
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-pre-token-generation.html}
+ */
+export const PreTokenGenerationTriggerSchemaV2 = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    scopes: z.array(z.string()),
+    groupConfiguration: z.object({
+      groupsToOverride: z.array(z.string()),
+      iamRolesToOverride: z.array(z.string()),
+      preferredRole: z.string(),
+    }),
+    clientMetadata: z.record(z.string(), z.string()),
+  }),
+  response: z.object({
+    claimsAndScopeOverrideDetails: z.object({
+      idTokenGeneration: z.object({
+        claimsToAddOrOverride: z.record(z.any()),
+        claimsToSuppress: z.array(z.string()),
+      }),
+      accessTokenGeneration: z.object({
+        claimsToAddOrOverride: z.record(z.any()),
+        claimsToSuppress: z.array(z.string()),
+        scopesToAdd: z.array(z.string()),
+        scopesToSuppress: z.array(z.string()),
+      }),
+      groupOverrideDetails: z.object({
+        groupsToOverride: z.array(z.string()),
+        iamRolesToOverride: z.array(z.string()),
+        preferredRole: z.string(),
+      }),
+    }),
+  }),
+});
+
+/**
+ * A zod schema for a Cognito Migrate User trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "userName": "string",
+ *   "request": {
+ *     "password": "string",
+ *     "validationData": { "key": "value" },
+ *     "clientMetadata": { "key": "value" }
+ *   },
+ *   "response": {
+ *     "userAttributes": { "key": "value" },
+ *     "finalUserStatus": "string",
+ *     "messageAction": "string",
+ *     "desiredDeliveryMediums": [ "string" ],
+ *     "forceAliasCreation": true,
+ *     "enableSMSMFA": true
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-migrate-user.html}
+ */
+export const MigrateUserTriggerSchema = z.object({
+  userName: z.string(),
+  request: z.object({
+    password: z.string(),
+    validationData: z.record(z.string(), z.string()),
+    clientMetadata: z.record(z.string(), z.string()),
+  }),
+  response: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    finalUserStatus: z.string(),
+    messageAction: z.string(),
+    desiredDeliveryMediums: z.array(z.string()),
+    forceAliasCreation: z.boolean(),
+    enableSMSMFA: z.boolean(),
+  }),
+});
+
+/**
+ * A zod schema for a Cognito Custom Message trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": { "string": "string", ... },
+ *     "codeParameter": "####",
+ *     "usernameParameter": "string",
+ *     "clientMetadata": { "string": "string", ... }
+ *   },
+ *   "response": {
+ *     "smsMessage": "string",
+ *     "emailMessage": "string",
+ *     "emailSubject": "string"
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-message.html}
+ */
+export const CustomMessageTriggerSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    codeParameter: z.string(),
+    usernameParameter: z.string(),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+  }),
+  response: z.object({
+    smsMessage: z.string(),
+    emailMessage: z.string(),
+    emailSubject: z.string(),
+  }),
+});
+
+/**
+ * A zod schema for a Cognito Custom Email Sender trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "type": "customEmailSenderRequestV1",
+ *     "code": "string",
+ *     "clientMetadata": { "string": "string", ... },
+ *     "userAttributes": { "string": "string", ... }
+ *   },
+ *   "response": {}
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-email-sender.html}
+ */
+export const CustomEmailSenderTriggerSchema = z.object({
+  request: z.object({
+    type: z.literal('customEmailSenderRequestV1'),
+    code: z.string(),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+    userAttributes: z.record(z.string(), z.string()),
+  }),
+  response: z.object({}),
+});
+
+/**
+ * A zod schema for a Cognito Custom SMS Sender trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "type": "customSMSSenderRequestV1",
+ *     "code": "string",
+ *     "clientMetadata": { "string": "string", ... },
+ *     "userAttributes": { "string": "string", ... }
+ *   },
+ *   "response": {}
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-custom-sms-sender.html}
+ */
+export const CustomSMSSenderTriggerSchema = z.object({
+  request: z.object({
+    type: z.literal('customSMSSenderRequestV1'),
+    code: z.string(),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+    userAttributes: z.record(z.string(), z.string()),
+  }),
+  response: z.object({}),
+});
+
+const ChallengeResultSchema = z.object({});
+
+/**
+ * A zod schema for a Cognito Define Auth Challenge trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": { "email": "user@example.com", "name": "John Doe" },
+ *     "session": [
+ *       {
+ *         "challengeName": "SRP_A",
+ *         "challengeResult": true,
+ *         "challengeMetadata": "metadata"
+ *       }
+ *     ],
+ *     "clientMetadata": { "key": "value" },
+ *     "userNotFound": false
+ *   },
+ *   "response": {
+ *     "challengeName": "PASSWORD_VERIFIER",
+ *     "issueTokens": false,
+ *     "failAuthentication": false
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-define-auth-challenge.html}
+ */
+export const DefineAuthChallengeSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    session: z.array(ChallengeResultSchema),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+    userNotFound: z.boolean(),
+  }),
+  response: z.object({
+    challengeName: z.string(),
+    issueTokens: z.boolean(),
+    failAuthentication: z.boolean(),
+  }),
+});
+
+/**
+ * A zod schema for a Cognito Create Auth Challenge trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": { "email": "user@example.com", "name": "John Doe" },
+ *     "challengeName": "CUSTOM_CHALLENGE",
+ *     "session": [
+ *       { "challengeName": "SRP_A", "challengeResult": true, "challengeMetadata": "metadata" }
+ *     ],
+ *     "clientMetadata": { "key": "value" },
+ *     "userNotFound": false
+ *   },
+ *   "response": {
+ *     "publicChallengeParameters": { "captchaUrl": "url/123.jpg" },
+ *     "privateChallengeParameters": { "answer": "5" },
+ *     "challengeMetadata": "custom metadata"
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-create-auth-challenge.html}
+ */
+export const CreateAuthChallengeSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    challengeName: z.string(),
+    session: z.array(ChallengeResultSchema),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+    userNotFound: z.boolean(),
+  }),
+  response: z.object({
+    publicChallengeParameters: z.record(z.string()),
+    privateChallengeParameters: z.record(z.string()),
+    challengeMetadata: z.string(),
+  }),
+});
+
+/**
+ * A zod schema for a Cognito Verify Auth Challenge Response trigger event.
+ *
+ * @example
+ * ```json
+ * {
+ *   "request": {
+ *     "userAttributes": { "email": "user@example.com", "name": "John Doe" },
+ *     "privateChallengeParameters": { "answer": "expectedAnswer" },
+ *     "challengeAnswer": "userAnswer",
+ *     "clientMetadata": { "key": "value" },
+ *     "userNotFound": false
+ *   },
+ *   "response": {
+ *     "answerCorrect": true
+ *   }
+ * }
+ * ```
+ * @see {@link https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-lambda-verify-auth-challenge-response.html}
+ */
+export const VerifyAuthChallengeSchema = z.object({
+  request: z.object({
+    userAttributes: z.record(z.string(), z.string()),
+    privateChallengeParameters: z.record(z.string(), z.string()),
+    challengeAnswer: z.string(),
+    clientMetadata: z.record(z.string(), z.string()).optional(),
+    userNotFound: z.boolean(),
+  }),
+  response: z.object({
+    answerCorrect: z.boolean(),
+  }),
 });

--- a/packages/parser/src/schemas/cognito.ts
+++ b/packages/parser/src/schemas/cognito.ts
@@ -402,7 +402,11 @@ export const CustomSMSSenderTriggerSchema = z.object({
   response: z.object({}),
 });
 
-const ChallengeResultSchema = z.object({});
+const ChallengeResultSchema = z.object({
+  challengeName: z.string(),
+  challengeResult: z.boolean(),
+  challengeMetadata: z.string().optional(),
+});
 
 /**
  * A zod schema for a Cognito Define Auth Challenge trigger event.

--- a/packages/parser/src/schemas/index.ts
+++ b/packages/parser/src/schemas/index.ts
@@ -26,6 +26,21 @@ export {
   CloudWatchLogsSchema,
 } from './cloudwatch.js';
 export {
+  PreSignupTriggerSchema,
+  PostConfirmationTriggerSchema,
+  PreAuthenticationTriggerSchema,
+  PostAuthenticationTriggerSchema,
+  PreTokenGenerationTriggerSchemaV1,
+  PreTokenGenerationTriggerSchemaV2,
+  MigrateUserTriggerSchema,
+  CustomMessageTriggerSchema,
+  CustomEmailSenderTriggerSchema,
+  CustomSMSSenderTriggerSchema,
+  DefineAuthChallengeSchema,
+  CreateAuthChallengeSchema,
+  VerifyAuthChallengeSchema,
+} from './cognito.js';
+export {
   DynamoDBStreamSchema,
   DynamoDBStreamToKinesisRecord,
 } from './dynamodb.js';
@@ -47,7 +62,6 @@ export {
   KinesisFirehoseSqsRecordSchema,
 } from './kinesis-firehose.js';
 export { LambdaFunctionUrlSchema } from './lambda.js';
-export { PreSignupTriggerSchema } from './cognito.js';
 export {
   S3SqsEventNotificationSchema,
   S3EventNotificationEventBridgeSchema,

--- a/packages/parser/src/schemas/index.ts
+++ b/packages/parser/src/schemas/index.ts
@@ -31,14 +31,14 @@ export {
   PreAuthenticationTriggerSchema,
   PostAuthenticationTriggerSchema,
   PreTokenGenerationTriggerSchemaV1,
-  PreTokenGenerationTriggerSchemaV2,
+  PreTokenGenerationTriggerSchemaV2AndV3,
   MigrateUserTriggerSchema,
   CustomMessageTriggerSchema,
   CustomEmailSenderTriggerSchema,
   CustomSMSSenderTriggerSchema,
-  DefineAuthChallengeSchema,
-  CreateAuthChallengeSchema,
-  VerifyAuthChallengeSchema,
+  DefineAuthChallengeTriggerSchema,
+  CreateAuthChallengeTriggerSchema,
+  VerifyAuthChallengeTriggerSchema,
 } from './cognito.js';
 export {
   DynamoDBStreamSchema,

--- a/packages/parser/src/schemas/index.ts
+++ b/packages/parser/src/schemas/index.ts
@@ -47,6 +47,7 @@ export {
   KinesisFirehoseSqsRecordSchema,
 } from './kinesis-firehose.js';
 export { LambdaFunctionUrlSchema } from './lambda.js';
+export { PreSignupTriggerSchema } from './cognito.js';
 export {
   S3SqsEventNotificationSchema,
   S3EventNotificationEventBridgeSchema,

--- a/packages/parser/tests/events/cognito/base.json
+++ b/packages/parser/tests/events/cognito/base.json
@@ -1,0 +1,13 @@
+{
+  "version": "1",
+  "region": "eu-west-1",
+  "userPoolId": "eu-west-1_bbYLzC8rt",
+  "userName": "example@email.com",
+  "callerContext": {
+    "awsSdkVersion": "aws-sdk-unknown-unknown",
+    "clientId": "4ma39kqn9j6ncsimddqs13sgok"
+  },
+  "triggerSource": "",
+  "request": {},
+  "response": {}
+}

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -307,7 +307,7 @@ describe('Schema: Cognito MigrateUserTrigger', () => {
   const baseMigrateUserEvent = {
     userName: 'testuser',
     request: {
-      password: 'TestPass123!',
+      password: 'dummyPass123!',
       validationData: {
         key1: 'value1',
       },

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -1,472 +1,283 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CreateAuthChallengeSchema,
+  CreateAuthChallengeTriggerSchema,
   CustomEmailSenderTriggerSchema,
   CustomMessageTriggerSchema,
   CustomSMSSenderTriggerSchema,
-  DefineAuthChallengeSchema,
+  DefineAuthChallengeTriggerSchema,
   MigrateUserTriggerSchema,
   PostAuthenticationTriggerSchema,
   PostConfirmationTriggerSchema,
   PreAuthenticationTriggerSchema,
   PreSignupTriggerSchema,
   PreTokenGenerationTriggerSchemaV1,
-  PreTokenGenerationTriggerSchemaV2,
-  VerifyAuthChallengeSchema,
+  VerifyAuthChallengeTriggerSchema,
 } from '../../../src/schemas/cognito.js';
-import { omit } from '../helpers/utils.js';
+import { getTestEvent } from '../helpers/utils.js';
 
-describe('Schema: Cognito PreSignupTrigger', () => {
-  // Prepare
-  const basePreSignupEvent = {
-    version: '1',
-    region: 'us-east-1',
-    userPoolId: 'us-east-1_ABC123',
-    userName: 'johndoe',
-    callerContext: {
-      awsSdkVersion: '2.814.0',
-      clientId: 'client123',
-    },
-    triggerSource: 'PreSignUp_SignUp',
-    request: {
-      userAttributes: {
-        email: 'johndoe@example.com',
-        name: 'John Doe',
-      },
-      validationData: null,
-      clientMetadata: {
-        someKey: 'someValue',
-      },
-    },
-    response: {
-      autoConfirmUser: true,
-      autoVerifyEmail: false,
-      autoVerifyPhone: false,
-    },
-  };
+describe('Schemas: Cognito User Pool', () => {
+  const baseEvent = getTestEvent({
+    eventsPath: 'cognito',
+    filename: 'base',
+  });
 
   it('parses a valid pre-signup event', () => {
     // Prepare
-    const event = structuredClone(basePreSignupEvent);
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'PreSignUp_SignUp';
+    event.request = {
+      userAttributes: {},
+      validationData: null,
+    };
+    event.response = {
+      autoConfirmUser: false,
+      autoVerifyEmail: false,
+      autoVerifyPhone: false,
+    };
+
     // Act
-    const result = PreSignupTriggerSchema.safeParse(event);
+    const result = PreSignupTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.userName).toEqual('johndoe');
-    }
+    expect(result).toEqual(event);
   });
 
   it('throws if the pre-signup event is missing a required field', () => {
     // Prepare
-    const event = omit(['userName'], structuredClone(basePreSignupEvent));
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => PreSignupTriggerSchema.parse(event)).toThrow();
   });
-});
-
-describe('Schema: Cognito PostConfirmationTrigger', () => {
-  // Prepare
-  const basePostConfirmationEvent = {
-    request: {
-      userAttributes: {
-        email: 'user@example.com',
-        name: 'John Doe',
-      },
-      clientMetadata: {
-        customKey: 'customValue',
-      },
-    },
-    response: {},
-  };
 
   it('parses a valid post-confirmation event', () => {
     // Prepare
-    const event = structuredClone(basePostConfirmationEvent);
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'PostConfirmation_ConfirmSignUp';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+    };
+
     // Act
-    const result = PostConfirmationTriggerSchema.safeParse(event);
+    const result = PostConfirmationTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
+    expect(result).toEqual(event);
   });
 
   it('throws if the post-confirmation event is missing a required field', () => {
     // Prepare
-    const event = {
-      ...basePostConfirmationEvent,
-      request: omit(
-        ['userAttributes'],
-        structuredClone(basePostConfirmationEvent.request)
-      ),
-    };
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => PostConfirmationTriggerSchema.parse(event)).toThrow();
   });
-});
-
-describe('Schema: Cognito PreAuthenticationTrigger', () => {
-  // Prepare
-  const basePreAuthEvent = {
-    request: {
-      userAttributes: {
-        email: 'user@example.com',
-        name: 'John Doe',
-      },
-      validationData: {
-        someKey: 'someValue',
-      },
-      userNotFound: false,
-    },
-    response: {},
-  };
-
-  it('parses a valid pre-authentication event', () => {
-    // Prepare
-    const event = structuredClone(basePreAuthEvent);
-    // Act
-    const result = PreAuthenticationTriggerSchema.safeParse(event);
-    // Assess
-    expect(result.success).toBe(true);
-  });
-
-  it('throws if the pre-authentication event is missing a required field', () => {
-    // Prepare
-    const event = {
-      ...basePreAuthEvent,
-      request: omit(
-        ['userAttributes'],
-        structuredClone(basePreAuthEvent.request)
-      ),
-    };
-    // Act & Assess
-    expect(() => PreAuthenticationTriggerSchema.parse(event)).toThrow();
-  });
-});
-
-describe('Schema: Cognito PostAuthenticationTrigger', () => {
-  // Prepare
-  const basePostAuthEvent = {
-    request: {
-      userAttributes: {
-        email: 'user@example.com',
-        name: 'John Doe',
-      },
-      newDeviceUsed: true,
-      clientMetadata: {
-        customKey: 'customValue',
-      },
-    },
-    response: {},
-  };
 
   it('parses a valid post-authentication event', () => {
     // Prepare
-    const event = structuredClone(basePostAuthEvent);
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'PostAuthentication_Authentication';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+      newDeviceUsed: false,
+      clientMetadata: {
+        someKey: 'someValue',
+      },
+    };
+
     // Act
-    const result = PostAuthenticationTriggerSchema.safeParse(event);
+    const result = PostAuthenticationTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
+    expect(result).toEqual(event);
   });
 
   it('throws if the post-authentication event is missing a required field', () => {
     // Prepare
-    const event = {
-      ...basePostAuthEvent,
-      request: omit(
-        ['newDeviceUsed'],
-        structuredClone(basePostAuthEvent.request)
-      ),
-    };
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => PostAuthenticationTriggerSchema.parse(event)).toThrow();
   });
-});
 
-describe('Schema: Cognito PreTokenGenerationTrigger V1', () => {
-  // Prepare
-  const basePreTokenGenEventV1 = {
-    request: {
+  it('parses a valid pre-authentication event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'PreAuthentication_Authentication';
+    event.request = {
       userAttributes: {
-        email: 'user@example.com',
-        name: 'John Doe',
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
       },
-      groupConfiguration: {
-        groupsToOverride: ['group1', 'group2'],
-        iamRolesToOverride: ['role1', 'role2'],
-        preferredRole: 'role1',
-      },
-      clientMetadata: {
-        key1: 'value1',
-      },
-    },
-    response: {
-      claimsOverrideDetails: {
-        claimsToAddOrOverride: {
-          customClaim: 'customValue',
-        },
-        claimsToSuppress: ['email'],
-        groupOverrideDetails: {
-          groupsToOverride: ['newGroup1', 'newGroup2'],
-          iamRolesToOverride: ['newRole1', 'newRole2'],
-          preferredRole: 'newRole1',
-        },
-      },
-    },
-  };
-
-  it('parses a valid pre-token generation V1 event', () => {
-    // Prepare
-    const event = structuredClone(basePreTokenGenEventV1);
-    // Act
-    const result = PreTokenGenerationTriggerSchemaV1.safeParse(event);
-    // Assess
-    expect(result.success).toBe(true);
-  });
-
-  it('throws if the pre-token generation V1 event is missing a required field', () => {
-    // Prepare
-    const event = {
-      ...basePreTokenGenEventV1,
-      request: omit(
-        ['groupConfiguration'],
-        structuredClone(basePreTokenGenEventV1.request)
-      ),
+      userNotFound: false,
     };
-    // Act & Assess
-    expect(() => PreTokenGenerationTriggerSchemaV1.parse(event)).toThrow();
-  });
-});
 
-describe('Schema: Cognito PreTokenGenerationTrigger V2', () => {
-  // Prepare
-  const basePreTokenGenEventV2 = {
-    request: {
-      userAttributes: {
-        email: 'user@example.com',
-        name: 'John Doe',
-      },
-      scopes: ['openid', 'email'],
-      groupConfiguration: {
-        groupsToOverride: ['group1', 'group2'],
-        iamRolesToOverride: ['role1', 'role2'],
-        preferredRole: 'role1',
-      },
-      clientMetadata: {
-        key1: 'value1',
-      },
-    },
-    response: {
-      claimsAndScopeOverrideDetails: {
-        idTokenGeneration: {
-          claimsToAddOrOverride: {
-            customClaim: 'customValue',
-          },
-          claimsToSuppress: ['email'],
-        },
-        accessTokenGeneration: {
-          claimsToAddOrOverride: {
-            customClaim: 'customValue',
-          },
-          claimsToSuppress: ['email'],
-          scopesToAdd: ['openid', 'profile'],
-          scopesToSuppress: ['phone'],
-        },
-        groupOverrideDetails: {
-          groupsToOverride: ['newGroup1', 'newGroup2'],
-          iamRolesToOverride: ['newRole1', 'newRole2'],
-          preferredRole: 'newRole1',
-        },
-      },
-    },
-  };
-
-  it('parses a valid pre-token generation V2 event', () => {
-    // Prepare
-    const event = structuredClone(basePreTokenGenEventV2);
     // Act
-    const result = PreTokenGenerationTriggerSchemaV2.safeParse(event);
+    const result = PreAuthenticationTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
+    expect(result).toEqual(event);
   });
 
-  it('throws if the pre-token generation V2 event is missing a required field', () => {
+  it('throws if the pre-authentication event is missing a required field', () => {
     // Prepare
-    const event = {
-      ...basePreTokenGenEventV2,
-      request: omit(
-        ['scopes'],
-        structuredClone(basePreTokenGenEventV2.request)
-      ),
-    };
-    // Act & Assess
-    expect(() => PreTokenGenerationTriggerSchemaV2.parse(event)).toThrow();
-  });
-});
+    const event = structuredClone(baseEvent);
 
-describe('Schema: Cognito MigrateUserTrigger', () => {
-  // Prepare
-  const baseMigrateUserEvent = {
-    userName: 'testuser',
-    request: {
-      password: 'dummyPass123!',
+    // Act & Assess
+    expect(() => PreAuthenticationTriggerSchema.parse(event)).toThrow();
+  });
+
+  it('parses a valid migrate user event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'UserMigration_Authentication';
+    event.request = {
+      password: 'string',
       validationData: {
         key1: 'value1',
       },
       clientMetadata: {
         key2: 'value2',
       },
-    },
-    response: {
-      userAttributes: {
-        email: 'testuser@example.com',
-        name: 'Test User',
-      },
-      finalUserStatus: 'CONFIRMED',
-      messageAction: 'SUPPRESS',
-      desiredDeliveryMediums: ['EMAIL'],
-      forceAliasCreation: true,
-      enableSMSMFA: false,
-    },
-  };
+    };
+    event.response = {
+      userAttributes: null,
+      forceAliasCreation: null,
+      enableSMSMFA: null,
+      finalUserStatus: null,
+      messageAction: null,
+      desiredDeliveryMediums: null,
+    };
 
-  it('parses a valid migrate user event', () => {
-    // Prepare
-    const event = structuredClone(baseMigrateUserEvent);
     // Act
-    const result = MigrateUserTriggerSchema.safeParse(event);
+    const result = MigrateUserTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.userName).toEqual('testuser');
-    }
+    expect(result).toEqual(event);
   });
 
   it('throws if the migrate user event is missing a required field', () => {
     // Prepare
-    const event = omit(['userName'], structuredClone(baseMigrateUserEvent));
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => MigrateUserTriggerSchema.parse(event)).toThrow();
   });
-});
-
-describe('Schema: Cognito CustomMessageTrigger', () => {
-  // Prepare
-  const baseCustomMessageEvent = {
-    request: {
-      userAttributes: { email: 'test@example.com', name: 'Test User' },
-      codeParameter: '####',
-      usernameParameter: 'TestUser',
-      clientMetadata: { key: 'value' },
-    },
-    response: {
-      smsMessage: 'Your code is ####',
-      emailMessage: 'Your verification code is ####',
-      emailSubject: 'Verification',
-    },
-  };
 
   it('parses a valid custom message event', () => {
     // Prepare
-    const event = structuredClone(baseCustomMessageEvent);
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'CustomMessage_SignUp';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+      codeParameter: 'string',
+      usernameParameter: 'string',
+      clientMetadata: {
+        key1: 'value1',
+      },
+      linkParameter: 'string',
+    };
+    event.response = {
+      smsMessage: null,
+      emailMessage: null,
+      emailSubject: null,
+    };
+
     // Act
-    const result = CustomMessageTriggerSchema.safeParse(event);
+    const result = CustomMessageTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
+    expect(result).toEqual(event);
   });
 
   it('throws if the custom message event is missing a required field', () => {
     // Prepare
-    const event = {
-      ...baseCustomMessageEvent,
-      request: omit(
-        ['codeParameter'],
-        structuredClone(baseCustomMessageEvent.request)
-      ),
-    };
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => CustomMessageTriggerSchema.parse(event)).toThrow();
   });
-});
 
-describe('Schema: Cognito CustomEmailSenderTrigger', () => {
-  // Prepare
-  const baseCustomEmailSenderEvent = {
-    request: {
-      type: 'customEmailSenderRequestV1',
-      code: 'encryptedCode',
-      clientMetadata: { key: 'value' },
-      userAttributes: { email: 'test@example.com', name: 'Test User' },
-    },
-    response: {},
-  };
-
-  it('parses a valid custom email sender event', () => {
+  it('parses a valid custom message event with custom email sender', () => {
     // Prepare
-    const event = structuredClone(baseCustomEmailSenderEvent);
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'CustomEmailSender_SignUp';
+    event.request = {
+      type: 'customEmailSenderRequestV1',
+      code: 'string',
+      clientMetadata: {
+        key1: 'value1',
+      },
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+    };
+
     // Act
-    const result = CustomEmailSenderTriggerSchema.safeParse(event);
+    const result = CustomEmailSenderTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.response).toEqual({});
-    }
+    expect(result).toEqual(event);
   });
 
-  it('throws if the custom email sender event is missing a required field', () => {
+  it('throws if the custom message event with custom email sender is missing a required field', () => {
     // Prepare
-    const event = {
-      ...baseCustomEmailSenderEvent,
-      request: omit(
-        ['code'],
-        structuredClone(baseCustomEmailSenderEvent.request)
-      ),
-    };
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => CustomEmailSenderTriggerSchema.parse(event)).toThrow();
   });
-});
 
-describe('Schema: Cognito CustomSMSSenderTrigger', () => {
-  // Prepare
-  const baseCustomSMSSenderEvent = {
-    request: {
-      type: 'customSMSSenderRequestV1',
-      code: 'encryptedCode',
-      clientMetadata: { key: 'value' },
-      userAttributes: {
-        phone_number: '+1234567890',
-        email: 'test@example.com',
-      },
-    },
-    response: {},
-  };
-
-  it('parses a valid custom SMS sender event', () => {
+  it('parses a valid custom message event with custom SMS sender', () => {
     // Prepare
-    const event = structuredClone(baseCustomSMSSenderEvent);
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'CustomSMSSender_SignUp';
+    event.request = {
+      type: 'customSMSSenderRequestV1',
+      code: 'string',
+      clientMetadata: {
+        key1: 'value1',
+      },
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+    };
+
     // Act
-    const result = CustomSMSSenderTriggerSchema.safeParse(event);
+    const result = CustomSMSSenderTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
+    expect(result).toEqual(event);
   });
 
-  it('throws if the custom SMS sender event is missing a required field', () => {
+  it('throws if the custom message event with custom SMS sender is missing a required field', () => {
     // Prepare
-    const event = {
-      ...baseCustomSMSSenderEvent,
-      request: omit(
-        ['code'],
-        structuredClone(baseCustomSMSSenderEvent.request)
-      ),
-    };
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
     expect(() => CustomSMSSenderTriggerSchema.parse(event)).toThrow();
   });
-});
 
-describe('Schema: Cognito DefineAuthChallenge', () => {
-  const baseDefineAuthChallengeEvent = {
-    request: {
-      userAttributes: { email: 'user@example.com', name: 'John Doe' },
+  it('parses a valid define auth challenge event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'DefineAuthChallenge_Authentication';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
       session: [
         {
           challengeName: 'SRP_A',
@@ -476,37 +287,32 @@ describe('Schema: Cognito DefineAuthChallenge', () => {
       ],
       clientMetadata: { key: 'value' },
       userNotFound: false,
-    },
-    response: {
-      challengeName: 'PASSWORD_VERIFIER',
-      issueTokens: false,
-      failAuthentication: false,
-    },
-  };
+    };
 
-  it('parses a valid define auth challenge event', () => {
-    const event = structuredClone(baseDefineAuthChallengeEvent);
-    const result = DefineAuthChallengeSchema.safeParse(event);
-    expect(result.success).toBe(true);
+    // Act
+    const result = DefineAuthChallengeTriggerSchema.parse(event);
+
+    // Assess
+    expect(result).toEqual(event);
   });
 
   it('throws if the define auth challenge event is missing a required field', () => {
-    const event = {
-      ...baseDefineAuthChallengeEvent,
-      request: omit(
-        ['userAttributes'],
-        structuredClone(baseDefineAuthChallengeEvent.request)
-      ),
-    };
-    expect(() => DefineAuthChallengeSchema.parse(event)).toThrow();
-  });
-});
+    // Prepare
+    const event = structuredClone(baseEvent);
 
-describe('Schema: Cognito CreateAuthChallenge', () => {
-  // Prepare
-  const baseCreateAuthChallengeEvent = {
-    request: {
-      userAttributes: { email: 'user@example.com', name: 'John Doe' },
+    // Act & Assess
+    expect(() => DefineAuthChallengeTriggerSchema.parse(event)).toThrow();
+  });
+
+  it('parses a valid create auth challenge event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'CreateAuthChallenge_Authentication';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
       challengeName: 'CUSTOM_CHALLENGE',
       session: [
         {
@@ -517,79 +323,84 @@ describe('Schema: Cognito CreateAuthChallenge', () => {
       ],
       clientMetadata: { key: 'value' },
       userNotFound: false,
-    },
-    response: {
-      publicChallengeParameters: { captchaUrl: 'url/123.jpg' },
-      privateChallengeParameters: { answer: '5' },
-      challengeMetadata: 'custom metadata',
-    },
-  };
+    };
 
-  it('parses a valid create auth challenge event', () => {
-    // Prepare
-    const event = structuredClone(baseCreateAuthChallengeEvent);
     // Act
-    const result = CreateAuthChallengeSchema.safeParse(event);
+    const result = CreateAuthChallengeTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.response.publicChallengeParameters.captchaUrl).toEqual(
-        'url/123.jpg'
-      );
-    }
+    expect(result).toEqual(event);
   });
 
   it('throws if the create auth challenge event is missing a required field', () => {
     // Prepare
-    const event = {
-      ...baseCreateAuthChallengeEvent,
-      request: omit(
-        ['challengeName'],
-        structuredClone(baseCreateAuthChallengeEvent.request)
-      ),
-    };
-    // Act & Assess
-    expect(() => CreateAuthChallengeSchema.parse(event)).toThrow();
-  });
-});
+    const event = structuredClone(baseEvent);
 
-describe('Schema: Cognito VerifyAuthChallenge', () => {
-  // Prepare
-  const baseVerifyAuthChallengeEvent = {
-    request: {
-      userAttributes: { email: 'user@example.com', name: 'John Doe' },
+    // Act & Assess
+    expect(() => CreateAuthChallengeTriggerSchema.parse(event)).toThrow();
+  });
+
+  it('parses a valid verify auth challenge event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'VerifyAuthChallengeResponse_Authentication';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
       privateChallengeParameters: { answer: 'expectedAnswer' },
       challengeAnswer: 'expectedAnswer',
       clientMetadata: { key: 'value' },
       userNotFound: false,
-    },
-    response: {
+    };
+    event.response = {
       answerCorrect: true,
-    },
-  };
+    };
 
-  it('parses a valid verify auth challenge event', () => {
-    // Prepare
-    const event = structuredClone(baseVerifyAuthChallengeEvent);
     // Act
-    const result = VerifyAuthChallengeSchema.safeParse(event);
+    const result = VerifyAuthChallengeTriggerSchema.parse(event);
+
     // Assess
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.response.answerCorrect).toBe(true);
-    }
+    expect(result).toEqual(event);
   });
 
   it('throws if the verify auth challenge event is missing a required field', () => {
     // Prepare
-    const event = {
-      ...baseVerifyAuthChallengeEvent,
-      request: omit(
-        ['privateChallengeParameters'],
-        structuredClone(baseVerifyAuthChallengeEvent.request)
-      ),
-    };
+    const event = structuredClone(baseEvent);
+
     // Act & Assess
-    expect(() => VerifyAuthChallengeSchema.parse(event)).toThrow();
+    expect(() => VerifyAuthChallengeTriggerSchema.parse(event)).toThrow();
+  });
+
+  it('parses a valid pre-token generation event v1', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+      groupConfiguration: {
+        groupsToOverride: ['group1', 'group2'],
+        iamRolesToOverride: ['role1', 'role2'],
+        preferredRole: 'role1',
+      },
+      clientMetadata: { key: 'value' },
+    };
+
+    // Act
+    const result = PreTokenGenerationTriggerSchemaV1.parse(event);
+
+    // Assess
+    expect(result).toEqual(event);
+  });
+
+  it('throws if the pre-token generation event v1 is missing a required field', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+
+    // Act & Assess
+    expect(() => PreTokenGenerationTriggerSchemaV1.parse(event)).toThrow();
   });
 });

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { PreSignupTriggerSchema } from '../../../src/schemas/cognito.js';
+import {
+  CreateAuthChallengeSchema,
+  CustomEmailSenderTriggerSchema,
+  CustomMessageTriggerSchema,
+  CustomSMSSenderTriggerSchema,
+  DefineAuthChallengeSchema,
+  MigrateUserTriggerSchema,
+  PostAuthenticationTriggerSchema,
+  PostConfirmationTriggerSchema,
+  PreAuthenticationTriggerSchema,
+  PreSignupTriggerSchema,
+  PreTokenGenerationTriggerSchemaV1,
+  PreTokenGenerationTriggerSchemaV2,
+  VerifyAuthChallengeSchema,
+} from '../../../src/schemas/cognito.js';
 import { omit } from '../helpers/utils.js';
 
 describe('Schema: Cognito PreSignupTrigger', () => {
   // Prepare
-  const baseEvent = {
+  const basePreSignupEvent = {
     version: '1',
     region: 'us-east-1',
     userPoolId: 'us-east-1_ABC123',
@@ -20,6 +34,9 @@ describe('Schema: Cognito PreSignupTrigger', () => {
         name: 'John Doe',
       },
       validationData: null,
+      clientMetadata: {
+        someKey: 'someValue',
+      },
     },
     response: {
       autoConfirmUser: true,
@@ -30,7 +47,7 @@ describe('Schema: Cognito PreSignupTrigger', () => {
 
   it('parses a valid pre-signup event', () => {
     // Prepare
-    const event = structuredClone(baseEvent);
+    const event = structuredClone(basePreSignupEvent);
     // Act
     const result = PreSignupTriggerSchema.safeParse(event);
     // Assess
@@ -40,10 +57,539 @@ describe('Schema: Cognito PreSignupTrigger', () => {
     }
   });
 
-  it('throws if the event is missing a required field', () => {
+  it('throws if the pre-signup event is missing a required field', () => {
     // Prepare
-    const event = omit(['userName'], structuredClone(baseEvent));
+    const event = omit(['userName'], structuredClone(basePreSignupEvent));
     // Act & Assess
     expect(() => PreSignupTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito PostConfirmationTrigger', () => {
+  // Prepare
+  const basePostConfirmationEvent = {
+    request: {
+      userAttributes: {
+        email: 'user@example.com',
+        name: 'John Doe',
+      },
+      clientMetadata: {
+        customKey: 'customValue',
+      },
+    },
+    response: {},
+  };
+
+  it('parses a valid post-confirmation event', () => {
+    // Prepare
+    const event = structuredClone(basePostConfirmationEvent);
+    // Act
+    const result = PostConfirmationTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the post-confirmation event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...basePostConfirmationEvent,
+      request: omit(
+        ['userAttributes'],
+        structuredClone(basePostConfirmationEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => PostConfirmationTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito PreAuthenticationTrigger', () => {
+  // Prepare
+  const basePreAuthEvent = {
+    request: {
+      userAttributes: {
+        email: 'user@example.com',
+        name: 'John Doe',
+      },
+      validationData: {
+        someKey: 'someValue',
+      },
+      userNotFound: false,
+    },
+    response: {},
+  };
+
+  it('parses a valid pre-authentication event', () => {
+    // Prepare
+    const event = structuredClone(basePreAuthEvent);
+    // Act
+    const result = PreAuthenticationTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the pre-authentication event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...basePreAuthEvent,
+      request: omit(
+        ['userAttributes'],
+        structuredClone(basePreAuthEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => PreAuthenticationTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito PostAuthenticationTrigger', () => {
+  // Prepare
+  const basePostAuthEvent = {
+    request: {
+      userAttributes: {
+        email: 'user@example.com',
+        name: 'John Doe',
+      },
+      newDeviceUsed: true,
+      clientMetadata: {
+        customKey: 'customValue',
+      },
+    },
+    response: {},
+  };
+
+  it('parses a valid post-authentication event', () => {
+    // Prepare
+    const event = structuredClone(basePostAuthEvent);
+    // Act
+    const result = PostAuthenticationTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the post-authentication event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...basePostAuthEvent,
+      request: omit(
+        ['newDeviceUsed'],
+        structuredClone(basePostAuthEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => PostAuthenticationTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito PreTokenGenerationTrigger V1', () => {
+  // Prepare
+  const basePreTokenGenEventV1 = {
+    request: {
+      userAttributes: {
+        email: 'user@example.com',
+        name: 'John Doe',
+      },
+      groupConfiguration: {
+        groupsToOverride: ['group1', 'group2'],
+        iamRolesToOverride: ['role1', 'role2'],
+        preferredRole: 'role1',
+      },
+      clientMetadata: {
+        key1: 'value1',
+      },
+    },
+    response: {
+      claimsOverrideDetails: {
+        claimsToAddOrOverride: {
+          customClaim: 'customValue',
+        },
+        claimsToSuppress: ['email'],
+        groupOverrideDetails: {
+          groupsToOverride: ['newGroup1', 'newGroup2'],
+          iamRolesToOverride: ['newRole1', 'newRole2'],
+          preferredRole: 'newRole1',
+        },
+      },
+    },
+  };
+
+  it('parses a valid pre-token generation V1 event', () => {
+    // Prepare
+    const event = structuredClone(basePreTokenGenEventV1);
+    // Act
+    const result = PreTokenGenerationTriggerSchemaV1.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the pre-token generation V1 event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...basePreTokenGenEventV1,
+      request: omit(
+        ['groupConfiguration'],
+        structuredClone(basePreTokenGenEventV1.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => PreTokenGenerationTriggerSchemaV1.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito PreTokenGenerationTrigger V2', () => {
+  // Prepare
+  const basePreTokenGenEventV2 = {
+    request: {
+      userAttributes: {
+        email: 'user@example.com',
+        name: 'John Doe',
+      },
+      scopes: ['openid', 'email'],
+      groupConfiguration: {
+        groupsToOverride: ['group1', 'group2'],
+        iamRolesToOverride: ['role1', 'role2'],
+        preferredRole: 'role1',
+      },
+      clientMetadata: {
+        key1: 'value1',
+      },
+    },
+    response: {
+      claimsAndScopeOverrideDetails: {
+        idTokenGeneration: {
+          claimsToAddOrOverride: {
+            customClaim: 'customValue',
+          },
+          claimsToSuppress: ['email'],
+        },
+        accessTokenGeneration: {
+          claimsToAddOrOverride: {
+            customClaim: 'customValue',
+          },
+          claimsToSuppress: ['email'],
+          scopesToAdd: ['openid', 'profile'],
+          scopesToSuppress: ['phone'],
+        },
+        groupOverrideDetails: {
+          groupsToOverride: ['newGroup1', 'newGroup2'],
+          iamRolesToOverride: ['newRole1', 'newRole2'],
+          preferredRole: 'newRole1',
+        },
+      },
+    },
+  };
+
+  it('parses a valid pre-token generation V2 event', () => {
+    // Prepare
+    const event = structuredClone(basePreTokenGenEventV2);
+    // Act
+    const result = PreTokenGenerationTriggerSchemaV2.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the pre-token generation V2 event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...basePreTokenGenEventV2,
+      request: omit(
+        ['scopes'],
+        structuredClone(basePreTokenGenEventV2.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => PreTokenGenerationTriggerSchemaV2.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito MigrateUserTrigger', () => {
+  // Prepare
+  const baseMigrateUserEvent = {
+    userName: 'testuser',
+    request: {
+      password: 'TestPass123!',
+      validationData: {
+        key1: 'value1',
+      },
+      clientMetadata: {
+        key2: 'value2',
+      },
+    },
+    response: {
+      userAttributes: {
+        email: 'testuser@example.com',
+        name: 'Test User',
+      },
+      finalUserStatus: 'CONFIRMED',
+      messageAction: 'SUPPRESS',
+      desiredDeliveryMediums: ['EMAIL'],
+      forceAliasCreation: true,
+      enableSMSMFA: false,
+    },
+  };
+
+  it('parses a valid migrate user event', () => {
+    // Prepare
+    const event = structuredClone(baseMigrateUserEvent);
+    // Act
+    const result = MigrateUserTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.userName).toEqual('testuser');
+    }
+  });
+
+  it('throws if the migrate user event is missing a required field', () => {
+    // Prepare
+    const event = omit(['userName'], structuredClone(baseMigrateUserEvent));
+    // Act & Assess
+    expect(() => MigrateUserTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito CustomMessageTrigger', () => {
+  // Prepare
+  const baseCustomMessageEvent = {
+    request: {
+      userAttributes: { email: 'test@example.com', name: 'Test User' },
+      codeParameter: '####',
+      usernameParameter: 'TestUser',
+      clientMetadata: { key: 'value' },
+    },
+    response: {
+      smsMessage: 'Your code is ####',
+      emailMessage: 'Your verification code is ####',
+      emailSubject: 'Verification',
+    },
+  };
+
+  it('parses a valid custom message event', () => {
+    // Prepare
+    const event = structuredClone(baseCustomMessageEvent);
+    // Act
+    const result = CustomMessageTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the custom message event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...baseCustomMessageEvent,
+      request: omit(
+        ['codeParameter'],
+        structuredClone(baseCustomMessageEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => CustomMessageTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito CustomEmailSenderTrigger', () => {
+  // Prepare
+  const baseCustomEmailSenderEvent = {
+    request: {
+      type: 'customEmailSenderRequestV1',
+      code: 'encryptedCode',
+      clientMetadata: { key: 'value' },
+      userAttributes: { email: 'test@example.com', name: 'Test User' },
+    },
+    response: {},
+  };
+
+  it('parses a valid custom email sender event', () => {
+    // Prepare
+    const event = structuredClone(baseCustomEmailSenderEvent);
+    // Act
+    const result = CustomEmailSenderTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.response).toEqual({});
+    }
+  });
+
+  it('throws if the custom email sender event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...baseCustomEmailSenderEvent,
+      request: omit(
+        ['code'],
+        structuredClone(baseCustomEmailSenderEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => CustomEmailSenderTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito CustomSMSSenderTrigger', () => {
+  // Prepare
+  const baseCustomSMSSenderEvent = {
+    request: {
+      type: 'customSMSSenderRequestV1',
+      code: 'encryptedCode',
+      clientMetadata: { key: 'value' },
+      userAttributes: {
+        phone_number: '+1234567890',
+        email: 'test@example.com',
+      },
+    },
+    response: {},
+  };
+
+  it('parses a valid custom SMS sender event', () => {
+    // Prepare
+    const event = structuredClone(baseCustomSMSSenderEvent);
+    // Act
+    const result = CustomSMSSenderTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the custom SMS sender event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...baseCustomSMSSenderEvent,
+      request: omit(
+        ['code'],
+        structuredClone(baseCustomSMSSenderEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => CustomSMSSenderTriggerSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito DefineAuthChallenge', () => {
+  const baseDefineAuthChallengeEvent = {
+    request: {
+      userAttributes: { email: 'user@example.com', name: 'John Doe' },
+      session: [
+        {
+          challengeName: 'SRP_A',
+          challengeResult: true,
+          challengeMetadata: 'metadata',
+        },
+      ],
+      clientMetadata: { key: 'value' },
+      userNotFound: false,
+    },
+    response: {
+      challengeName: 'PASSWORD_VERIFIER',
+      issueTokens: false,
+      failAuthentication: false,
+    },
+  };
+
+  it('parses a valid define auth challenge event', () => {
+    const event = structuredClone(baseDefineAuthChallengeEvent);
+    const result = DefineAuthChallengeSchema.safeParse(event);
+    expect(result.success).toBe(true);
+  });
+
+  it('throws if the define auth challenge event is missing a required field', () => {
+    const event = {
+      ...baseDefineAuthChallengeEvent,
+      request: omit(
+        ['userAttributes'],
+        structuredClone(baseDefineAuthChallengeEvent.request)
+      ),
+    };
+    expect(() => DefineAuthChallengeSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito CreateAuthChallenge', () => {
+  // Prepare
+  const baseCreateAuthChallengeEvent = {
+    request: {
+      userAttributes: { email: 'user@example.com', name: 'John Doe' },
+      challengeName: 'CUSTOM_CHALLENGE',
+      session: [
+        {
+          challengeName: 'SRP_A',
+          challengeResult: true,
+          challengeMetadata: 'metadata',
+        },
+      ],
+      clientMetadata: { key: 'value' },
+      userNotFound: false,
+    },
+    response: {
+      publicChallengeParameters: { captchaUrl: 'url/123.jpg' },
+      privateChallengeParameters: { answer: '5' },
+      challengeMetadata: 'custom metadata',
+    },
+  };
+
+  it('parses a valid create auth challenge event', () => {
+    // Prepare
+    const event = structuredClone(baseCreateAuthChallengeEvent);
+    // Act
+    const result = CreateAuthChallengeSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.response.publicChallengeParameters.captchaUrl).toEqual(
+        'url/123.jpg'
+      );
+    }
+  });
+
+  it('throws if the create auth challenge event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...baseCreateAuthChallengeEvent,
+      request: omit(
+        ['challengeName'],
+        structuredClone(baseCreateAuthChallengeEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => CreateAuthChallengeSchema.parse(event)).toThrow();
+  });
+});
+
+describe('Schema: Cognito VerifyAuthChallenge', () => {
+  // Prepare
+  const baseVerifyAuthChallengeEvent = {
+    request: {
+      userAttributes: { email: 'user@example.com', name: 'John Doe' },
+      privateChallengeParameters: { answer: 'expectedAnswer' },
+      challengeAnswer: 'expectedAnswer',
+      clientMetadata: { key: 'value' },
+      userNotFound: false,
+    },
+    response: {
+      answerCorrect: true,
+    },
+  };
+
+  it('parses a valid verify auth challenge event', () => {
+    // Prepare
+    const event = structuredClone(baseVerifyAuthChallengeEvent);
+    // Act
+    const result = VerifyAuthChallengeSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.response.answerCorrect).toBe(true);
+    }
+  });
+
+  it('throws if the verify auth challenge event is missing a required field', () => {
+    // Prepare
+    const event = {
+      ...baseVerifyAuthChallengeEvent,
+      request: omit(
+        ['privateChallengeParameters'],
+        structuredClone(baseVerifyAuthChallengeEvent.request)
+      ),
+    };
+    // Act & Assess
+    expect(() => VerifyAuthChallengeSchema.parse(event)).toThrow();
   });
 });

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -3,7 +3,7 @@ import { PreSignupTriggerSchema } from '../../../src/schemas/cognito.js';
 import { omit } from '../helpers/utils.js';
 
 describe('Schema: Cognito PreSignupTrigger', () => {
-  // Prepare: Define a valid Cognito pre-signup event inline
+  // Prepare
   const baseEvent = {
     version: '1',
     region: 'us-east-1',

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { PreSignupTriggerSchema } from '../../../src/schemas/cognito.js';
+import { omit } from '../helpers/utils.js';
+
+describe('Schema: Cognito PreSignupTrigger', () => {
+  // Prepare: Define a valid Cognito pre-signup event inline
+  const baseEvent = {
+    version: '1',
+    region: 'us-east-1',
+    userPoolId: 'us-east-1_ABC123',
+    userName: 'johndoe',
+    callerContext: {
+      awsSdkVersion: '2.814.0',
+      clientId: 'client123',
+    },
+    triggerSource: 'PreSignUp_SignUp',
+    request: {
+      userAttributes: {
+        email: 'johndoe@example.com',
+        name: 'John Doe',
+      },
+      validationData: null,
+    },
+    response: {
+      autoConfirmUser: true,
+      autoVerifyEmail: false,
+      autoVerifyPhone: false,
+    },
+  };
+
+  it('parses a valid pre-signup event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    // Act
+    const result = PreSignupTriggerSchema.safeParse(event);
+    // Assess
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.userName).toEqual('johndoe');
+    }
+  });
+
+  it('throws if the event is missing a required field', () => {
+    // Prepare
+    const event = omit(['userName'], structuredClone(baseEvent));
+    // Act & Assess
+    expect(() => PreSignupTriggerSchema.parse(event)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

### Changes

This PR adds comprehensive Cognito trigger schemas to the Parser utility. The new schemas are implemented using Zod and ensure that AWS Cognito Lambda triggers conform to the expected event structures. The updates cover all 12 trigger types, including:

Pre-Signup Trigger: Validates events when users sign up.
Post-Confirmation Trigger: Validates events after user confirmation.
Pre-Authentication Trigger: Validates events prior to authentication.
Post-Authentication Trigger: Validates events after authentication.
Pre-Token Generation Trigger (V1 & V2): Validates events before token generation.
Migrate User Trigger: Validates events for user migration during sign-in or forgot-password flows.
Custom Message Trigger: Validates events for custom message modifications.
Custom Email Sender Trigger: Validates events for custom email sender functions (with an empty response object).
Custom SMS Sender Trigger: Validates events for custom SMS sender functions.
Define Auth Challenge Trigger: Validates events for initiating a custom auth challenge flow.
Create Auth Challenge Trigger: Validates events that create challenge details for custom authentication.
Verify Auth Challenge Trigger: Validates events that verify the user’s answer to a custom challenge.

Key changes include:
Implemented the new schemas in packages/parser/src/schemas/cognito.ts using Zod.
Updated packages/parser/src/schemas/index.ts to export all new Cognito trigger schemas.
Added and updated unit tests in packages/parser/tests/unit/schemas/cognito.test.ts to cover valid and invalid event payloads using the Prepare/Act/Assess format.
Ensured 100% test coverage for the new schemas.
Resolved Node.js import issues in index files to meet repository linting standards.
Issue number: #3675

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.

Disclaimer: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
