### PR TITLE
chore: pin version of commons dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25088,7 +25088,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0"
+        "@aws-lambda-powertools/commons": "2.19.0"
       }
     },
     "packages/idempotency": {
@@ -25096,8 +25096,8 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0",
-        "@aws-lambda-powertools/jmespath": "^2.19.0"
+        "@aws-lambda-powertools/commons": "2.19.0",
+        "@aws-lambda-powertools/jmespath": "2.19.0"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -25127,7 +25127,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0"
+        "@aws-lambda-powertools/commons": "2.19.0"
       }
     },
     "packages/logger": {
@@ -25135,7 +25135,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0",
+        "@aws-lambda-powertools/commons": "2.19.0",
         "lodash.merge": "^4.6.2"
       },
       "devDependencies": {
@@ -25160,7 +25160,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0"
+        "@aws-lambda-powertools/commons": "2.19.0"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -25182,7 +25182,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0"
+        "@aws-lambda-powertools/commons": "2.19.0"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -25228,7 +25228,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0"
+        "@aws-lambda-powertools/commons": "2.19.0"
       },
       "peerDependencies": {
         "@middy/core": "4.x || 5.x || 6.x",
@@ -25265,7 +25265,7 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0",
+        "@aws-lambda-powertools/commons": "2.19.0",
         "aws-xray-sdk-core": "^3.10.3"
       },
       "devDependencies": {
@@ -25287,8 +25287,8 @@
       "version": "2.19.0",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^2.19.0",
-        "@aws-lambda-powertools/jmespath": "^2.19.0",
+        "@aws-lambda-powertools/commons": "2.19.0",
+        "@aws-lambda-powertools/jmespath": "2.19.0",
         "ajv": "^8.17.1"
       }
     }

--- a/packages/event-handler/package.json
+++ b/packages/event-handler/package.json
@@ -73,7 +73,7 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0"
+    "@aws-lambda-powertools/commons": "2.19.0"
   },
   "keywords": [
     "aws",

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -98,8 +98,8 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0",
-    "@aws-lambda-powertools/jmespath": "^2.19.0"
+    "@aws-lambda-powertools/commons": "2.19.0",
+    "@aws-lambda-powertools/jmespath": "2.19.0"
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": ">=3.x",

--- a/packages/jmespath/package.json
+++ b/packages/jmespath/package.json
@@ -71,7 +71,7 @@
     "lib"
   ],
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0"
+    "@aws-lambda-powertools/commons": "2.19.0"
   },
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -98,7 +98,7 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0",
+    "@aws-lambda-powertools/commons": "2.19.0",
     "lodash.merge": "^4.6.2"
   },
   "keywords": [

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -88,7 +88,7 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0"
+    "@aws-lambda-powertools/commons": "2.19.0"
   },
   "keywords": [
     "aws",

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -165,7 +165,7 @@
     "aws-sdk-client-mock": "^4.1.0"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0"
+    "@aws-lambda-powertools/commons": "2.19.0"
   },
   "peerDependencies": {
     "@aws-sdk/client-appconfigdata": ">=3.x",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -200,7 +200,7 @@
     "nodejs"
   ],
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0"
+    "@aws-lambda-powertools/commons": "2.19.0"
   },
   "peerDependencies": {
     "@middy/core": "4.x || 5.x || 6.x",

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -87,7 +87,7 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0",
+    "@aws-lambda-powertools/commons": "2.19.0",
     "aws-xray-sdk-core": "^3.10.3"
   },
   "keywords": [

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -96,8 +96,8 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "^2.19.0",
-    "@aws-lambda-powertools/jmespath": "^2.19.0",
+    "@aws-lambda-powertools/commons": "2.19.0",
+    "@aws-lambda-powertools/jmespath": "2.19.0",
     "ajv": "^8.17.1"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the `package.json` for all utilities that depend on the `commons` package so that they now require the same version of the package as their own.

Since we version all our utilities together, this ensures that whenever there's an update to `commons` that updated version is installed with the correct version of each utility. Prior to this fix, the version range used the `^`  symbol, which meant that depending on how customers updated a utility (i.e. `logger`) npm might not have updated `commons` in case of a minor version update.

The change should be seamless and not require any change on the customer side, since it'll be effective starting from the next release.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3879

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
