### PR TITLE
fix(parser): Make Kafka key property optional

### DIFF
--- a/packages/parser/src/schemas/kafka.ts
+++ b/packages/parser/src/schemas/kafka.ts
@@ -9,9 +9,12 @@ const KafkaRecordSchema = z.object({
   offset: z.number(),
   timestamp: z.number(),
   timestampType: z.string(),
-  key: z.string().transform((key) => {
-    return Buffer.from(key, 'base64').toString();
-  }),
+  key: z
+    .string()
+    .transform((key) => {
+      return Buffer.from(key, 'base64').toString();
+    })
+    .optional(),
   value: z.string().transform((value) => {
     return Buffer.from(value, 'base64').toString();
   }),


### PR DESCRIPTION
## Summary

This PR updates the parser kafka schema to make the `key` property optional.

I wasn't sure whether a test case was warranted. Happy to add one

### Changes

> Please provide a summary of what's being changed

Mark `key` property optional

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3841 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
