### PR TITLE
fix(logger): set `hourCycle` to h23 when tz is not UTC

### DIFF
--- a/packages/logger/src/formatter/LogFormatter.ts
+++ b/packages/logger/src/formatter/LogFormatter.ts
@@ -200,13 +200,13 @@ abstract class LogFormatter {
       : 'UTC';
 
     return new Intl.DateTimeFormat('en', {
+      hourCycle: 'h23',
       year: 'numeric',
       month: twoDigitFormatOption,
       day: twoDigitFormatOption,
       hour: twoDigitFormatOption,
       minute: twoDigitFormatOption,
       second: twoDigitFormatOption,
-      hour12: false,
       timeZone: validTimeZone,
     });
   };


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

This PR updates the date formatter in the `LogFormatter` base class to use [`hourCycle`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#hourcycle) set to `h23` and removes `hour12` which was set to `false`.

This allows customers to correctly format timestamps containing midnight as `00` rather than `24` in all supported Node.js runtimes.

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4083

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
