### PR TITLE
refactor(event-handler): replace EnvironmentVariablesService class with helper functions in Event Handler

### DIFF
--- a/packages/event-handler/src/appsync-events/Router.ts
+++ b/packages/event-handler/src/appsync-events/Router.ts
@@ -1,4 +1,3 @@
-import { EnvironmentVariablesService } from '@aws-lambda-powertools/commons';
 import type { GenericLogger } from '@aws-lambda-powertools/commons/types';
 import { isRecord } from '@aws-lambda-powertools/commons/typeutils';
 import type {
@@ -8,6 +7,7 @@ import type {
   RouterOptions,
 } from '../types/appsync-events.js';
 import { RouteHandlerRegistry } from './RouteHandlerRegistry.js';
+import { getStringFromEnv, isDevMode } from '@aws-lambda-powertools/commons/utils/env';
 
 /**
  * Class for registering routes for the `onPublish` and `onSubscribe` events in AWS AppSync Events APIs.
@@ -31,14 +31,12 @@ class Router {
    * Whether the router is running in development mode.
    */
   protected readonly isDev: boolean = false;
-  /**
-   * The environment variables service instance.
-   */
-  protected readonly envService: EnvironmentVariablesService;
-
+ 
   public constructor(options?: RouterOptions) {
-    this.envService = new EnvironmentVariablesService();
-    const alcLogLevel = this.envService.get('AWS_LAMBDA_LOG_LEVEL');
+    const alcLogLevel = getStringFromEnv({
+      key: 'AWS_LAMBDA_LOG_LEVEL',
+      defaultValue: '',
+    });
     this.logger = options?.logger ?? {
       debug: alcLogLevel === 'DEBUG' ? console.debug : () => undefined,
       error: console.error,
@@ -52,7 +50,7 @@ class Router {
       logger: this.logger,
       eventType: 'onSubscribe',
     });
-    this.isDev = this.envService.isDevMode();
+    this.isDev = isDevMode();
   }
 
   /**

--- a/packages/event-handler/src/appsync-events/Router.ts
+++ b/packages/event-handler/src/appsync-events/Router.ts
@@ -1,5 +1,6 @@
 import type { GenericLogger } from '@aws-lambda-powertools/commons/types';
 import { isRecord } from '@aws-lambda-powertools/commons/typeutils';
+import { getStringFromEnv, isDevMode } from '@aws-lambda-powertools/commons/utils/env';
 import type {
   OnPublishHandler,
   OnSubscribeHandler,
@@ -7,7 +8,6 @@ import type {
   RouterOptions,
 } from '../types/appsync-events.js';
 import { RouteHandlerRegistry } from './RouteHandlerRegistry.js';
-import { getStringFromEnv, isDevMode } from '@aws-lambda-powertools/commons/utils/env';
 
 /**
  * Class for registering routes for the `onPublish` and `onSubscribe` events in AWS AppSync Events APIs.


### PR DESCRIPTION
## Summary

### Changes

This PR removes the legacy class-based EnvironmentVariablesService from the Event Handler package and replaces it with functional helpers.
- Changed the contents of `packages/event-handler/src/appsync-events/Router.ts` removing the `EnvironmentVariablesService` import and added `@aws-lambda-powertools/commons/utils/env` functions.

**Issue number:** #4115 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
