### PR TITLE
test: fix transient fails in log sampling tests

### DIFF
--- a/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.FunctionCode.ts
@@ -9,23 +9,12 @@ const LOG_MSG = process.env.LOG_MSG || 'Hello World';
 const logger = new Logger({
   sampleRateValue: SAMPLE_RATE,
 });
-let firstInvocation = true;
 
 class Lambda implements LambdaInterface {
-  private readonly logMsg: string;
+  private readonly logMsg = LOG_MSG;
 
-  public constructor() {
-    this.logMsg = LOG_MSG;
-  }
-
-  // Decorate your handler class method
   @logger.injectLambdaContext()
   public async handler(_event: TestEvent, context: Context): TestOutput {
-    if (firstInvocation) {
-      firstInvocation = false;
-    } else {
-      logger.refreshSampleRateCalculation();
-    }
     this.printLogInAllLevels();
 
     return {

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.ts
@@ -5,7 +5,7 @@ import {
   TestStack,
   invokeFunction,
 } from '@aws-lambda-powertools/testing-utils';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { LoggerTestNodejsFunction } from '../helpers/resources.js';
 import {
   RESOURCE_NAME_PREFIX,
@@ -14,10 +14,6 @@ import {
   TEARDOWN_TIMEOUT,
   TEST_CASE_TIMEOUT,
 } from './constants.js';
-
-vi.hoisted(() => {
-  process.env.AWS_PROFILE = 'aamorosi-Admin';
-});
 
 describe('Logger E2E tests, sample rate and injectLambdaContext()', () => {
   const testStack = new TestStack({

--- a/packages/logger/tests/e2e/sampleRate.decorator.test.ts
+++ b/packages/logger/tests/e2e/sampleRate.decorator.test.ts
@@ -5,7 +5,7 @@ import {
   TestStack,
   invokeFunction,
 } from '@aws-lambda-powertools/testing-utils';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { LoggerTestNodejsFunction } from '../helpers/resources.js';
 import {
   RESOURCE_NAME_PREFIX,
@@ -14,6 +14,10 @@ import {
   TEARDOWN_TIMEOUT,
   TEST_CASE_TIMEOUT,
 } from './constants.js';
+
+vi.hoisted(() => {
+  process.env.AWS_PROFILE = 'aamorosi-Admin';
+});
 
 describe('Logger E2E tests, sample rate and injectLambdaContext()', () => {
   const testStack = new TestStack({


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the e2e test for Logger, related to log sampling, to account for the new mechanism introduced in #3278. The test was using the decorator - which now refreshes the sampling calculation at each request - but was also calling the refresh method manually, which caused double sampling in some cases and causing the test to fail.

As a side quest, I also slightly improved the logs for the e2e tests. In #3665 we adopted a new CLI toolkit and back then I silenced most of the logs except when running in debug mode. Over time I realized that I'd have preferred to have some indication that the stacks were being created/destroyed, so I improved the logs to do that. Now they look like this:

![image](https://github.com/user-attachments/assets/624837dc-9ea7-4ed0-8c51-f030ac6f497d)

Enabling debug mode when re-running still prints out everything.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3735

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
