### PR TITLE
refactor(event-handler): mark identity field as unknown in event

### DIFF
--- a/packages/event-handler/src/types/appsync-events.ts
+++ b/packages/event-handler/src/types/appsync-events.ts
@@ -162,6 +162,12 @@ type RouteOptions<T extends boolean | undefined = false> = {
 // #region Events
 
 type AppSyncEventsEvent = {
+  /**
+   * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
+   * When using an API key, it will be `null`. When using IAM, it will contain the AWS credentials of the user. When using Cognito,
+   * it will contain the Cognito user pool information. When using a Lambda authorizer, it will contain the information returned
+   * by the authorizer.
+   */
   identity: unknown;
   result: null;
   request: {
@@ -187,11 +193,6 @@ type AppSyncEventsEvent = {
 
 /**
  * Event type for AppSync Events publish events.
- *
- * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
- * When using an API key, it will be `null`. When using IAM, it will contain the AWS credentials of the user. When using Cognito,
- * it will contain the Cognito user pool information. When using a Lambda authorizer, it will contain the information returned
- * by the authorizer.
  *
  * @example
  * ```json
@@ -247,11 +248,6 @@ type AppSyncEventsPublishEvent = AppSyncEventsEvent & {
 
 /**
  * Event type for AppSync Events subscribe events.
- *
- * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
- * When using an API key, it will be `null`. When using IAM, it will contain the AWS credentials of the user. When using Cognito,
- * it will contain the Cognito user pool information. When using a Lambda authorizer, it will contain the information returned
- * by the authorizer.
  *
  * @example
  * ```json

--- a/packages/event-handler/src/types/appsync-events.ts
+++ b/packages/event-handler/src/types/appsync-events.ts
@@ -162,7 +162,7 @@ type RouteOptions<T extends boolean | undefined = false> = {
 // #region Events
 
 type AppSyncEventsEvent = {
-  identity: null;
+  identity: unknown;
   result: null;
   request: {
     headers: Record<string, string>;
@@ -187,6 +187,11 @@ type AppSyncEventsEvent = {
 
 /**
  * Event type for AppSync Events publish events.
+ *
+ * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
+ * When using an API key, it will be `null`. When using IAM, it will contain the AWS credentials of the user. When using Cognito,
+ * it will contain the Cognito user pool information. When using a Lambda authorizer, it will contain the information returned
+ * by the authorizer.
  *
  * @example
  * ```json
@@ -242,6 +247,11 @@ type AppSyncEventsPublishEvent = AppSyncEventsEvent & {
 
 /**
  * Event type for AppSync Events subscribe events.
+ *
+ * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
+ * When using an API key, it will be `null`. When using IAM, it will contain the AWS credentials of the user. When using Cognito,
+ * it will contain the Cognito user pool information. When using a Lambda authorizer, it will contain the information returned
+ * by the authorizer.
  *
  * @example
  * ```json

--- a/packages/event-handler/src/types/appsync-events.ts
+++ b/packages/event-handler/src/types/appsync-events.ts
@@ -161,6 +161,11 @@ type RouteOptions<T extends boolean | undefined = false> = {
 
 // #region Events
 
+/**
+ * Event type for AppSync Events.
+ *
+ * For strongly typed validation and parsing at runtime, check out the `@aws-lambda-powertools/parser` package.
+ */
 type AppSyncEventsEvent = {
   /**
    * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
@@ -234,6 +239,9 @@ type AppSyncEventsEvent = {
  *     }
  *   ]
  * }
+ *
+ * For strongly typed validation and parsing at runtime, check out the `@aws-lambda-powertools/parser` package.
+ *
  * ```
  */
 type AppSyncEventsPublishEvent = AppSyncEventsEvent & {
@@ -277,6 +285,8 @@ type AppSyncEventsPublishEvent = AppSyncEventsEvent & {
  *   "events": null
  * }
  * ```
+ *
+ * For strongly typed validation and parsing at runtime, check out the `@aws-lambda-powertools/parser` package.
  */
 type AppSyncEventsSubscribeEvent = AppSyncEventsEvent & {
   info: {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the type of the `identity` field in the types for AppSync Events in the Event Handler package to account for the fact that the field can have different contents based on the authorizer used in the API.

The PR also adds a short explanation of what kind of values customers can expect from the field in the docstring of the event.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3921

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
