### PR TITLE
fix(tracer): skip tracing CONNECT requests

### DIFF
--- a/docs/features/tracer.md
+++ b/docs/features/tracer.md
@@ -363,7 +363,7 @@ Tracer exposes a `getRootXrayTraceId()` method that allows you to retrieve the [
 
 === "index.ts"
 
-    ```typescript hl_lines="9"
+    ```typescript hl_lines="13"
     --8<-- "examples/snippets/tracer/accessRootTraceId.ts"
     ```
 

--- a/examples/snippets/tracer/accessRootTraceId.ts
+++ b/examples/snippets/tracer/accessRootTraceId.ts
@@ -1,11 +1,15 @@
+import { Logger } from '@aws-lambda-powertools/logger';
 import { Tracer } from '@aws-lambda-powertools/tracer';
 
 const tracer = new Tracer({ serviceName: 'serverlessAirline' });
+const logger = new Logger({ serviceName: 'serverlessAirline' });
 
 export const handler = async (): Promise<unknown> => {
   try {
     throw new Error('Something went wrong');
-  } catch (_error) {
+  } catch (error) {
+    logger.error('An error occurred', { error });
+
     const rootTraceId = tracer.getRootXrayTraceId();
 
     // Example of returning an error response

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -277,6 +277,8 @@ class Tracer extends Utility implements TracerInterface {
   }
 
   /**
+   * @deprecated Use {@link captureAWSv3Client | `captureAWSv3Client()`} instead.
+   *
    * Patch all AWS SDK v2 clients and create traces when your application makes calls to AWS services.
    *
    * If you want to patch a specific client use {@link captureAWSClient} and if you are using AWS SDK v3 use {@link captureAWSv3Client} instead.
@@ -295,16 +297,17 @@ class Tracer extends Utility implements TracerInterface {
    * }
    * ```
    *
-   * @deprecated Use {@link captureAWSv3Client} instead.
    * @param aws - AWS SDK v2 import
    */
-  public captureAWS<T>(aws: T): T {
+  /* v8 ignore start */ public captureAWS<T>(aws: T): T {
     if (!this.isTracingEnabled()) return aws;
 
     return this.provider.captureAWS(aws);
-  }
+  } /* v8 ignore stop */
 
   /**
+   * @deprecated Use {@link captureAWSv3Client | `captureAWSv3Client()`} instead.
+   *
    * Patch a specific AWS SDK v2 client and create traces when your application makes calls to that AWS service.
    *
    * If you want to patch all clients use {@link captureAWS} and if you are using AWS SDK v3 use {@link captureAWSv3Client} instead.
@@ -323,7 +326,7 @@ class Tracer extends Utility implements TracerInterface {
    *   ...
    * }
    * ```
-   * @deprecated Use {@link captureAWSv3Client} instead.
+   *
    * @param service - AWS SDK v2 client
    */
   /* v8 ignore start */ public captureAWSClient<T>(service: T): T {

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -48,18 +48,18 @@ import {
  */
 class ProviderService implements ProviderServiceInterface {
   /**
-   * @deprecated
+   * @deprecated Use {@link captureAWSv3Client} instead.
    */
-  public captureAWS<T>(awssdk: T): T {
+  /* v8 ignore start */ public captureAWS<T>(awssdk: T): T {
     return captureAWS(awssdk);
-  }
+  } /* v8 ignore stop */
 
   /**
-   * @deprecated
+   * @deprecated Use {@link captureAWSv3Client} instead.
    */
-  public captureAWSClient<T>(service: T): T {
+  /* v8 ignore start */ public captureAWSClient<T>(service: T): T {
     return captureAWSClient(service);
-  }
+  } /* v8 ignore stop */
 
   public captureAWSv3Client<T>(service: T): T {
     addUserAgentMiddleware(service, 'tracer');
@@ -119,12 +119,12 @@ class ProviderService implements ProviderServiceInterface {
      */
     const onRequestStart = (message: unknown): void => {
       const { request } = message as DiagnosticsChannel.RequestCreateMessage;
+      const method = request.method;
+      if (method === 'CONNECT') return;
 
       const parentSubsegment = this.getSegment();
       const requestURL = getRequestURL(request);
       if (parentSubsegment && requestURL) {
-        const method = request.method;
-
         const subsegment = parentSubsegment.addNewSubsegment(
           requestURL.hostname
         );

--- a/packages/tracer/tests/unit/ProviderService.test.ts
+++ b/packages/tracer/tests/unit/ProviderService.test.ts
@@ -47,34 +47,6 @@ describe('Class: ProviderService', () => {
     vi.clearAllMocks();
   });
 
-  describe('Method: captureAWS', () => {
-    it('calls the correct underlying function with proper arguments', () => {
-      // Prepare
-      const provider: ProviderService = new ProviderService();
-
-      // Act
-      provider.captureAWS({});
-
-      // Assess
-      expect(mocks.captureAWS).toHaveBeenCalledTimes(1);
-      expect(mocks.captureAWS).toHaveBeenCalledWith({});
-    });
-  });
-
-  describe('Method: captureAWSClient', () => {
-    it('calls the correct underlying function with proper arguments', () => {
-      // Prepare
-      const provider: ProviderService = new ProviderService();
-
-      // Act
-      provider.captureAWSClient({});
-
-      // Assess
-      expect(mocks.captureAWSClient).toHaveBeenCalledTimes(1);
-      expect(mocks.captureAWSClient).toHaveBeenCalledWith({});
-    });
-  });
-
   describe('Method: captureAWSv3Client', () => {
     it('calls the correct underlying function with proper arguments', () => {
       // Prepare
@@ -656,5 +628,23 @@ describe('Class: ProviderService', () => {
         /Root=1-abcdef12-3456abcdef123456abcdef12;Parent=\S{16};Sampled=0/
       )
     );
+  });
+
+  it('skips requests with CONNECT method', () => {
+    // Prepare
+    const provider: ProviderService = new ProviderService();
+    const segment = new Subsegment('## dummySegment');
+    vi.spyOn(provider, 'getSegment').mockImplementation(() => segment);
+    vi.spyOn(segment, 'addNewSubsegment');
+
+    // Act
+    provider.instrumentFetch();
+    mockFetch({
+      origin: 'https://aws.amazon.com',
+      method: 'CONNECT',
+    });
+
+    // Assess
+    expect(segment.addNewSubsegment).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -1456,67 +1456,36 @@ describe('Class: Tracer', () => {
         new Error('dummy error')
       );
     });
-  });
 
-  describe('Method: captureAWS', () => {
-    it('does nothing when called while tracing is disabled', () => {
-      // Prepare
-      const tracer: Tracer = new Tracer({ enabled: false });
-      const captureAWSSpy = vi
-        .spyOn(tracer.provider, 'captureAWS')
-        .mockImplementation(() => null);
+    describe('Method: captureAWSv3Client', () => {
+      it('does nothing when tracing is disabled', () => {
+        // Prepare
+        const tracer: Tracer = new Tracer({ enabled: false });
+        const captureAWSv3ClientSpy = vi
+          .spyOn(tracer.provider, 'captureAWSv3Client')
+          .mockImplementation(() => null);
 
-      // Act
-      tracer.captureAWS({});
+        // Act
+        tracer.captureAWSv3Client({});
 
-      // Assess
-      expect(captureAWSSpy).toBeCalledTimes(0);
-    });
+        // Assess
+        expect(captureAWSv3ClientSpy).toBeCalledTimes(0);
+      });
 
-    it('returns the decorated object that was passed to it', () => {
-      // Prepare
-      const tracer: Tracer = new Tracer();
-      const captureAWSSpy = vi
-        .spyOn(tracer.provider, 'captureAWS')
-        .mockImplementation(() => null);
+      it('returns the decorated object that was passed to it', () => {
+        // Prepare
+        const tracer: Tracer = new Tracer();
+        const captureAWSv3ClientSpy = vi
+          .spyOn(tracer.provider, 'captureAWSv3Client')
+          .mockImplementation(() => null);
 
-      // Act
-      tracer.captureAWS({});
+        // Act
+        tracer.captureAWSv3Client({});
 
-      // Assess
-      expect(captureAWSSpy).toBeCalledTimes(1);
-      expect(captureAWSSpy).toBeCalledWith({});
-    });
-  });
-
-  describe('Method: captureAWSv3Client', () => {
-    it('does nothing when tracing is disabled', () => {
-      // Prepare
-      const tracer: Tracer = new Tracer({ enabled: false });
-      const captureAWSv3ClientSpy = vi
-        .spyOn(tracer.provider, 'captureAWSv3Client')
-        .mockImplementation(() => null);
-
-      // Act
-      tracer.captureAWSv3Client({});
-
-      // Assess
-      expect(captureAWSv3ClientSpy).toBeCalledTimes(0);
-    });
-
-    it('returns the decorated object that was passed to it', () => {
-      // Prepare
-      const tracer: Tracer = new Tracer();
-      const captureAWSv3ClientSpy = vi
-        .spyOn(tracer.provider, 'captureAWSv3Client')
-        .mockImplementation(() => null);
-
-      // Act
-      tracer.captureAWSv3Client({});
-
-      // Assess
-      expect(captureAWSv3ClientSpy).toBeCalledTimes(1);
-      expect(captureAWSv3ClientSpy).toBeCalledWith({});
+        // Assess
+        expect(captureAWSv3ClientSpy).toBeCalledTimes(1);
+        expect(captureAWSv3ClientSpy).toBeCalledWith({});
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR fixes the bug described in the linked issue, which caused runtime errors when using the Tracer with requests being sent via a proxy using the `fetch` module. Moving forward, tracing of these requests will be skipped entirely and the only request that will appear in the trace data will be the one being proxied.

This aligns with the Powertools for AWS Lambda (Python) and X-Ray SDK implementations, as well as what suggested by the customer reporting the bug in the linked issue.

While working on this PR I also removed some old unit tests that covered portions of code that were deprecated. These same lines are also now excluded from the coverage report.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** fixes #4114

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
