### PR TITLE
fix(event-handler): ignore return type from onSubscribe handler

### DIFF
--- a/packages/event-handler/src/appsync-events/AppSyncEventsResolver.ts
+++ b/packages/event-handler/src/appsync-events/AppSyncEventsResolver.ts
@@ -173,10 +173,7 @@ class AppSyncEventsResolver extends Router {
     }
     const { handler } = routeHandlerOptions;
     try {
-      return await (handler as OnSubscribeHandler).apply(this, [
-        event,
-        context,
-      ]);
+      await (handler as OnSubscribeHandler).apply(this, [event, context]);
     } catch (error) {
       this.logger.error(`An error occurred in handler ${path}`, error);
       if (error instanceof UnauthorizedException) throw error;

--- a/packages/event-handler/tests/unit/AppSyncEventsResolver.test.ts
+++ b/packages/event-handler/tests/unit/AppSyncEventsResolver.test.ts
@@ -75,7 +75,7 @@ describe('Class: AppSyncEventsResolver', () => {
     expect(result).toEqual(null);
   });
 
-  it('returns the response of the onSubscribe handler', async () => {
+  it('ignores the response of the onSubscribe handler', async () => {
     // Prepare
     const app = new AppSyncEventsResolver({ logger: console });
     app.onSubscribe('/foo', async () => true);
@@ -87,7 +87,7 @@ describe('Class: AppSyncEventsResolver', () => {
     );
 
     // Assess
-    expect(result).toBe(true);
+    expect(result).toBe(undefined);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the implementation of the `AppSyncEventsResolver` class to always ignore the response returned by an `onSubscribe` handler defined by customers. This is required to avoid customers inadvertently rejecting the subscription.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3884

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
