### PR TITLE
chore: restore typeVersions for old ts config

### DIFF
--- a/packages/event-handler/package.json
+++ b/packages/event-handler/package.json
@@ -50,6 +50,18 @@
       }
     }
   },
+  "typesVersions": {
+    "*": {
+      "appsync-events": [
+        "./lib/cjs/appsync-events/index.d.ts",
+        "./lib/esm/appsync-events/index.d.ts"
+      ],
+      "types": [
+        "./lib/cjs/types/index.d.ts",
+        "./lib/esm/types/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "lib"
   ],

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -131,6 +131,46 @@
       }
     }
   },
+  "typesVersions": {
+    "*": {
+      "middleware": [
+        "lib/cjs/middleware/index.d.ts",
+        "lib/esm/middleware/index.d.ts"
+      ],
+      "schemas": [
+        "lib/cjs/schemas/index.d.ts",
+        "lib/esm/schemas/index.d.ts"
+      ],
+      "schemas/*": [
+        "lib/cjs/schemas/*.d.ts",
+        "lib/esm/schemas/*.d.ts"
+      ],
+      "envelopes": [
+        "lib/cjs/envelopes/index.d.ts",
+        "lib/esm/envelopes/index.d.ts"
+      ],
+      "envelopes/*": [
+        "lib/cjs/envelopes/*.d.ts",
+        "lib/esm/envelopes/*.d.ts"
+      ],
+      "helpers": [
+        "lib/cjs/helpers/index.d.ts",
+        "lib/esm/helpers/index.d.ts"
+      ],
+      "helpers/dynamodb": [
+        "lib/cjs/helpers/dynamodb.d.ts",
+        "lib/esm/helpers/dynamodb.d.ts"
+      ],
+      "types": [
+        "lib/cjs/types/index.d.ts",
+        "lib/esm/types/index.d.ts"
+      ],
+      "errors": [
+        "lib/cjs/errors.d.ts",
+        "lib/esm/errors.d.ts"
+      ]
+    }
+  },
   "main": "./lib/cjs/index.js",
   "types": "./lib/cjs/index.d.ts",
   "files": [

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -67,6 +67,22 @@
       }
     }
   },
+  "typesVersions": {
+    "*": {
+      "middleware": [
+        "lib/cjs/middleware.d.ts",
+        "lib/esm/middleware.d.ts"
+      ],
+      "errors": [
+        "lib/cjs/errors.d.ts",
+        "lib/esm/errors.d.ts"
+      ],
+      "decorator": [
+        "lib/cjs/decorator.d.ts",
+        "lib/esm/decorator.d.ts"
+      ]
+    }
+  },
   "types": "./lib/cjs/index.d.ts",
   "main": "./lib/cjs/index.js",
   "files": [


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR restores the `typeVersions` field in the `package.json` files of Parser and adds it for the first time to the Validation and Event Handler utilities.

This field, while functionally equivalent to the new `exports` syntax used in these three packages, is required for older `tsconfig.json` configuration that default to `modeResolution: "Node"`.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3865

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
