### PR TITLE
fix(ci): Switch GovCloud publish-layer-version to --cli-input-json

### DIFF
--- a/.github/workflows/layers_govcloud.yml
+++ b/.github/workflows/layers_govcloud.yml
@@ -101,12 +101,16 @@ jobs:
       - name: Create Layer
         id: create-layer
         run: |
-          LAYER_VERSION=$(aws --region us-gov-east-1 lambda publish-layer-version \
-            --layer-name AWSLambdaPowertoolsTypeScriptV2 \
+          cat AWSLambdaPowertoolsTypeScriptV2.json | jq '{
+            "LayerName": "AWSLambdaPowertoolsTypeScriptV2",
+            "Description": .Description,
+            "CompatibleRuntimes": .CompatibleRuntimes,
+            "LicenseInfo": .LicenseInfo
+          }' > input.json
+        
+          LAYER_VERSION=$(aws --region us-gov-west-1 lambda publish-layer-version \
             --zip-file fileb://./AWSLambdaPowertoolsTypeScriptV2.zip \
-            --compatible-runtimes "$(echo \"$(jq -r  '.CompatibleRuntimes | join(" ")' 'AWSLambdaPowertoolsTypeScriptV2.json')\" | sed -e "s/ /\" \"/g")" \
-            --license-info "MIT-0" \
-            --description "$(jq -r '.Description' 'AWSLambdaPowertoolsTypeScriptV2.json')" \
+            --cli-input-json file://./input.json
             --query 'Version' \
             --output text)
 
@@ -125,8 +129,12 @@ jobs:
           REMOTE_SHA=$(aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' --query 'Content.CodeSha256' --output text)
           SHA=$(jq -r '.Content.CodeSha256' 'AWSLambdaPowertoolsTypeScriptV2.json')
           test "$REMOTE_SHA" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
-          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' --output table
-
+          aws --region us-gov-east-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-east-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' > govcloud.json
+          echo ::notice::GovCloud Details
+          cat govcloud.json | jq -r '{"Layer Version Arn": .LayerVersionArn, "Version": .Version, "Description": .Description, "Compatible Runtimes": .CompatibleRuntimes, "SHA": .Content.CodeSha256} | keys[] as $k | [$k, .[$k]] | @tsv' | column -t -s $'\t'
+          echo ::notice::Commercial Details
+          cat AWSLambdaPowertoolsTypeScriptV2.json | jq -r '{"Layer Version Arn": .LayerVersionArn, "Version": .Version, "Description": .Description, "Compatible Runtimes": .CompatibleRuntimes, "SHA": .Content.CodeSha256} | keys[] as $k | [$k, .[$k]] | @tsv' | column -t -s $'\t'
+          
   copy_west:
     name: Copy (West)
     needs: download
@@ -158,12 +166,16 @@ jobs:
       - name: Create Layer
         id: create-layer
         run: |
+          cat AWSLambdaPowertoolsTypeScriptV2.json | jq '{
+            "LayerName": "AWSLambdaPowertoolsTypeScriptV2",
+            "Description": .Description,
+            "CompatibleRuntimes": .CompatibleRuntimes,
+            "LicenseInfo": .LicenseInfo
+          }' > input.json
+        
           LAYER_VERSION=$(aws --region us-gov-west-1 lambda publish-layer-version \
-            --layer-name AWSLambdaPowertoolsTypeScriptV2 \
             --zip-file fileb://./AWSLambdaPowertoolsTypeScriptV2.zip \
-            --compatible-runtimes "$(echo \"$(jq -r  '.CompatibleRuntimes | join(" ")' 'AWSLambdaPowertoolsTypeScriptV2.json')\" | sed -e "s/ /\" \"/g")" \
-            --license-info "MIT-0" \
-            --description "$(jq -r '.Description' 'AWSLambdaPowertoolsTypeScriptV2.json')" \
+            --cli-input-json file://./input.json
             --query 'Version' \
             --output text)
 
@@ -182,4 +194,8 @@ jobs:
           REMOTE_SHA=$(aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' --query 'Content.CodeSha256' --output text)
           SHA=$(jq -r '.Content.CodeSha256' 'AWSLambdaPowertoolsTypeScriptV2.json')
           test "$REMOTE_SHA" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
-          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' --output table
+          aws --region us-gov-west-1 lambda get-layer-version-by-arn --arn 'arn:aws-us-gov:lambda:us-gov-west-1:${{ secrets.AWS_ACCOUNT_ID }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' > govcloud.json
+          echo ::notice::GovCloud Details
+          cat govcloud.json | jq -r '{"Layer Version Arn": .LayerVersionArn, "Version": .Version, "Description": .Description, "Compatible Runtimes": .CompatibleRuntimes, "SHA": .Content.CodeSha256} | keys[] as $k | [$k, .[$k]] | @tsv' | column -t -s $'\t'
+          echo ::notice::Commercial Details
+          cat AWSLambdaPowertoolsTypeScriptV2.json | jq -r '{"Layer Version Arn": .LayerVersionArn, "Version": .Version, "Description": .Description, "Compatible Runtimes": .CompatibleRuntimes, "SHA": .Content.CodeSha256} | keys[] as $k | [$k, .[$k]] | @tsv' | column -t -s $'\t'


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

- Moves the `publish-layer-version` command to use `--cli-json-input`
- Improves validation step by outputting a table

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3423 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
