### PR TITLE
ci: fix version output interpolation in make-version workflow

### DIFF
--- a/.github/workflows/make-version.yml
+++ b/.github/workflows/make-version.yml
@@ -45,8 +45,7 @@ jobs:
           release-type: ${{ github.event.inputs.release-type }}
       - name: Update user agent version
         run: |
-          VERSION=$(${{ steps.version-n-changelog.outputs.new-version }})
-          echo -e "// this file is auto generated, do not modify\nexport const PT_VERSION = '$VERSION';" > packages/commons/src/version.ts
+          echo -e "// this file is auto generated, do not modify\nexport const PT_VERSION = '${{ steps.version-n-changelog.outputs.new-version }}';" > packages/commons/src/version.ts
       - name: Stage changes
         run: git add .
       - name: Create PR


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the `make-version.yml` workflow, and specifically the step that updates the `packages/commons/src/version.ts` file with the new version. Some of the refactors done in previous PRs since the last release broke the command by removing enclosing quotes around the version number.

This PR addresses this by simplifying the interpolation, and hopefully fixing the workflow once and for all.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4214

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
