### PR TITLE
ci: update `make-release.yml` workflow to use latest upstream

### DIFF
--- a/.github/workflows/make-version.yml
+++ b/.github/workflows/make-version.yml
@@ -34,13 +34,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - name: Setup dependencies
-        uses: aws-powertools/actions/.github/actions/cached-node-modules@5ae7c190d6b51491bb14f593c3509c1bcbf7a3c1 # v1.1.0
+        uses: aws-powertools/actions/.github/actions/cached-node-modules@7d2401cbbb232594bde7285bc5b8c0c78dcbe6e2 # v1.2.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           build: "false"
       - name: Version and changelog
         id: version-n-changelog
-        uses: aws-powertools/actions/.github/actions/version-n-changelog@5ae7c190d6b51491bb14f593c3509c1bcbf7a3c1 # v1.1.0
+        uses: aws-powertools/actions/.github/actions/version-n-changelog@7d2401cbbb232594bde7285bc5b8c0c78dcbe6e2 # v1.2.0
         with:
           release-type: ${{ github.event.inputs.release-type }}
       - name: Update user agent version
@@ -51,7 +51,7 @@ jobs:
         run: git add .
       - name: Create PR
         id: create-pr
-        uses: aws-powertools/actions/.github/actions/create-pr@5ae7c190d6b51491bb14f593c3509c1bcbf7a3c1 # v1.1.0
+        uses: aws-powertools/actions/.github/actions/create-pr@7d2401cbbb232594bde7285bc5b8c0c78dcbe6e2 # v1.2.0
         with:
           temp_branch_prefix: "ci-bump"
           pull_request_title: "chore(ci): bump version to ${{ steps.version-n-changelog.outputs.new-version  }}"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the hash of the GitHub Actions coming from the `aws-powertools/actions` repo in the `make-release.yml` workflow to use the latest v1.2.0 release, which should address the issue that prevents PRs with the changelog and versioned packages to be opened as seen [here](https://github.com/aws-powertools/powertools-lambda-typescript/actions/runs/16509178066/job/46687350480#step:8:60).

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4214

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
