### PR TITLE
chore: remove typedoc zod plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "middy6": "npm:@middy/core@^6.0.0",
         "typedoc": "^0.28.3",
         "typedoc-plugin-missing-exports": "^4.0.0",
-        "typedoc-plugin-zod": "^1.4.1",
         "typescript": "^5.8.3",
         "vitest": "^3.0.9"
       },
@@ -24269,16 +24268,6 @@
       "license": "MIT",
       "peerDependencies": {
         "typedoc": "^0.28.1"
-      }
-    },
-    "node_modules/typedoc-plugin-zod": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-zod/-/typedoc-plugin-zod-1.4.1.tgz",
-      "integrity": "sha512-D7+uhPFCyKMcKnUSZip/BldE08Jo/yykvbxlIcY11fI8dKyCe23/igOiZ7rPW2mXD5N9kHEA2he9LkCoU+6HtA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typedoc": "0.23.x || 0.24.x || 0.25.x || 0.26.x || 0.27.x || 0.28.x"
       }
     },
     "node_modules/typedoc/node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "middy6": "npm:@middy/core@^6.0.0",
     "typedoc": "^0.28.3",
     "typedoc-plugin-missing-exports": "^4.0.0",
-    "typedoc-plugin-zod": "^1.4.1",
     "typescript": "^5.8.3",
     "vitest": "^3.0.9"
   },

--- a/typedoc.json
+++ b/typedoc.json
@@ -14,7 +14,7 @@
     "examples/**",
     "packages/testing"
   ],
-  "plugin": ["typedoc-plugin-zod", "typedoc-plugin-missing-exports"],
+  "plugin": ["typedoc-plugin-missing-exports"],
   "skipErrorChecking": true,
   "excludePrivate": true,
   "visibilityFilters": {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR removes the `typedoc-plugin-zod` dev dependency which was causing our docs builds to silently fail while adding very little to the overall docs experience. See linked issue for full details.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes  #3877

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
