### PR TITLE
fix(logger): warn customers when the ALC log level is less verbose than log buffer

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -133,6 +133,13 @@ class Logger extends Utility implements LoggerInterface {
    * Log level used internally by the current instance of Logger.
    */
   private logLevel: number = LogLevelThreshold.INFO;
+
+  /**
+   * Advanced Logging Control Log Level
+   * If not a valid value this will be left undefined, even if the
+   * environment variable AWS_LAMBDA_LOG_LEVEL is set
+   */
+  #alcLogLevel?: Uppercase<LogLevel>;
   /**
    * Persistent log attributes that will be logged in all log items.
    */
@@ -819,16 +826,15 @@ class Logger extends Utility implements LoggerInterface {
   }
 
   private awsLogLevelShortCircuit(selectedLogLevel?: string): boolean {
-    const awsLogLevel = this.getEnvVarsService().getAwsLogLevel();
-    if (this.isValidLogLevel(awsLogLevel)) {
-      this.logLevel = LogLevelThreshold[awsLogLevel];
+    if (this.#alcLogLevel !== undefined) {
+      this.logLevel = LogLevelThreshold[this.#alcLogLevel];
 
       if (
         this.isValidLogLevel(selectedLogLevel) &&
         this.logLevel > LogLevelThreshold[selectedLogLevel]
       ) {
         this.#warnOnce(
-          `Current log level (${selectedLogLevel}) does not match AWS Lambda Advanced Logging Controls minimum log level (${awsLogLevel}). This can lead to data loss, consider adjusting them.`
+          `Current log level (${selectedLogLevel}) does not match AWS Lambda Advanced Logging Controls minimum log level (${this.#alcLogLevel}). This can lead to data loss, consider adjusting them.`
         );
       }
 
@@ -1306,6 +1312,11 @@ class Logger extends Utility implements LoggerInterface {
     );
 
     // configurations that affect Logger behavior
+    const AlcLogLevel = this.getEnvVarsService().getAwsLogLevel();
+    if (this.isValidLogLevel(AlcLogLevel)) {
+      this.#alcLogLevel = AlcLogLevel;
+    }
+
     this.setLogEvent();
     this.setInitialLogLevel(logLevel);
     this.setInitialSampleRate(sampleRateValue);
@@ -1378,10 +1389,12 @@ class Logger extends Utility implements LoggerInterface {
       this.#bufferConfig.bufferAtVerbosity =
         LogLevelThreshold[bufferAtLogLevel];
     }
-    const AlcLogLevel =
-      this.getEnvVarsService().getAwsLogLevel() as keyof typeof LogLevelThreshold;
 
-    if (LogLevelThreshold[AlcLogLevel] > this.#bufferConfig.bufferAtVerbosity) {
+    if (
+      this.#alcLogLevel !== undefined &&
+      LogLevelThreshold[this.#alcLogLevel] >
+        this.#bufferConfig.bufferAtVerbosity
+    ) {
       this.#warnOnce(
         'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Buffered logs will be filtered by ALC'
       );
@@ -1451,10 +1464,12 @@ class Logger extends Utility implements LoggerInterface {
         )
       );
     }
-    const AlcLogLevel =
-      this.getEnvVarsService().getAwsLogLevel() as keyof typeof LogLevelThreshold;
 
-    if (LogLevelThreshold[AlcLogLevel] > this.#bufferConfig.bufferAtVerbosity) {
+    if (
+      this.#alcLogLevel !== undefined &&
+      LogLevelThreshold[this.#alcLogLevel] >
+        this.#bufferConfig.bufferAtVerbosity
+    ) {
       this.#warnOnce(
         'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Some logs might be missing.'
       );

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1383,7 +1383,7 @@ class Logger extends Utility implements LoggerInterface {
 
     if (LogLevelThreshold[AlcLogLevel] > this.#bufferConfig.bufferAtVerbosity) {
       this.#warnOnce(
-        'Advanced Loggging Controls (ALC) Log Level is higher than Log Buffering Log Level. Buffered logs will be filtered by ALC'
+        'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Buffered logs will be filtered by ALC'
       );
     }
   }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1378,6 +1378,14 @@ class Logger extends Utility implements LoggerInterface {
       this.#bufferConfig.bufferAtVerbosity =
         LogLevelThreshold[bufferAtLogLevel];
     }
+    const AlcLogLevel =
+      this.getEnvVarsService().getAwsLogLevel() as keyof typeof LogLevelThreshold;
+
+    if (LogLevelThreshold[AlcLogLevel] > this.#bufferConfig.bufferAtVerbosity) {
+      this.#warnOnce(
+        'Advanced Loggging Controls (ALC) Log Level is higher than Log Buffering Log Level. Buffered logs will be filtered by ALC'
+      );
+    }
   }
 
   /**

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1451,6 +1451,14 @@ class Logger extends Utility implements LoggerInterface {
         )
       );
     }
+    const AlcLogLevel =
+      this.getEnvVarsService().getAwsLogLevel() as keyof typeof LogLevelThreshold;
+
+    if (LogLevelThreshold[AlcLogLevel] > this.#bufferConfig.bufferAtVerbosity) {
+      this.#warnOnce(
+        'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Some logs might be missing.'
+      );
+    }
 
     this.#buffer?.delete(traceId);
   }

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -92,7 +92,7 @@ describe('Buffer logs', () => {
     );
   });
 
-  it('outputs a warning when the Advanced Logging Configuration Log Level is higher than the Log Buffering Log Level', () => {
+  it('outputs a warning when the Advanced Logging Configuration Log Level is less verbose than the Log Buffering Log Level', () => {
     // Assemble
     process.env.AWS_LAMBDA_LOG_LEVEL = 'INFO';
     const logger = new Logger({
@@ -108,6 +108,29 @@ describe('Buffer logs', () => {
       expect.objectContaining({
         message: expect.stringContaining(
           'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Buffered logs will be filtered by ALC'
+        ),
+        level: LogLevel.WARN,
+      })
+    );
+  });
+
+  it('When the buffer is flushed it outputs a warning if the Advanced Logging Configuration Log Level is less verbose than the Log Buffering Log Level', () => {
+    // Assemble
+    process.env.AWS_LAMBDA_LOG_LEVEL = 'INFO';
+    const logger = new Logger({
+      logLevel: LogLevel.DEBUG,
+      logBufferOptions: { enabled: true, bufferAtVerbosity: 'DEBUG' },
+    });
+
+    // Act
+    logger.debug('This is a debug');
+    logger.flushBuffer();
+
+    // Assess
+    expect(console.warn).toHaveLogged(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Some logs might be missing.'
         ),
         level: LogLevel.WARN,
       })

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -107,7 +107,7 @@ describe('Buffer logs', () => {
     expect(console.warn).toHaveLogged(
       expect.objectContaining({
         message: expect.stringContaining(
-          'Advanced Loggging Controls (ALC) Log Level is higher than Log Buffering Log Level. Buffered logs will be filtered by ALC'
+          'Advanced Loggging Controls (ALC) Log Level is less verbose than Log Buffering Log Level. Buffered logs will be filtered by ALC'
         ),
         level: LogLevel.WARN,
       })

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -92,6 +92,28 @@ describe('Buffer logs', () => {
     );
   });
 
+  it('outputs a warning when the Advanced Logging Configuration Log Level is higher than the Log Buffering Log Level', () => {
+    // Assemble
+    process.env.AWS_LAMBDA_LOG_LEVEL = 'INFO';
+    const logger = new Logger({
+      logLevel: LogLevel.DEBUG,
+      logBufferOptions: { enabled: true, bufferAtVerbosity: 'DEBUG' },
+    });
+
+    // Act
+    logger.debug('This is a debug');
+
+    // Assess
+    expect(console.warn).toHaveLogged(
+      expect.objectContaining({
+        message: expect.stringContaining(
+          'Advanced Loggging Controls (ALC) Log Level is higher than Log Buffering Log Level. Buffered logs will be filtered by ALC'
+        ),
+        level: LogLevel.WARN,
+      })
+    );
+  });
+
   it('outputs a warning when there is an error buffering the log', () => {
     // Prepare
     const logger = new Logger({ logBufferOptions: { maxBytes: 100 } });


### PR DESCRIPTION
## Summary
When the Advanced Logging Control is less verbose than the Logger Log buffer, buffered logs will not be visible. This PR adds a warning that is emitted when this scenario is detected.

There's an existing warning message if the ALC Log Level is less verbose than the Logger Log Level.

### Changes

* Emit a warning when ALC Log level is less verbose than buffer level
* Add a test for this behaviour


> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:**  #3821 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
