### PR TITLE
fix(metrics): emit warning when default dimensions are overwritten

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -240,8 +240,10 @@ class Metrics extends Utility implements MetricsInterface {
     super();
 
     this.dimensions = {};
-    this.setOptions(options);
+    this.setEnvConfig();
+    this.setConsole();
     this.#logger = options.logger || this.console;
+    this.setOptions(options);
   }
 
   /**
@@ -824,13 +826,39 @@ class Metrics extends Utility implements MetricsInterface {
    * @param dimensions - The dimensions to be added to the default dimensions object
    */
   public setDefaultDimensions(dimensions: Dimensions | undefined): void {
+    if (!dimensions) return;
+
+    const cleanedDimensions: Dimensions = {};
+
+    for (const [key, value] of Object.entries(dimensions)) {
+      if (
+        isStringUndefinedNullEmpty(key) ||
+        isStringUndefinedNullEmpty(value)
+      ) {
+        this.#logger.warn(
+          `The dimension ${key} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
+        );
+        continue;
+      }
+
+      if (Object.hasOwn(this.defaultDimensions, key)) {
+        this.#logger.warn(
+          `Dimension "${key}" has already been added. The previous value will be overwritten.`
+        );
+      }
+
+      cleanedDimensions[key] = value;
+    }
+
     const targetDimensions = {
       ...this.defaultDimensions,
-      ...dimensions,
+      ...cleanedDimensions,
     };
-    if (MAX_DIMENSION_COUNT <= Object.keys(targetDimensions).length) {
+
+    if (Object.keys(targetDimensions).length >= MAX_DIMENSION_COUNT) {
       throw new Error('Max dimension count hit');
     }
+
     this.defaultDimensions = targetDimensions;
   }
 
@@ -1058,8 +1086,6 @@ class Metrics extends Utility implements MetricsInterface {
       functionName,
     } = options;
 
-    this.setEnvConfig();
-    this.setConsole();
     this.setCustomConfigService(customConfigService);
     this.setDisabled();
     this.setNamespace(namespace);

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -828,17 +828,7 @@ class Metrics extends Utility implements MetricsInterface {
    * @param dimensions - The dimensions to be added to the default dimensions object
    */
   public setDefaultDimensions(dimensions: Dimensions | undefined): void {
-    if (isNullOrUndefined(dimensions)) {
-      this.#logger.warn(
-        'No dimensions were supplied to setDefaultDimensions. Skipping update.'
-      );
-      return;
-    }
-
-    if (!isRecord(dimensions)) {
-      this.#logger.warn(
-        'Invalid dimensions type provided to setDefaultDimensions. Expected an object.'
-      );
+    if (isNullOrUndefined(dimensions) || !isRecord(dimensions)) {
       return;
     }
 

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -826,7 +826,12 @@ class Metrics extends Utility implements MetricsInterface {
    * @param dimensions - The dimensions to be added to the default dimensions object
    */
   public setDefaultDimensions(dimensions: Dimensions | undefined): void {
-    if (!dimensions) return;
+    if (!dimensions) {
+      this.#logger.warn(
+        'No dimensions were supplied to setDefaultDimensions. Skipping update.'
+      );
+      return;
+    }
 
     const cleanedDimensions: Dimensions = {};
 

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -1,7 +1,9 @@
 import { Console } from 'node:console';
 import {
   isIntegerNumber,
+  isNullOrUndefined,
   isNumber,
+  isRecord,
   isString,
   isStringUndefinedNullEmpty,
   Utility,
@@ -826,9 +828,16 @@ class Metrics extends Utility implements MetricsInterface {
    * @param dimensions - The dimensions to be added to the default dimensions object
    */
   public setDefaultDimensions(dimensions: Dimensions | undefined): void {
-    if (!dimensions) {
+    if (isNullOrUndefined(dimensions)) {
       this.#logger.warn(
         'No dimensions were supplied to setDefaultDimensions. Skipping update.'
+      );
+      return;
+    }
+
+    if (!isRecord(dimensions)) {
+      this.#logger.warn(
+        'Invalid dimensions type provided to setDefaultDimensions. Expected an object.'
       );
       return;
     }

--- a/packages/metrics/tests/unit/creatingMetrics.test.ts
+++ b/packages/metrics/tests/unit/creatingMetrics.test.ts
@@ -182,9 +182,6 @@ describe('Creating metrics', () => {
     const metrics = new Metrics({
       singleMetric: false,
       namespace: DEFAULT_NAMESPACE,
-      defaultDimensions: {
-        enviroment: 'test',
-      },
     });
 
     // Act

--- a/packages/metrics/tests/unit/creatingMetrics.test.ts
+++ b/packages/metrics/tests/unit/creatingMetrics.test.ts
@@ -182,6 +182,9 @@ describe('Creating metrics', () => {
     const metrics = new Metrics({
       singleMetric: false,
       namespace: DEFAULT_NAMESPACE,
+      defaultDimensions: {
+        enviroment: 'test',
+      },
     });
 
     // Act

--- a/packages/metrics/tests/unit/customTimestamp.test.ts
+++ b/packages/metrics/tests/unit/customTimestamp.test.ts
@@ -48,7 +48,12 @@ describe('Setting custom timestamp', () => {
 
   it('logs a warning when the provided timestamp is too far in the past', () => {
     // Prepare
-    const metrics = new Metrics({ singleMetric: true });
+    const metrics = new Metrics({
+      singleMetric: true,
+      defaultDimensions: {
+        environment: 'test',
+      },
+    });
 
     // Act
     metrics.setTimestamp(Date.now() - EMF_MAX_TIMESTAMP_PAST_AGE - 1000);
@@ -63,7 +68,12 @@ describe('Setting custom timestamp', () => {
 
   it('logs a warning when the provided timestamp is too far in the future', () => {
     // Prepare
-    const metrics = new Metrics({ singleMetric: true });
+    const metrics = new Metrics({
+      singleMetric: true,
+      defaultDimensions: {
+        environment: 'test',
+      },
+    });
 
     // Act
     metrics.setTimestamp(Date.now() + EMF_MAX_TIMESTAMP_FUTURE_AGE + 1000);
@@ -81,6 +91,9 @@ describe('Setting custom timestamp', () => {
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
+      defaultDimensions: {
+        environment: 'test',
+      },
     });
 
     // Act
@@ -108,6 +121,9 @@ describe('Setting custom timestamp', () => {
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
+      defaultDimensions: {
+        environment: 'test',
+      },
     });
 
     // Act

--- a/packages/metrics/tests/unit/customTimestamp.test.ts
+++ b/packages/metrics/tests/unit/customTimestamp.test.ts
@@ -50,9 +50,6 @@ describe('Setting custom timestamp', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
-      defaultDimensions: {
-        environment: 'test',
-      },
     });
 
     // Act
@@ -70,9 +67,6 @@ describe('Setting custom timestamp', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
-      defaultDimensions: {
-        environment: 'test',
-      },
     });
 
     // Act
@@ -91,9 +85,6 @@ describe('Setting custom timestamp', () => {
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
-      defaultDimensions: {
-        environment: 'test',
-      },
     });
 
     // Act
@@ -121,9 +112,6 @@ describe('Setting custom timestamp', () => {
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
-      defaultDimensions: {
-        environment: 'test',
-      },
     });
 
     // Act

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -579,7 +579,7 @@ describe('Working with dimensions', () => {
     );
   });
 
-  it('logs a warning and returns immediately if dimensions is undefined', () => {
+  it('returns immediately if dimensions is undefined', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
@@ -590,9 +590,7 @@ describe('Working with dimensions', () => {
     metrics.addMetric('myMetric', MetricUnit.Count, 1);
 
     // Assert
-    expect(console.warn).toHaveBeenCalledWith(
-      'No dimensions were supplied to setDefaultDimensions. Skipping update.'
-    );
+    expect(console.warn).not.toHaveBeenCalled();
 
     expect(console.log).toHaveEmittedEMFWith(
       expect.objectContaining({
@@ -641,24 +639,19 @@ describe('Working with dimensions', () => {
       );
     }
   );
-  it('logs a warning and returns immediately if dimensions is not a plain object (fails isRecord)', () => {
+  it('returns immediately without logging if dimensions is not a plain object', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
-      defaultDimensions: {
-        enviroment: 'test',
-      },
     });
 
     // Act
-    // @ts-expect-error – intentionally passing an invalid value to simulate bad input at runtime
-    metrics.setDefaultDimensions('invalid-dimensions');
+    // @ts-expect-error – simulate runtime misuse
+    metrics.setDefaultDimensions('not-an-object');
 
     // Assert
-    expect(console.warn).toHaveBeenCalledWith(
-      'Invalid dimensions type provided to setDefaultDimensions. Expected an object.'
-    );
+    expect(console.warn).not.toHaveBeenCalled();
 
     metrics.addMetric('someMetric', MetricUnit.Count, 1);
 

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -462,9 +462,6 @@ describe('Working with dimensions', () => {
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
-      defaultDimensions: {
-        enviroment: 'test',
-      },
     });
 
     // Act & Assess
@@ -501,9 +498,6 @@ describe('Working with dimensions', () => {
       const metrics = new Metrics({
         singleMetric: true,
         namespace: DEFAULT_NAMESPACE,
-        defaultDimensions: {
-          enviroment: 'test',
-        },
       });
 
       // Act & Assess
@@ -611,9 +605,6 @@ describe('Working with dimensions', () => {
       const metrics = new Metrics({
         singleMetric: true,
         namespace: DEFAULT_NAMESPACE,
-        defaultDimensions: {
-          enviroment: 'test',
-        },
       });
 
       // Act

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -641,4 +641,31 @@ describe('Working with dimensions', () => {
       );
     }
   );
+  it('logs a warning and returns immediately if dimensions is not a plain object (fails isRecord)', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+      namespace: DEFAULT_NAMESPACE,
+      defaultDimensions: {
+        enviroment: 'test',
+      },
+    });
+
+    // Act
+    // @ts-expect-error – intentionally passing an invalid value to simulate bad input at runtime
+    metrics.setDefaultDimensions('invalid-dimensions');
+
+    // Assert
+    expect(console.warn).toHaveBeenCalledWith(
+      'Invalid dimensions type provided to setDefaultDimensions. Expected an object.'
+    );
+
+    metrics.addMetric('someMetric', MetricUnit.Count, 1);
+
+    expect(console.log).toHaveEmittedEMFWith(
+      expect.objectContaining({
+        service: 'hello-world',
+      })
+    );
+  });
 });

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -462,6 +462,9 @@ describe('Working with dimensions', () => {
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
+      defaultDimensions: {
+        enviroment: 'test',
+      },
     });
 
     // Act & Assess
@@ -498,6 +501,9 @@ describe('Working with dimensions', () => {
       const metrics = new Metrics({
         singleMetric: true,
         namespace: DEFAULT_NAMESPACE,
+        defaultDimensions: {
+          enviroment: 'test',
+        },
       });
 
       // Act & Assess
@@ -573,23 +579,28 @@ describe('Working with dimensions', () => {
     );
   });
 
-  it('returns immediately if dimensions is undefined', () => {
+  it('logs a warning and returns immediately if dimensions is undefined', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
       namespace: DEFAULT_NAMESPACE,
     });
+
     // Act
-    metrics.setDefaultDimensions(undefined);
     metrics.addMetric('myMetric', MetricUnit.Count, 1);
-    // Assess: No warning, only default dimensions/service
-    expect(console.warn).not.toHaveBeenCalled();
+
+    // Assert
+    expect(console.warn).toHaveBeenCalledWith(
+      'No dimensions were supplied to setDefaultDimensions. Skipping update.'
+    );
+
     expect(console.log).toHaveEmittedEMFWith(
       expect.objectContaining({
         service: 'hello-world',
       })
     );
   });
+
   it.each([
     { value: undefined, name: 'valid-name' },
     { value: null, name: 'valid-name' },
@@ -602,6 +613,9 @@ describe('Working with dimensions', () => {
       const metrics = new Metrics({
         singleMetric: true,
         namespace: DEFAULT_NAMESPACE,
+        defaultDimensions: {
+          enviroment: 'test',
+        },
       });
 
       // Act

--- a/packages/metrics/tests/unit/initializeMetrics.test.ts
+++ b/packages/metrics/tests/unit/initializeMetrics.test.ts
@@ -67,9 +67,6 @@ describe('Initialize Metrics', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
-      defaultDimensions: {
-        environment: 'test',
-      },
     });
 
     // Act

--- a/packages/metrics/tests/unit/initializeMetrics.test.ts
+++ b/packages/metrics/tests/unit/initializeMetrics.test.ts
@@ -65,7 +65,12 @@ describe('Initialize Metrics', () => {
 
   it('uses the default namespace when none is provided', () => {
     // Prepare
-    const metrics = new Metrics({ singleMetric: true });
+    const metrics = new Metrics({
+      singleMetric: true,
+      defaultDimensions: {
+        environment: 'test',
+      },
+    });
 
     // Act
     metrics.addMetric('test', MetricUnit.Count, 1);


### PR DESCRIPTION
## Summary
Adds warning messages to the Metrics `setDefaultDimensions` method when overwriting existing default dimensions, ensuring consistency and parity with `addDimension`/`addDimensions` methods.

### Changes

This pull request improves the robustness of the `setDefaultDimensions` method in the Metrics utility by:

- Moved setEnvConfig() and setConsole() calls from setOptions() to the constructor to ensure logger is initialized before any method uses it.
- Ensuring it gracefully handles `undefined`, `null`, and invalid values for default dimensions.
- Updated the `setDefaultDimensions()` method in the Metrics utility to emit a warning when a default dimension is being overwritten.
- Logging a warning if an invalid dimension name or value is provided (i.e., non-string or empty).
- Adding new unit tests to verify the above behaviors, including:
  - Ensuring that calling `setDefaultDimensions(undefined)` results in immediate return, with no warning emitted and only default dimensions applied.
  - Verifying that invalid dimension values (undefined, null, empty strings) or names are skipped, a warning is emitted in the console, and only valid dimensions are set.



This PR addresses [#4134](https://github.com/aws-powertools/powertools-lambda-typescript/issues/4134) by improving input validation and error reporting for the `setDefaultDimensions` method in the Metrics module, to prevent invalid dimension names/values from being set.

**Issue number:** #4134

### Tests Added

The following tests were added:

```typescript
it('returns immediately if dimensions is undefined', () => {
  // Prepare
  const metrics = new Metrics({
    singleMetric: true,
    namespace: DEFAULT_NAMESPACE,
  });
  // Act
  metrics.setDefaultDimensions(undefined);
  metrics.addMetric('myMetric', MetricUnit.Count, 1);
  // Assess: No warning, only default dimensions/service
  expect(console.warn).not.toHaveBeenCalled();
  expect(console.log).toHaveEmittedEMFWith(
    expect.objectContaining({
      service: 'hello-world',
    })
  );
});

it.each([
  { value: undefined, name: 'valid-name' },
  { value: null, name: 'valid-name' },
  { value: '', name: 'valid-name' },
  { value: 'valid-value', name: '' },
])(
  'skips invalid default dimension values in setDefaultDimensions ($name)',
  ({ value, name }) => {
    // Arrange
    const metrics = new Metrics({
      singleMetric: true,
      namespace: DEFAULT_NAMESPACE,
    });

    // Act
    metrics.setDefaultDimensions({
      validDimension: 'valid',
      [name as string]: value as string,
    });

    metrics.addMetric('test', MetricUnit.Count, 1);
    metrics.publishStoredMetrics();

    // Assert
    expect(console.warn).toHaveBeenCalledWith(
      `The dimension ${name} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
    );

    expect(console.log).toHaveEmittedEMFWith(
      expect.objectContaining({ validDimension: 'valid' })
    );

    expect(console.log).toHaveEmittedEMFWith(
      expect.not.objectContaining({ [name]: value })
    );
  }
);
```

### setDefaultDimensions Update

- Modified to emit a warning if a dimension name or value does not meet requirements (non-empty string).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.