### PR TITLE
chore(event-handler): align implementation with other runtimes

### DIFF
--- a/packages/event-handler/README.md
+++ b/packages/event-handler/README.md
@@ -6,7 +6,7 @@ You can use the library in both TypeScript and JavaScript code bases.
 
 ## Intro
 
-Event handler for Amazon API Gateway REST and HTTP APIs, Application Loader Balancer (ALB), Lambda Function URLs, and VPC Lattice.
+Event handler for Amazon API Gateway REST and HTTP APIs, Application Loader Balancer (ALB), Lambda Function URLs, VPC Lattice, AWS AppSync Events APIs, and Amazon Bedrock Agent Functions.
 
 ## Usage
 
@@ -101,6 +101,8 @@ app.onSubscribe('/default/foo', async (event) => {
 export const handler = async (event, context) =>
   app.resolve(event, context);
 ```
+
+## Bedrock Agent Functions
 
 See the [documentation](https://docs.powertools.aws.dev/lambda/typescript/latest/features/event-handler/appsync-events) for more details on how to use the AppSync event handler.
 

--- a/packages/event-handler/src/bedrock-agent/BedrockAgentFunctionResolver.ts
+++ b/packages/event-handler/src/bedrock-agent/BedrockAgentFunctionResolver.ts
@@ -169,6 +169,32 @@ export class BedrockAgentFunctionResolver {
     this.#logger.debug(`Tool "${name}" has been registered.`);
   }
 
+  /**
+   * Resolve an incoming Bedrock Agent function invocation event.
+   *
+   * @example
+   * ```ts
+   * import {
+   *   BedrockAgentFunctionResolver
+   * } from '@aws-lambda-powertools/event-handler/bedrock-agent';
+   *
+   * const app = new BedrockAgentFunctionResolver();
+   *
+   * app.tool(async (params) => {
+   *   const { name } = params;
+   *   return `Hello, ${name}!`;
+   * }, {
+   *   name: 'greeting',
+   *   description: 'Greets a person by name',
+   * });
+   *
+   * export const handler = async (event, context) =>
+   *   app.resolve(event, context);
+   * ```
+   *
+   * @param event - The incoming payload of the AWS Lambda function.
+   * @param context - The context object provided by AWS Lambda, which contains information about the invocation, function, and execution environment.
+   */
   async resolve(
     event: unknown,
     context: Context
@@ -181,7 +207,7 @@ export class BedrockAgentFunctionResolver {
       actionGroup,
       sessionAttributes,
       promptSessionAttributes,
-      // TODO: add knowledge bases
+      knowledgeBasesConfiguration,
     } = event;
 
     const tool = this.#tools.get(toolName);
@@ -189,11 +215,10 @@ export class BedrockAgentFunctionResolver {
     if (tool == null) {
       this.#logger.error(`Tool ${toolName} has not been registered.`);
       return new BedrockFunctionResponse({
-        actionGroup,
-        func: toolName,
         body: `Error: tool ${toolName} has not been registered.`,
         sessionAttributes,
         promptSessionAttributes,
+        knowledgeBasesConfiguration,
       }).build({
         actionGroup,
         func: toolName,
@@ -234,11 +259,10 @@ export class BedrockAgentFunctionResolver {
           ? ''
           : JSON.stringify(response);
       return new BedrockFunctionResponse({
-        actionGroup,
-        func: toolName,
         body,
         sessionAttributes,
         promptSessionAttributes,
+        knowledgeBasesConfiguration,
       }).build({
         actionGroup,
         func: toolName,
@@ -246,11 +270,10 @@ export class BedrockAgentFunctionResolver {
     } catch (error) {
       this.#logger.error(`An error occurred in tool ${toolName}.`, error);
       return new BedrockFunctionResponse({
-        actionGroup,
-        func: toolName,
         body: `Unable to complete tool execution due to ${error instanceof Error ? `${error.name} - ${error.message}` : String(error)}`,
         sessionAttributes,
         promptSessionAttributes,
+        knowledgeBasesConfiguration,
       }).build({
         actionGroup,
         func: toolName,

--- a/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
+++ b/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
@@ -1,0 +1,99 @@
+import type { BedrockAgentFunctionResolver } from './BedrockAgentFunctionResolver.js';
+
+/**
+ * Class representing a response from a Bedrock agent function.
+ *
+ * You can use this class to customize the response sent back to the Bedrock agent with additional fields like:
+ * - session attributes
+ * - prompt session attributes
+ * - response state (`FAILURE` or `REPROMPT`)
+ *
+ * When working with the {@link BedrockAgentFunctionResolver} class, this is built automatically
+ * when you return anything from your function handler other than an instance of this class.
+ */
+class BedrockFunctionResponse {
+  /**
+   * The name of the action group, this comes from the `event.actionGroup` field
+   * in the Bedrock agent function event.
+   */
+  readonly actionGroup: string;
+  /**
+   * The name of the function returning the response, this comes from the `event.function` field
+   * in the Bedrock agent function event.
+   */
+  readonly func: string;
+  /**
+   * The response object that defines the response from execution of the function.
+   */
+  readonly body: string;
+  /**
+   * Optional field to indicate the whether the response is a failure or a reprompt.
+   * If not provided, the default is undefined, which means no specific response state is set.
+   *
+   * - `FAILURE`: The agent throws a `DependencyFailedException` for the current session.
+   * - `REPROMPT`: The agent passes a response string to the model to reprompt it.
+   */
+  readonly responseState?: 'FAILURE' | 'REPROMPT';
+  /**
+   * Optional field to store session attributes and their values.
+   * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-attributes | Bedrock Agent Session State Attributes} for more details.
+   */
+  readonly sessionAttributes: Record<string, string>;
+  /**
+   * Optional field to instruct the agent to prompt attributes and their values.
+   * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-attributes | Bedrock Agent Session State Attributes} for more details.
+   */
+  readonly promptSessionAttributes: Record<string, string>;
+
+  constructor({
+    actionGroup,
+    func,
+    body,
+    responseState = undefined,
+    sessionAttributes = {},
+    promptSessionAttributes = {},
+  }: {
+    actionGroup: string;
+    func: string;
+    body: string;
+    responseState?: 'FAILURE' | 'REPROMPT';
+    sessionAttributes?: Record<string, string>;
+    promptSessionAttributes?: Record<string, string>;
+  }) {
+    this.actionGroup = actionGroup;
+    this.func = func;
+    this.body = body;
+    this.responseState = responseState;
+    this.sessionAttributes = sessionAttributes;
+    this.promptSessionAttributes = promptSessionAttributes;
+  }
+
+  /**
+   * Builds the Bedrock function response object according to the Bedrock agent function {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-lambda.html#agents-lambda-response | response format}.
+   */
+  build() {
+    return {
+      messageVersion: '1.0',
+      response: {
+        actionGroup: this.actionGroup,
+        function: this.func,
+        functionResponse: {
+          ...(this.responseState && { responseState: this.responseState }),
+          responseBody: {
+            TEXT: {
+              body: this.body,
+            },
+          },
+        },
+      },
+      ...(this.sessionAttributes && {
+        sessionAttributes: this.sessionAttributes,
+      }),
+      ...(this.promptSessionAttributes && {
+        promptSessionAttributes: this.promptSessionAttributes,
+      }),
+    };
+  }
+}
+
+export { BedrockFunctionResponse };

--- a/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
+++ b/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
@@ -13,16 +13,6 @@ import type { BedrockAgentFunctionResolver } from './BedrockAgentFunctionResolve
  */
 class BedrockFunctionResponse {
   /**
-   * The name of the action group, this comes from the `event.actionGroup` field
-   * in the Bedrock agent function event.
-   */
-  readonly actionGroup: string;
-  /**
-   * The name of the function returning the response, this comes from the `event.function` field
-   * in the Bedrock agent function event.
-   */
-  readonly func: string;
-  /**
    * The response object that defines the response from execution of the function.
    */
   readonly body: string;
@@ -60,8 +50,6 @@ class BedrockFunctionResponse {
     sessionAttributes?: Record<string, string>;
     promptSessionAttributes?: Record<string, string>;
   }) {
-    this.actionGroup = actionGroup;
-    this.func = func;
     this.body = body;
     this.responseState = responseState;
     this.sessionAttributes = sessionAttributes;
@@ -70,13 +58,20 @@ class BedrockFunctionResponse {
 
   /**
    * Builds the Bedrock function response object according to the Bedrock agent function {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-lambda.html#agents-lambda-response | response format}.
+   *
+   * @param options - The options for building the response.
+   * @param options.actionGroup - The action group of the function, this comes from the `event.actionGroup` field in the Bedrock agent function event.
+   * @param options.func - The name of the function being invoked by the agent, this comes from the `event.function` field in the Bedrock agent function event.
    */
-  build() {
+  build(options: {
+    actionGroup: string;
+    func: string;
+  }) {
     return {
       messageVersion: '1.0',
       response: {
-        actionGroup: this.actionGroup,
-        function: this.func,
+        actionGroup: options.actionGroup,
+        function: options.func,
         functionResponse: {
           ...(this.responseState && { responseState: this.responseState }),
           responseBody: {

--- a/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
+++ b/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
@@ -34,26 +34,30 @@ class BedrockFunctionResponse {
    * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-attributes | Bedrock Agent Session State Attributes} for more details.
    */
   readonly promptSessionAttributes: Record<string, string>;
+  /**
+   * Optional field to configure knowledge bases for the agent.
+   * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-kb | Bedrock Agent Knowledge Bases} for more details.
+   */
+  readonly knowledgeBasesConfiguration?: Record<string, unknown>;
 
   constructor({
-    actionGroup,
-    func,
     body,
     responseState = undefined,
     sessionAttributes = {},
     promptSessionAttributes = {},
+    knowledgeBasesConfiguration = {},
   }: {
-    actionGroup: string;
-    func: string;
     body: string;
     responseState?: 'FAILURE' | 'REPROMPT';
     sessionAttributes?: Record<string, string>;
     promptSessionAttributes?: Record<string, string>;
+    knowledgeBasesConfiguration?: Record<string, unknown>;
   }) {
     this.body = body;
     this.responseState = responseState;
     this.sessionAttributes = sessionAttributes;
     this.promptSessionAttributes = promptSessionAttributes;
+    this.knowledgeBasesConfiguration = knowledgeBasesConfiguration;
   }
 
   /**
@@ -86,6 +90,9 @@ class BedrockFunctionResponse {
       }),
       ...(this.promptSessionAttributes && {
         promptSessionAttributes: this.promptSessionAttributes,
+      }),
+      ...(this.knowledgeBasesConfiguration && {
+        knowledgeBasesConfiguration: this.knowledgeBasesConfiguration,
       }),
     };
   }

--- a/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
+++ b/packages/event-handler/src/bedrock-agent/BedrockFunctionResponse.ts
@@ -1,5 +1,8 @@
+import type {
+  BedrockAgentFunctionEvent,
+  ResponseState,
+} from '../types/bedrock-agent.js';
 import type { BedrockAgentFunctionResolver } from './BedrockAgentFunctionResolver.js';
-
 /**
  * Class representing a response from a Bedrock agent function.
  *
@@ -23,35 +26,35 @@ class BedrockFunctionResponse {
    * - `FAILURE`: The agent throws a `DependencyFailedException` for the current session.
    * - `REPROMPT`: The agent passes a response string to the model to reprompt it.
    */
-  readonly responseState?: 'FAILURE' | 'REPROMPT';
+  readonly responseState?: ResponseState;
   /**
    * Optional field to store session attributes and their values.
    * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-attributes | Bedrock Agent Session State Attributes} for more details.
    */
-  readonly sessionAttributes: Record<string, string>;
+  readonly sessionAttributes: BedrockAgentFunctionEvent['sessionAttributes'];
   /**
    * Optional field to instruct the agent to prompt attributes and their values.
    * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-attributes | Bedrock Agent Session State Attributes} for more details.
    */
-  readonly promptSessionAttributes: Record<string, string>;
+  readonly promptSessionAttributes: BedrockAgentFunctionEvent['promptSessionAttributes'];
   /**
    * Optional field to configure knowledge bases for the agent.
    * @see {@link https://docs.aws.amazon.com/bedrock/latest/userguide/agents-session-state.html#session-state-kb | Bedrock Agent Knowledge Bases} for more details.
    */
-  readonly knowledgeBasesConfiguration?: Record<string, unknown>;
+  readonly knowledgeBasesConfiguration?: BedrockAgentFunctionEvent['knowledgeBasesConfiguration'];
 
   constructor({
     body,
     responseState = undefined,
     sessionAttributes = {},
     promptSessionAttributes = {},
-    knowledgeBasesConfiguration = {},
+    knowledgeBasesConfiguration = undefined,
   }: {
     body: string;
-    responseState?: 'FAILURE' | 'REPROMPT';
-    sessionAttributes?: Record<string, string>;
-    promptSessionAttributes?: Record<string, string>;
-    knowledgeBasesConfiguration?: Record<string, unknown>;
+    responseState?: ResponseState;
+    sessionAttributes?: BedrockAgentFunctionEvent['sessionAttributes'];
+    promptSessionAttributes?: BedrockAgentFunctionEvent['promptSessionAttributes'];
+    knowledgeBasesConfiguration?: BedrockAgentFunctionEvent['knowledgeBasesConfiguration'];
   }) {
     this.body = body;
     this.responseState = responseState;

--- a/packages/event-handler/src/bedrock-agent/index.ts
+++ b/packages/event-handler/src/bedrock-agent/index.ts
@@ -1,1 +1,2 @@
 export { BedrockAgentFunctionResolver } from './BedrockAgentFunctionResolver.js';
+export { BedrockFunctionResponse } from './BedrockFunctionResponse.js';

--- a/packages/event-handler/src/types/bedrock-agent.ts
+++ b/packages/event-handler/src/types/bedrock-agent.ts
@@ -114,9 +114,9 @@ type BedrockAgentFunctionEvent = {
   parameters?: Array<Parameter>;
   inputText: string;
   sessionId: string;
-  sessionAttributes: Record<string, string>;
-  promptSessionAttributes: Record<string, string>;
-  knowledgeBasesConfiguration?: Record<string, unknown>;
+  sessionAttributes: Record<string, JSONValue>;
+  promptSessionAttributes: Record<string, JSONValue>;
+  knowledgeBasesConfiguration?: Record<string, JSONValue>;
 };
 
 /**
@@ -143,8 +143,9 @@ type BedrockAgentFunctionResponse = {
       };
     };
   };
-  sessionAttributes?: Record<string, string>;
-  promptSessionAttributes?: Record<string, string>;
+  sessionAttributes?: BedrockAgentFunctionEvent['sessionAttributes'];
+  promptSessionAttributes?: BedrockAgentFunctionEvent['promptSessionAttributes'];
+  knowledgeBasesConfiguration?: BedrockAgentFunctionEvent['knowledgeBasesConfiguration'];
 };
 
 /**
@@ -169,4 +170,5 @@ export type {
   BedrockAgentFunctionEvent,
   BedrockAgentFunctionResponse,
   ResolverOptions,
+  ResponseState,
 };

--- a/packages/event-handler/src/types/bedrock-agent.ts
+++ b/packages/event-handler/src/types/bedrock-agent.ts
@@ -4,21 +4,45 @@ import type { BedrockAgentFunctionResolver } from '../bedrock-agent/BedrockAgent
 import type { BedrockFunctionResponse } from '../bedrock-agent/BedrockFunctionResponse.js';
 import type { GenericLogger } from '../types/common.js';
 
+/**
+ * Configuration for a tool in the Bedrock Agent Function Resolver.
+ */
 type Configuration = {
+  /**
+   * The name of the tool, which must be unique across all registered tools.
+   */
   name: string;
-  description: string;
+  /**
+   * A description of the tool, which is optional but highly recommended.
+   */
+  description?: string;
 };
 
+/**
+ * Parameter for a tool function in the Bedrock Agent Function Resolver.
+ * This is used to define the structure of parameters in tool functions.
+ */
 type Parameter = {
   name: string;
   type: 'string' | 'number' | 'integer' | 'boolean' | 'array';
   value: string;
 };
 
+/**
+ * Primitive types that can be used as parameter values in tool functions.
+ * This is used to define the structure of parameters in tool functions.
+ */
 type ParameterPrimitives = string | number | boolean;
 
+/**
+ * Represents a value for a parameter, which can be a primitive type or an array of values.
+ * This is used to define the structure of parameters in tool functions.
+ */
 type ParameterValue = ParameterPrimitives | Array<ParameterValue>;
 
+/**
+ * Function to handle tool invocations in the Bedrock Agent Function Resolver.
+ */
 type ToolFunction<TParams = Record<string, ParameterValue>> = (
   params: TParams,
   options?: {
@@ -27,11 +51,21 @@ type ToolFunction<TParams = Record<string, ParameterValue>> = (
   }
 ) => Promise<JSONValue | BedrockFunctionResponse>;
 
+/**
+ * Tool in the Bedrock Agent Function Resolver.
+ *
+ * Used to register a tool in {@link BedrockAgentFunctionResolver | `BedrockAgentFunctionResolver`}.
+ */
 type Tool<TParams = Record<string, ParameterValue>> = {
   handler: ToolFunction<TParams>;
   config: Configuration;
 };
 
+/**
+ * Function invocation in the Bedrock Agent Function Resolver.
+ *
+ * This is used to define the structure of function invocations in tool functions.
+ */
 type FunctionInvocation = {
   actionGroup: string;
   function: string;
@@ -43,7 +77,28 @@ type FunctionInvocation = {
  *
  * @example
  * ```json
- *
+ * {
+ *   "messageVersion": "1.0",
+ *   "actionGroup": "exampleActionGroup",
+ *   "function": "getWeather",
+ *   "agent": {
+ *     "name": "WeatherAgent",
+ *     "id": "agent-id-123",
+ *     "alias": "v1",
+ *     "version": "1.0"
+ *   },
+ *   "parameters": [{
+ *     "name": "location",
+ *     "type": "string",
+ *     "value": "Seattle"
+ *   }],
+ *   "inputText": "What's the weather like in Seattle?",
+ *   "sessionId": "session-id-456",
+ *   "sessionAttributes": {
+ *     "userId": "user-789",
+ *   },
+ *   "promptSessionAttributes": {},
+ * }
  * ```
  */
 type BedrockAgentFunctionEvent = {
@@ -61,10 +116,19 @@ type BedrockAgentFunctionEvent = {
   sessionId: string;
   sessionAttributes: Record<string, string>;
   promptSessionAttributes: Record<string, string>;
+  knowledgeBasesConfiguration?: Record<string, unknown>;
 };
 
+/**
+ * Represents the state of the response from a Bedrock agent function:
+ * - `FAILURE`: The agent throws a `DependencyFailedException` for the current session.
+ * - `REPROMPT`: The agent passes a response string to the model to reprompt it.
+ */
 type ResponseState = 'FAILURE' | 'REPROMPT';
 
+/**
+ * Response structure for a Bedrock agent function.
+ */
 type BedrockAgentFunctionResponse = {
   messageVersion: string;
   response: {
@@ -84,7 +148,7 @@ type BedrockAgentFunctionResponse = {
 };
 
 /**
- * Options for the {@link BedrockAgentFunctionResolver} class
+ * Options for the {@link BedrockAgentFunctionResolver | `BedrockAgentFunctionResolver`} class
  */
 type ResolverOptions = {
   /**

--- a/packages/event-handler/src/types/index.ts
+++ b/packages/event-handler/src/types/index.ts
@@ -14,6 +14,7 @@ export type {
   BedrockAgentFunctionResponse,
   ResolverOptions,
   Parameter,
+  ResponseState,
 } from './bedrock-agent.js';
 
 export type {

--- a/packages/event-handler/src/types/index.ts
+++ b/packages/event-handler/src/types/index.ts
@@ -13,6 +13,7 @@ export type {
   BedrockAgentFunctionEvent,
   BedrockAgentFunctionResponse,
   ResolverOptions,
+  Parameter,
 } from './bedrock-agent.js';
 
 export type {

--- a/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
+++ b/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
@@ -243,52 +243,6 @@ describe('Class: BedrockAgentFunctionResolver', () => {
     );
   });
 
-  it('can be invoked using the decorator pattern', async () => {
-    // Prepare
-    const app = new BedrockAgentFunctionResolver();
-
-    class Lambda {
-      @app.tool({ name: 'hello', description: 'Says hello' })
-      async helloWorld() {
-        return 'Hello, world!';
-      }
-
-      @app.tool({ name: 'add', description: 'Adds two numbers' })
-      async add(params: { a: number; b: number }) {
-        const { a, b } = params;
-        return a + b;
-      }
-
-      public async handler(event: BedrockAgentFunctionEvent, context: Context) {
-        return app.resolve(event, context);
-      }
-    }
-
-    const lambda = new Lambda();
-
-    const addEvent = createEvent('add', [
-      {
-        name: 'a',
-        type: 'number',
-        value: '1',
-      },
-      {
-        name: 'b',
-        type: 'number',
-        value: '2',
-      },
-    ]);
-
-    // Act
-    const actual = await lambda.handler(addEvent, context);
-
-    // Assess
-    expect(actual.response.function).toEqual('add');
-    expect(actual.response.functionResponse.responseBody.TEXT.body).toEqual(
-      '3'
-    );
-  });
-
   it.each([
     {
       toolFunction: async () => ({

--- a/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
+++ b/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
@@ -1,10 +1,8 @@
 import context from '@aws-lambda-powertools/testing-utils/context';
-import type { Context } from 'aws-lambda';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BedrockFunctionResponse } from '../../../src/bedrock-agent/BedrockFunctionResponse.js';
 import { BedrockAgentFunctionResolver } from '../../../src/bedrock-agent/index.js';
 import type {
-  BedrockAgentFunctionEvent,
   Configuration,
   Parameter,
   ToolFunction,
@@ -575,14 +573,6 @@ describe('Class: BedrockAgentFunctionResolver', () => {
       }
     );
 
-    const customSessionAttrs = {
-      sessionAttr: '12345',
-    };
-
-    const customPromptAttrs = {
-      promptAttr: 'promptAttr',
-    };
-
     const customEvent = {
       ...createEvent('greeting', [
         {
@@ -592,8 +582,16 @@ describe('Class: BedrockAgentFunctionResolver', () => {
         },
       ]),
       actionGroup: 'actionGroup',
-      sessionAttributes: customSessionAttrs,
-      promptSessionAttributes: customPromptAttrs,
+      sessionAttributes: {
+        sessionAttr: '12345',
+      },
+      promptSessionAttributes: {
+        promptAttr: 'promptAttr',
+      },
+      knowledgeBasesConfiguration: {
+        knowledgeBase1: { enabled: true },
+        knowledgeBase2: { enabled: false },
+      },
     };
 
     // Act
@@ -613,8 +611,9 @@ describe('Class: BedrockAgentFunctionResolver', () => {
           },
         },
       },
-      sessionAttributes: customSessionAttrs,
-      promptSessionAttributes: customPromptAttrs,
+      sessionAttributes: customEvent.sessionAttributes,
+      promptSessionAttributes: customEvent.promptSessionAttributes,
+      knowledgeBasesConfiguration: customEvent.knowledgeBasesConfiguration,
     });
   });
 });

--- a/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
+++ b/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
@@ -336,8 +336,6 @@ describe('Class: BedrockAgentFunctionResolver', () => {
     app.tool(
       async () => {
         return new BedrockFunctionResponse({
-          actionGroup: 'customActionGroup',
-          func: 'custom-response',
           body: 'I am not sure',
           responseState: 'REPROMPT',
           sessionAttributes: { customAttr: 'value' },

--- a/packages/event-handler/typedoc.json
+++ b/packages/event-handler/typedoc.json
@@ -4,6 +4,7 @@
   ],
   "entryPoints": [
     "./src/appsync-events/index.ts",
+    "./src/bedrock-agent/index.ts",
     "./src/types/index.ts",
   ],
   "readme": "README.md"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR makes a few targeted changes to the implementation of the `BedrockAgentFunctionResolver` upcoming feature, specifically:
- removed 5 tools limit on the grounds that customers can create multiple action groups in their agents backed by the same Lambda function, and thus there's no point in restricting the numbers of tools - we'll however call out the 5 tools limit in the docs (separate PR)
- made sure session, prompt, and knowledge base configurations are always propagated in responses
- removed decorator implementation because of the unsolved bug described in #3973
- added a new `BedrockFunctionResponse` class that is both used under the hood by the resolver class to build responses and can be used by customers to fully customize the response with things like session attributes of statuses
- added docstring comments to all types, classes, and methods & added the submodule to API docs reference

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3988

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
