### PR TITLE
feat: make getKey protected on DynamoDbPersistenceLayer

### DIFF
--- a/packages/idempotency/src/persistence/DynamoDBPersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/DynamoDBPersistenceLayer.ts
@@ -272,7 +272,7 @@ class DynamoDBPersistenceLayer extends BasePersistenceLayer {
    *
    * @param idempotencyKey
    */
-  private getKey(idempotencyKey: string): Record<string, AttributeValue> {
+  protected getKey(idempotencyKey: string): Record<string, AttributeValue> {
     if (this.sortKeyAttr) {
       return marshall({
         [this.keyAttr]: this.staticPkValue,


### PR DESCRIPTION
## Summary
Makes getKey protected so that deriving classes can determine their own key strategy.

### Changes

Makes getKey protected so that deriving classes can determine their own key strategy.


> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3781

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
