### PR TITLE
fix(parser): cognito schema `preferredRole` may be null

### DIFF
--- a/packages/parser/src/schemas/cognito.ts
+++ b/packages/parser/src/schemas/cognito.ts
@@ -192,7 +192,7 @@ const PostAuthenticationTriggerSchema = CognitoTriggerBaseSchema.extend({
 const PreTokenGenerationTriggerGroupConfigurationSchema = z.object({
   groupsToOverride: z.array(z.string()),
   iamRolesToOverride: z.array(z.string()),
-  preferredRole: z.string().optional(),
+  preferredRole: z.string().nullable(),
 });
 
 /**

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -396,6 +396,29 @@ describe('Schemas: Cognito User Pool', () => {
     expect(result).toEqual(event);
   });
 
+  it('parses a valid pre-token generation event v1 with null preferredRole', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+      groupConfiguration: {
+        groupsToOverride: ['group1', 'group2'],
+        iamRolesToOverride: ['role1', 'role2'],
+        preferredRole: null,
+      },
+      clientMetadata: { key: 'value' },
+    };
+
+    // Act
+    const result = PreTokenGenerationTriggerSchemaV1.parse(event);
+
+    // Assess
+    expect(result).toEqual(event);
+  });
+
   it('throws if the pre-token generation event v1 is missing a required field', () => {
     // Prepare
     const event = structuredClone(baseEvent);


### PR DESCRIPTION
## Summary

### Changes

For the Cognito Trigger pre-token generation event, handle that the `preferredRole`
    field may be `null`.

**Issue number:** closes #4250

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
