### PR TITLE
refactor(ci): Updated the publish command in the CI to use `npm publish` instead of `lerna publish`

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -65,7 +65,7 @@ jobs:
         uses: aws-powertools/actions/.github/actions/cached-node-modules@29979bc5339bf54f76a11ac36ff67701986bb0f0
       - name: Publish to npm
         run: |
-          NPM_CONFIG_PROVENANCE=true npx lerna publish from-package --git-head ${{ github.sha }} --yes 
+          npm publish --workspaces --provenance
       - name: Set release version
         id: set-release-version
         run: |

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -50,4 +50,4 @@ jobs:
         uses: aws-powertools/actions/.github/actions/cached-node-modules@29979bc5339bf54f76a11ac36ff67701986bb0f0
       - name: Publish to npm
         run: |
-          NPM_CONFIG_PROVENANCE=true npx lerna publish from-package --force-publish ${{ github.event.input.package }} --git-head ${{ github.sha }} --yes
+          npm publish --workspace ${{ github.event.input.package }} --provenance


### PR DESCRIPTION
## Summary

This PR updates the `make-release` and `publish-package` Github workflows to switch from using publish commands from `lerna` to the native `npm` publish command to publish the packages to the npm registry.

### Changes

- Updated the `lerna publish` command to `npm publish` in the `make-release.yml` and `publish-package.yml` Github workflows
- For generating provenance statements, the `--provenance` flag was used
-  The `from-package` from lerna was removed as `npm publish` uses the `--workspaces` flag to publish all the workspaces which are not marked as `private`. If a package with the same version is tried to be published, it will throw an error
- To publish an individual package through `publish-package.yml`, the `--workspace <workspace-path>` was used

**Issue number:** 
#4171 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
