### PR TITLE
chore(docs): fix youtube iframes

### DIFF
--- a/docs/we_made_this.md
+++ b/docs/we_made_this.md
@@ -89,7 +89,7 @@ This article discusses how to use the Idempotency feature to work around EventBr
 
 An overview of all the Powertools for AWS Lambda features put into a real world example.
 
-<iframe width="620" height="378" src="https://youtu.be/DYf7kpR24dk?si=qm2wWg0asxLUY8xe" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/DYf7kpR24dk?si=qm2wWg0asxLUY8xe" title" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### AWS re:Invent 2024 - Gain expert-level knowledge about Powertools for AWS Lambda (OPN402)
 
@@ -97,4 +97,4 @@ An overview of all the Powertools for AWS Lambda features put into a real world 
 
 Did you learn serverless best practices but are unsure about implementation? Have you used Powertools for AWS Lambda but felt you barely scratched the surface? This session dives deep into observability practices, safe retries with idempotency, mono- and multi-function APIs, and more. Learn about each practice in depth, achieve expert-level knowledge, and hear from maintainers about what’s next.
 
-<iframe width="620" height="378" src="https://youtu.be/kxJTq8FTkDA?si=tV75z2HVGlPxYtPA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/kxJTq8FTkDA?si=tV75z2HVGlPxYtPA" title" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR fixes the YouTube embeds in the community contents page so that they should load correctly.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3881

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
