### PR TITLE
fix(logger): warn only once on ALC log level mismatch

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -237,6 +237,11 @@ class Logger extends Utility implements LoggerInterface {
   };
 
   /**
+   * Map used to store the warning messages that have already been logged.
+   */
+  readonly #warnOnceMap = new Map<string, boolean>();
+
+  /**
    * Log level used by the current instance of Logger.
    *
    * Returns the log level as a number. The higher the number, the less verbose the logs.
@@ -715,6 +720,17 @@ class Logger extends Utility implements LoggerInterface {
   }
 
   /**
+   * Log a warning message once per unique message.
+   *
+   * @param message - The log message.
+   */
+  #warnOnce(message: string): void {
+    if (this.#warnOnceMap.has(message)) return;
+    this.#warnOnceMap.set(message, true);
+    this.warn(message);
+  }
+
+  /**
    * Factory method for instantiating logger instances. Used by `createChild` method.
    * Important for customization and subclassing. It allows subclasses, like `MyOwnLogger`,
    * to override its behavior while keeping the main business logic in `createChild` intact.
@@ -811,7 +827,7 @@ class Logger extends Utility implements LoggerInterface {
         this.isValidLogLevel(selectedLogLevel) &&
         this.logLevel > LogLevelThreshold[selectedLogLevel]
       ) {
-        this.warn(
+        this.#warnOnce(
           `Current log level (${selectedLogLevel}) does not match AWS Lambda Advanced Logging Controls minimum log level (${awsLogLevel}). This can lead to data loss, consider adjusting them.`
         );
       }
@@ -1153,7 +1169,10 @@ class Logger extends Utility implements LoggerInterface {
   private setInitialLogLevel(logLevel?: ConstructorOptions['logLevel']): void {
     const constructorLogLevel = logLevel?.toUpperCase();
 
-    if (this.awsLogLevelShortCircuit(constructorLogLevel)) return;
+    if (this.awsLogLevelShortCircuit(constructorLogLevel)) {
+      this.#initialLogLevel = this.logLevel;
+      return;
+    }
 
     if (this.isValidLogLevel(constructorLogLevel)) {
       this.logLevel = LogLevelThreshold[constructorLogLevel];
@@ -1483,7 +1502,7 @@ class Logger extends Utility implements LoggerInterface {
   public setCorrelationId(value: unknown, correlationIdPath?: string): void {
     if (typeof correlationIdPath === 'string') {
       if (!this.#correlationIdSearchFn) {
-        this.warn(
+        this.#warnOnce(
           'correlationIdPath is set but no search function was provided. The correlation ID will not be added to the log attributes.'
         );
         return;

--- a/packages/logger/tests/unit/injectLambdaContext.test.ts
+++ b/packages/logger/tests/unit/injectLambdaContext.test.ts
@@ -297,7 +297,7 @@ describe('Inject Lambda Context', () => {
     expect(logger.getCorrelationId()).toBe('12345-test-id');
   });
 
-  it('warns when correlationIdPath is provided but no search function is available', async () => {
+  it('warns once when correlationIdPath is provided but no search function is available', async () => {
     // Prepare
     const logger = new Logger(); // No search function provided
     const warnSpy = vi.spyOn(logger, 'warn');
@@ -306,7 +306,7 @@ describe('Inject Lambda Context', () => {
         'x-correlation-id': '12345-test-id',
       },
     };
-    // Act - Use middleware which will internally call setCorrelationIdFromPath
+    // Act
     const handler = middy(async () => {
       logger.info('Hello, world!');
     }).use(
@@ -316,11 +316,13 @@ describe('Inject Lambda Context', () => {
     );
 
     await handler(testEvent, context);
+    await handler(testEvent, context);
 
     // Assess
     expect(warnSpy).toHaveBeenCalledWith(
       'correlationIdPath is set but no search function was provided. The correlation ID will not be added to the log attributes.'
     );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does not set correlation ID when search function returns falsy value', async () => {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR implements a new internal behavior for Logger that adds the ability to log a warning only once per logger instance.

Besides the new behavior described above, the PR also addresses another bug described in the linked issue which caused the Logger to not save the Advanced Logging Controls log level upon initialization, which in turns caused the warning to be emitted when log sampling was refreshed.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3815

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
