### PR TITLE
chore: fix esm scope for layers stack

### DIFF
--- a/layers/src/canary-stack.ts
+++ b/layers/src/canary-stack.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
-import path from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { CustomResource, Duration, Stack, type StackProps } from 'aws-cdk-lib';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { LayerVersion, Runtime, Tracing } from 'aws-cdk-lib/aws-lambda';
@@ -14,6 +15,9 @@ export interface CanaryStackProps extends StackProps {
   readonly powertoolsPackageVersion: string;
   readonly ssmParameterLayerArn: string;
 }
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export class CanaryStack extends Stack {
   public constructor(scope: Construct, id: string, props: CanaryStackProps) {
@@ -36,7 +40,7 @@ export class CanaryStack extends Stack {
     ];
 
     const canaryFunction = new NodejsFunction(this, 'CanaryFunction', {
-      entry: path.join(
+      entry: join(
         __dirname,
         '../tests/e2e/layerPublisher.class.test.functionCode.ts'
       ),

--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { join, resolve, sep } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { CfnOutput, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
 import {
   Architecture,
@@ -11,6 +12,9 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import type { Construct } from 'constructs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 export interface LayerPublisherStackProps extends StackProps {
   readonly layerName?: string;


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the CDK stacks for the Lambda layers to remove usage of `__dirname` which is a feature not available in the Node.js ESM scope.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4006

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
