### PR TITLE
Fix/service dimension cleanup

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -437,11 +437,6 @@ class Metrics extends Utility implements MetricsInterface {
     if (!this.getColdStart()) return;
     const singleMetric = this.singleMetric();
 
-    if (this.defaultDimensions.service) {
-      singleMetric.setDefaultDimensions({
-        service: this.defaultDimensions.service,
-      });
-    }
     const value = this.functionName?.trim() ?? functionName?.trim();
     if (value && value.length > 0) {
       singleMetric.addDimension('function_name', value);
@@ -846,9 +841,14 @@ class Metrics extends Utility implements MetricsInterface {
       }
 
       if (Object.hasOwn(this.defaultDimensions, key)) {
-        this.#logger.warn(
-          `Dimension "${key}" has already been added. The previous value will be overwritten.`
-        );
+        const currentValue = this.defaultDimensions[key];
+        const suppressOverwriteWarning =
+          key === 'service' && currentValue === this.defaultServiceName;
+        if (!suppressOverwriteWarning) {
+          this.#logger.warn(
+            `Dimension "${key}" has already been added. The previous value will be overwritten.`
+          );
+        }
       }
 
       cleanedDimensions[key] = value;

--- a/packages/metrics/tests/unit/customTimestamp.test.ts
+++ b/packages/metrics/tests/unit/customTimestamp.test.ts
@@ -48,7 +48,9 @@ describe('Setting custom timestamp', () => {
 
   it('logs a warning when the provided timestamp is too far in the past', () => {
     // Prepare
-    const metrics = new Metrics({ singleMetric: true });
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
 
     // Act
     metrics.setTimestamp(Date.now() - EMF_MAX_TIMESTAMP_PAST_AGE - 1000);
@@ -63,7 +65,9 @@ describe('Setting custom timestamp', () => {
 
   it('logs a warning when the provided timestamp is too far in the future', () => {
     // Prepare
-    const metrics = new Metrics({ singleMetric: true });
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
 
     // Act
     metrics.setTimestamp(Date.now() + EMF_MAX_TIMESTAMP_FUTURE_AGE + 1000);

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -552,4 +552,104 @@ describe('Working with dimensions', () => {
       })
     );
   });
+
+  it('warns when setDefaultDimensions overwrites existing dimensions', () => {
+    // Prepare
+    const metrics = new Metrics({
+      namespace: DEFAULT_NAMESPACE,
+      defaultDimensions: { environment: 'prod' },
+    });
+
+    // Act
+    metrics.setDefaultDimensions({ region: 'us-east-1' });
+    metrics.setDefaultDimensions({
+      environment: 'staging', // overwrites default dimension
+    });
+
+    // Assess
+    expect(console.warn).toHaveBeenCalledOnce();
+    expect(console.warn).toHaveBeenCalledWith(
+      'Dimension "environment" has already been added. The previous value will be overwritten.'
+    );
+  });
+
+  it('returns immediately if dimensions is undefined', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+      namespace: DEFAULT_NAMESPACE,
+    });
+
+    // Act
+    metrics.addMetric('myMetric', MetricUnit.Count, 1);
+
+    // Assert
+    expect(console.warn).not.toHaveBeenCalled();
+
+    expect(console.log).toHaveEmittedEMFWith(
+      expect.objectContaining({
+        service: 'hello-world',
+      })
+    );
+  });
+
+  it.each([
+    { value: undefined, name: 'valid-name' },
+    { value: null, name: 'valid-name' },
+    { value: '', name: 'valid-name' },
+    { value: 'valid-value', name: '' },
+  ])(
+    'skips invalid default dimension values in setDefaultDimensions ($name)',
+    ({ value, name }) => {
+      // Arrange
+      const metrics = new Metrics({
+        singleMetric: true,
+        namespace: DEFAULT_NAMESPACE,
+      });
+
+      // Act
+      metrics.setDefaultDimensions({
+        validDimension: 'valid',
+        [name as string]: value as string,
+      });
+
+      metrics.addMetric('test', MetricUnit.Count, 1);
+      metrics.publishStoredMetrics();
+
+      // Assert
+      expect(console.warn).toHaveBeenCalledWith(
+        `The dimension ${name} doesn't meet the requirements and won't be added. Ensure the dimension name and value are non empty strings`
+      );
+
+      expect(console.log).toHaveEmittedEMFWith(
+        expect.objectContaining({ validDimension: 'valid' })
+      );
+
+      expect(console.log).toHaveEmittedEMFWith(
+        expect.not.objectContaining({ [name]: value })
+      );
+    }
+  );
+  it('returns immediately without logging if dimensions is not a plain object', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+      namespace: DEFAULT_NAMESPACE,
+    });
+
+    // Act
+    // @ts-expect-error – simulate runtime misuse
+    metrics.setDefaultDimensions('not-an-object');
+
+    // Assert
+    expect(console.warn).not.toHaveBeenCalled();
+
+    metrics.addMetric('someMetric', MetricUnit.Count, 1);
+
+    expect(console.log).toHaveEmittedEMFWith(
+      expect.objectContaining({
+        service: 'hello-world',
+      })
+    );
+  });
 });

--- a/packages/metrics/tests/unit/initializeMetrics.test.ts
+++ b/packages/metrics/tests/unit/initializeMetrics.test.ts
@@ -65,7 +65,9 @@ describe('Initialize Metrics', () => {
 
   it('uses the default namespace when none is provided', () => {
     // Prepare
-    const metrics = new Metrics({ singleMetric: true });
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
 
     // Act
     metrics.addMetric('test', MetricUnit.Count, 1);


### PR DESCRIPTION
## Summary
This PR restores and improves the warning mechanism for overwritten default dimensions in the `Metrics` utility:

### Changes
* **Restores** the warning logic that was unintentionally removed in a prior revert.
* **Fixes a bug** where calling `captureColdStartMetric()` would emit **duplicate warnings** for the `service` dimension.
* **Refines warning behavior** to only trigger when the overwritten `service` dimension is different from the internal default (i.e., truly user-defined).

---

### Additional Fix

Previously, passing `defaultDimensions` with a `service` key in the constructor triggered **unnecessary warnings**, beacause `service` was set internally as a default dimension via `setService()`:

```ts
new Metrics({
  defaultDimensions: {
    service: 'auth-service', // <-- warning was wrongly emitted 
  },
});
```

Now, this behavior is handled correctly. **No warning is emitted** if the `service` in `defaultDimensions` is the same as the internal default service name.

---

### Final Fix Summary

* Avoids redundant call to `setDefaultDimensions()` inside `captureColdStartMetric()`, which previously caused a second warning.
* Prevents unnecessary or duplicate warnings when instantiating `Metrics` with `service` value in `defaultDimensions`.



**Issue number:** #4134

---

### Note

Instantiating the object like this will still emit a warning as user is trying to overwrite previously passed `serviceName`, even if they are equal. This behaviour is consistent with other methods like `addDimensions` and `addDimension`.
```ts
const metrics = new Metrics({
  serviceName: 'some-service',
  defaultDimensions: {
    service: 'some-service', // ⚠️ Warning: service already added
  },
});
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.