### PR TITLE
chore: drop Node.js 18 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,6 @@ body:
       options:
         - 22.x
         - 20.x
-        - 18.x
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -19,7 +19,7 @@ jobs:
       NODE_ENV: dev
     strategy:
       matrix:
-        version: [18, 20, 22]
+        version: [20, 22]
         workspace: [
           "packages/batch",
           "packages/commons",

--- a/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
       NODE_ENV: dev
     strategy:
       matrix:
-        version: [18, 20, 22]
+        version: [20, 22]
         workspace: [
           "packages/batch",
           "packages/commons",

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -33,7 +33,7 @@ jobs:
             packages/tracer,
             layers,
           ]
-        version: [18, 20, 22]
+        version: [20, 22]
         arch: [x86_64, arm64]
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013  -->
 # Powertools for AWS Lambda (TypeScript)
 
-![NodeSupport](https://img.shields.io/static/v1?label=node&message=%2018|%2020|%2022&style=flat&logo=nodedotjs)
+![NodeSupport](https://img.shields.io/static/v1?label=node&message=%2020|%2022&style=flat&logo=nodedotjs)
 ![GitHub Release](https://img.shields.io/github/v/release/aws-powertools/powertools-lambda-typescript?style=flat)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aws-powertools_powertools-lambda-typescript&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aws-powertools_powertools-lambda-typescript)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=aws-powertools_powertools-lambda-typescript&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=aws-powertools_powertools-lambda-typescript)

--- a/docs/getting-started/lambda-layers.md
+++ b/docs/getting-started/lambda-layers.md
@@ -109,7 +109,6 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
         "CreatedDate": "2025-04-08T07:38:30.424+0000",
         "Version": 24,
         "CompatibleRuntimes": [
-            "nodejs18.x",
             "nodejs20.x",
             "nodejs22.x"
         ],

--- a/layers/package.json
+++ b/layers/package.json
@@ -12,7 +12,6 @@
     "test:unit": "vitest --run tests/unit",
     "test:unit:coverage": "echo 'Not Implemented'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs18x": "echo 'Not Implemented'",
     "test:e2e:nodejs20x": "echo 'Not Implemented'",
     "test:e2e:nodejs22x": "echo 'Not Implemented'",
     "test:e2e": "vitest --run tests/e2e",

--- a/layers/src/canary-stack.ts
+++ b/layers/src/canary-stack.ts
@@ -45,7 +45,7 @@ export class CanaryStack extends Stack {
         '../tests/e2e/layerPublisher.class.test.functionCode.ts'
       ),
       handler: 'handler',
-      runtime: Runtime.NODEJS_18_X,
+      runtime: Runtime.NODEJS_20_X,
       functionName: `canary-${suffix}`,
       timeout: Duration.seconds(30),
       bundling: {

--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -41,11 +41,7 @@ export class LayerPublisherStack extends Stack {
     this.lambdaLayerVersion = new LayerVersion(this, 'LambdaPowertoolsLayer', {
       layerVersionName: props?.layerName,
       description: `Powertools for AWS Lambda (TypeScript) version ${powertoolsPackageVersion}`,
-      compatibleRuntimes: [
-        Runtime.NODEJS_18_X,
-        Runtime.NODEJS_20_X,
-        Runtime.NODEJS_22_X,
-      ],
+      compatibleRuntimes: [Runtime.NODEJS_20_X, Runtime.NODEJS_22_X],
       license: 'MIT-0',
       compatibleArchitectures: [Architecture.ARM_64, Architecture.X86_64],
       code: Code.fromAsset(resolve(__dirname), {

--- a/layers/tests/unit/layer-publisher.test.ts
+++ b/layers/tests/unit/layer-publisher.test.ts
@@ -20,7 +20,7 @@ describe('Class: LayerPublisherStack', () => {
     // Assess
     template.resourceCountIs('AWS::Lambda::LayerVersion', 1);
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      CompatibleRuntimes: ['nodejs18.x', 'nodejs20.x', 'nodejs22.x'],
+      CompatibleRuntimes: ['nodejs20.x', 'nodejs22.x'],
       LicenseInfo: 'MIT-0',
       /* CompatibleArchitectures: [
         'x86_64',

--- a/layers/tests/unit/layer-publisher.test.ts
+++ b/layers/tests/unit/layer-publisher.test.ts
@@ -1,7 +1,7 @@
 import { App } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { describe, it } from 'vitest';
-import { LayerPublisherStack } from '../../src/layer-publisher-stack';
+import { LayerPublisherStack } from '../../src/layer-publisher-stack.js';
 
 describe('Class: LayerPublisherStack', () => {
   it('creates the stack with a layer in it', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vitest": "^3.0.9"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "examples/app": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
         "markdownlint-cli2": "^0.18.1",
-        "middy4": "npm:@middy/core@^4.7.0",
         "middy5": "npm:@middy/core@^5.4.3",
         "middy6": "npm:@middy/core@^6.0.0",
         "typedoc": "^0.28.8",
@@ -17300,20 +17299,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/middy4": {
-      "name": "@middy/core",
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.7.0.tgz",
-      "integrity": "sha512-yI++DmhDQ8+ugvY7+GrEnb2PF0M/6Wzbgu4Tf7QhOlhwKGDd4j6or+Ab7qYPWx+jnKf8F0tqlmh0gV4JLi0yHw==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/willfarrell"
       }
     },
     "node_modules/middy5": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "markdownlint-cli2": "^0.18.1",
-    "middy4": "npm:@middy/core@^4.7.0",
     "middy5": "npm:@middy/core@^5.4.3",
     "middy6": "npm:@middy/core@^6.0.0",
     "typedoc": "^0.28.8",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
     "*.md": "markdownlint-cli2 --fix"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }

--- a/packages/batch/package.json
+++ b/packages/batch/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs18x": "echo 'Not Implemented'",
     "test:e2e:nodejs20x": "echo 'Not Implemented'",
     "test:e2e:nodejs22x": "echo 'Not Implemented'",
     "test:e2e": "echo 'Not Implemented'",

--- a/packages/event-handler/package.json
+++ b/packages/event-handler/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs18x": "echo \"Not implemented\"",
     "test:e2e:nodejs20x": "echo \"Not implemented\"",
     "test:e2e:nodejs22x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs18x": "RUNTIME=nodejs18x vitest --run tests/e2e",
     "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs18x": "echo \"Not implemented\"",
     "test:e2e:nodejs20x": "echo \"Not implemented\"",
     "test:e2e:nodejs22x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs18x": "RUNTIME=nodejs18x vitest --run tests/e2e",
     "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.FunctionCode.ts
+++ b/packages/logger/tests/e2e/logEventEnvVarSetting.middy.test.FunctionCode.ts
@@ -1,5 +1,5 @@
 import type { Context } from 'aws-lambda';
-import middy from 'middy4';
+import middy from 'middy5';
 import { Logger } from '../../src/index.js';
 import { injectLambdaContext } from '../../src/middleware/middy.js';
 import type { TestEvent, TestOutput } from '../helpers/types.js';

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs18x": "RUNTIME=nodejs18x vitest --run tests/e2e",
     "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "vitest --run tests/types --typecheck",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs18x": "RUNTIME=nodejs18x vitest --run tests/e2e",
     "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "vitest --run tests/types --typecheck",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs18x": "echo 'Not implemented'",
     "test:e2e:nodejs20x": "echo 'Not implemented'",
     "test:e2e:nodejs22x": "echo 'Not implemented'",
     "test:e2e": "echo 'Not implemented'",

--- a/packages/testing/src/constants.ts
+++ b/packages/testing/src/constants.ts
@@ -9,7 +9,6 @@ const defaultRuntime = 'nodejs22x';
  * The AWS Lambda runtimes that are supported by the project.
  */
 const TEST_RUNTIMES = {
-  nodejs18x: Runtime.NODEJS_18_X,
   nodejs20x: Runtime.NODEJS_20_X,
   [defaultRuntime]: Runtime.NODEJS_22_X,
 } as const;

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs18x": "RUNTIME=nodejs18x vitest --run tests/e2e",
     "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -11,7 +11,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs18x": "echo \"Not implemented\"",
     "test:e2e:nodejs20x": "echo \"Not implemented\"",
     "test:e2e:nodejs22x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "incremental": true,
     "composite": true,
-    "target": "ES2022", // Node.js 18
+    "target": "ES2023", // Node.js 20
     "experimentalDecorators": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR drops support for Node.js 18 by:
- increasing the minimum `engine` version in the main `package.json` & `package-lock.json`
- removing the `18.x` from GitHub Issue templates
- removing `18` from all matrixes in GitHub Actions
- removing Node.js 18 from the badge in the main `README.md` file
- removing `test:e2e:nodejs18x` commands from all `package.json` files
- removing the `NODEJS_18_X` runtime and increasing the minimum runtime to `NODEJS_20_X` in all Lambda layer configurations
- setting the compile target to `ES2023` (aka Node.js 20) in the main `tsconfig.json` file
- removing Middy.js `4.x` from dev dependencies and tests, since `5.x` (new minimum supported version by Powertools for AWS) supports only Node.js 20 and above

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #3562

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
