### PR TITLE
docs(event-handler): add examples on how to drop messages

### DIFF
--- a/docs/features/event-handler/appsync-events.md
+++ b/docs/features/event-handler/appsync-events.md
@@ -167,14 +167,23 @@ This is useful when you want to for example:
 
 You can enable this with the `aggregate` parameter:
 
-!!! note "Aggregate Processing"
-    When enabling `aggregate`, your handler receives a list of all events, requiring you to manage the response format. Ensure your response includes results for each event in the expected [AppSync Request and Response Format](#appsync-request-and-response-format).
-
 === "Aggregated processing"
 
     ```typescript hl_lines="17 32 34"
     --8<-- "examples/snippets/event-handler/appsync-events/aggregatedProcessing.ts"
     ```
+
+When enabling `aggregate`, your handler receives a list of all the events, requiring you to manage the response format. Ensure your response includes results for each event in the expected [AppSync Request and Response Format](#appsync-request-and-response-format).
+
+If you want to omit one or more events from the response, you can do so by excluding them from the returned array. Likewise, if you want to discard the entire batch and prevent subscribers from receiving it, you can return an empty array.
+
+=== "Aggregated processing with partial results"
+
+    ```typescript hl_lines="17 19"
+    --8<-- "examples/snippets/event-handler/appsync-events/aggregatedProcessingWithPartialResults.ts"
+    ```
+
+    1. You can also return an empty array `[]` to discard the entire batch and prevent subscribers from receiving it.
 
 ### Handling errors
 
@@ -237,7 +246,7 @@ You can also do content-based authorization for channel by throwing an `Unauthor
 
 === "UnauthorizedException"
 
-    ```typescript hl_lines="3 14 20"
+    ```typescript hl_lines="3 14 25-27"
     --8<-- "examples/snippets/event-handler/appsync-events/unauthorizedException.ts"
     ```
 

--- a/examples/snippets/event-handler/appsync-events/aggregatedProcessingWithPartialResults.ts
+++ b/examples/snippets/event-handler/appsync-events/aggregatedProcessingWithPartialResults.ts
@@ -1,0 +1,23 @@
+import { AppSyncEventsResolver } from '@aws-lambda-powertools/event-handler/appsync-events';
+import type { AppSyncEventsPublishEvent } from '@aws-lambda-powertools/event-handler/types';
+import type { Context } from 'aws-lambda';
+
+const app = new AppSyncEventsResolver();
+
+app.onPublish(
+  '/default/foo/*',
+  async (events) => {
+    const payloadsToReturn: AppSyncEventsPublishEvent['events'] = [];
+
+    for (const event of events) {
+      if (event.payload.includes('foo')) continue;
+      payloadsToReturn.push(event);
+    }
+
+    return payloadsToReturn; // (1)!
+  },
+  { aggregate: true }
+);
+
+export const handler = async (event: unknown, context: Context) =>
+  app.resolve(event, context);

--- a/examples/snippets/event-handler/appsync-events/unauthorizedException.ts
+++ b/examples/snippets/event-handler/appsync-events/unauthorizedException.ts
@@ -22,7 +22,7 @@ app.onSubscribe('/private/*', async (info) => {
   const channelGroup = 'premium-users';
 
   if (!userGroups.includes(channelGroup)) {
-    new UnauthorizedException(
+    throw new UnauthorizedException(
       `Subscription requires ${channelGroup} group membership`
     );
   }

--- a/examples/snippets/event-handler/appsync-events/unauthorizedException.ts
+++ b/examples/snippets/event-handler/appsync-events/unauthorizedException.ts
@@ -14,10 +14,18 @@ app.onPublish('/*', () => {
   throw new UnauthorizedException('You can only publish to /default/foo');
 });
 
-app.onSubscribe('/default/foo', () => true);
+app.onSubscribe('/private/*', async (info) => {
+  const userGroups =
+    info.identity?.groups && Array.isArray(info.identity?.groups)
+      ? info.identity?.groups
+      : [];
+  const channelGroup = 'premium-users';
 
-app.onSubscribe('/*', () => {
-  throw new UnauthorizedException('You can only subscribe to /default/foo');
+  if (!userGroups.includes(channelGroup)) {
+    new UnauthorizedException(
+      `Subscription requires ${channelGroup} group membership`
+    );
+  }
 });
 
 export const handler = async (event: unknown, context: Context) =>

--- a/packages/event-handler/src/types/appsync-events.ts
+++ b/packages/event-handler/src/types/appsync-events.ts
@@ -168,12 +168,12 @@ type RouteOptions<T extends boolean | undefined = false> = {
  */
 type AppSyncEventsEvent = {
   /**
-   * The `identity` field is marked as `unknown` because it varies based on the authentication type used in AppSync.
+   * The `identity` field varies based on the authentication type used for the AppSync API.
    * When using an API key, it will be `null`. When using IAM, it will contain the AWS credentials of the user. When using Cognito,
    * it will contain the Cognito user pool information. When using a Lambda authorizer, it will contain the information returned
    * by the authorizer.
    */
-  identity: unknown;
+  identity: null | Record<string, unknown>;
   result: null;
   request: {
     headers: Record<string, string>;


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds a new paragraph and code snippet to the Event Handler AppSync Events resolver docs to show how to drop one or more events - or the entire batch - when using aggregated processing.

<img width="1109" alt="443184828-6f3fa2ed-e68c-4df0-99e2-ddeaa9205785" src="https://github.com/user-attachments/assets/450bdb0a-316f-47d1-a5ef-dc060798681f" />

The PR also updates the type that was modified in #3922 to include `Record<string, unknown>` for easier usage and updates one of the snippets for unauthorized errors to have a more realistic example.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** #3923

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
