### PR TITLE
fix(event-handler): fix decorated scope in appsync events

### DIFF
--- a/packages/event-handler/src/appsync-events/AppSyncEventsResolver.ts
+++ b/packages/event-handler/src/appsync-events/AppSyncEventsResolver.ts
@@ -114,11 +114,11 @@ class AppSyncEventsResolver extends Router {
     if (aggregate) {
       try {
         return {
-          events: await (handler as OnPublishHandlerAggregateFn).apply(this, [
+          events: await (handler as OnPublishHandlerAggregateFn)(
             event.events,
             event,
-            context,
-          ]),
+            context
+          ),
         };
       } catch (error) {
         this.logger.error(`An error occurred in handler ${path}`, error);
@@ -131,11 +131,11 @@ class AppSyncEventsResolver extends Router {
         event.events.map(async (message) => {
           const { id, payload } = message;
           try {
-            const result = await (handler as OnPublishHandlerFn).apply(this, [
+            const result = await (handler as OnPublishHandlerFn)(
               payload,
               event,
-              context,
-            ]);
+              context
+            );
             return {
               id,
               payload: result,
@@ -173,7 +173,7 @@ class AppSyncEventsResolver extends Router {
     }
     const { handler } = routeHandlerOptions;
     try {
-      await (handler as OnSubscribeHandler).apply(this, [event, context]);
+      await (handler as OnSubscribeHandler)(event, context);
     } catch (error) {
       this.logger.error(`An error occurred in handler ${path}`, error);
       if (error instanceof UnauthorizedException) throw error;

--- a/packages/event-handler/tests/unit/AppSyncEventsResolver.test.ts
+++ b/packages/event-handler/tests/unit/AppSyncEventsResolver.test.ts
@@ -4,12 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AppSyncEventsResolver,
   UnauthorizedException,
-} from '../../../src/appsync-events/index.js';
-import type { AppSyncEventsSubscribeEvent } from '../../../src/types/appsync-events.js';
+} from '../../src/appsync-events/index.js';
+import type { AppSyncEventsSubscribeEvent } from '../../src/types/appsync-events.js';
 import {
   onPublishEventFactory,
   onSubscribeEventFactory,
-} from '../../helpers/factories.js';
+} from '../helpers/factories.js';
 
 describe('Class: AppSyncEventsResolver', () => {
   beforeEach(() => {

--- a/packages/event-handler/tests/unit/AppSyncEventsResolver.test.ts
+++ b/packages/event-handler/tests/unit/AppSyncEventsResolver.test.ts
@@ -1,13 +1,15 @@
 import context from '@aws-lambda-powertools/testing-utils/context';
+import type { Context } from 'aws-lambda';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   AppSyncEventsResolver,
   UnauthorizedException,
-} from '../../src/appsync-events/index.js';
+} from '../../../src/appsync-events/index.js';
+import type { AppSyncEventsSubscribeEvent } from '../../../src/types/appsync-events.js';
 import {
   onPublishEventFactory,
   onSubscribeEventFactory,
-} from '../helpers/factories.js';
+} from '../../helpers/factories.js';
 
 describe('Class: AppSyncEventsResolver', () => {
   beforeEach(() => {
@@ -61,6 +63,93 @@ describe('Class: AppSyncEventsResolver', () => {
         },
       ],
     });
+  });
+
+  it('preserves the scope when decorating methods', async () => {
+    // Prepare
+    const app = new AppSyncEventsResolver({ logger: console });
+
+    class Lambda {
+      public scope = 'scoped';
+
+      @app.onPublish('/foo')
+      public async handleFoo(payload: string) {
+        return `${this.scope} ${payload}`;
+      }
+
+      public async handler(event: unknown, context: Context) {
+        return this.stuff(event, context);
+      }
+
+      async stuff(event: unknown, context: Context) {
+        return app.resolve(event, context);
+      }
+    }
+    const lambda = new Lambda();
+    const handler = lambda.handler.bind(lambda);
+
+    // Act
+    const result = await handler(
+      onPublishEventFactory(
+        [
+          {
+            id: '1',
+            payload: 'foo',
+          },
+        ],
+        {
+          path: '/foo',
+          segments: ['foo'],
+        }
+      ),
+      context
+    );
+
+    // Assess
+    expect(result).toEqual({
+      events: [
+        {
+          id: '1',
+          payload: 'scoped foo',
+        },
+      ],
+    });
+  });
+
+  it('preserves the scope when decorating methods', async () => {
+    // Prepare
+    const app = new AppSyncEventsResolver({ logger: console });
+
+    class Lambda {
+      public scope = 'scoped';
+
+      @app.onSubscribe('/foo')
+      public async handleFoo(payload: AppSyncEventsSubscribeEvent) {
+        console.debug(`${this.scope} ${payload.info.channel.path}`);
+      }
+
+      public async handler(event: unknown, context: Context) {
+        return this.stuff(event, context);
+      }
+
+      async stuff(event: unknown, context: Context) {
+        return app.resolve(event, context);
+      }
+    }
+    const lambda = new Lambda();
+    const handler = lambda.handler.bind(lambda);
+
+    // Act
+    await handler(
+      onSubscribeEventFactory({
+        path: '/foo',
+        segments: ['foo'],
+      }),
+      context
+    );
+
+    // Assess
+    expect(console.debug).toHaveBeenCalledWith('scoped /foo');
   });
 
   it('returns null if there are no onSubscribe handlers', async () => {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR improves the decorator logic of the `AppSyncEventsResolver` by fixing a fundamental issue that prevented it from being useful.

Prior to this fix the decorators would consistently cause the decorated methods to become unbound and lose the reference to `this`, preventing customers to access other class methods or properties from within the decorated methods.

This was happening because unlike other decorator implementations in the codebase, the one in this area of the codebase works in two steps:
1. at init time the decorator saves a reference of the decorated method for later usage
2. at runtime the `app.resolve` method can call a decorated method depending on routing decisions

By the time the reference is called, the initial scope is lost causing the issue. At the same time, the `this` scope is not yet available at init time - this is because decorators are evaluated before class init - so it's not possible to save a reference or bind `this` along with the the decorated method.

Because of this, we need to get around this decorator design aspect.

Specifically, at runtime (step 2) - which is when `app.resolve()` is called - we introspect the class methods, find their definition, and when we encounter the `.resolve` keyword (which represents the method), we save a reference to `this` for later use. This reference is then used and passed to the decorated method to apply the correct `this` value.

While this is relatively unorthodox, as long as we find one instance of `this` that belongs to the class to which the decorated method belongs it should be fine.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #3973

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
