### PR TITLE
feat(event-handler): expose event & context as object

### DIFF
--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -145,8 +145,7 @@ class AppSyncGraphQLResolver extends Router {
     if (resolverHandlerOptions) {
       return resolverHandlerOptions.handler.apply(options?.scope ?? this, [
         event.arguments,
-        event,
-        context,
+        { event, context },
       ]);
     }
 

--- a/packages/event-handler/src/types/appsync-graphql.ts
+++ b/packages/event-handler/src/types/appsync-graphql.ts
@@ -7,14 +7,18 @@ import type { Router } from '../appsync-graphql/Router.js';
 
 type ResolverSyncHandlerFn<TParams = Record<string, unknown>> = (
   args: TParams,
-  event: AppSyncResolverEvent<TParams>,
-  context: Context
+  options: {
+    event: AppSyncResolverEvent<TParams>;
+    context: Context;
+  }
 ) => unknown;
 
 type ResolverHandlerFn<TParams = Record<string, unknown>> = (
   args: TParams,
-  event: AppSyncResolverEvent<TParams>,
-  context: Context
+  options: {
+    event: AppSyncResolverEvent<TParams>;
+    context: Context;
+  }
 ) => Promise<unknown>;
 
 type ResolverHandler<TParams = Record<string, unknown>> =

--- a/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
+++ b/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
@@ -174,13 +174,16 @@ describe('Class: AppSyncGraphQLResolver', () => {
   it('resolver function has access to event and context', async () => {
     // Prepare
     const app = new AppSyncGraphQLResolver({ logger: console });
-    app.onQuery<{ id: string }>('getPost', async ({ id }, event, context) => {
-      return {
-        id,
-        event,
-        context,
-      };
-    });
+    app.onQuery<{ id: string }>(
+      'getPost',
+      async ({ id }, { event, context }) => {
+        return {
+          id,
+          event,
+          context,
+        };
+      }
+    );
 
     // Act
     const event = onGraphqlEventFactory('getPost', 'Query', { id: '123' });


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the implementation of the `AppSyncGraphQLResolver` to pass the AWS Lambda function's `event` and `context` to the route resolver as an object rather than individual arguments.

This aligns the implementation to the Bedrock Agents resolver, which is how we want to expose these values moving forward.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4112

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
