### PR TITLE
refactor(tracer): fix code quality issues

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -822,7 +822,6 @@ class Tracer extends Utility implements TracerInterface {
 
     if (this.#envConfig.captureHTTPsRequests.toLowerCase() === 'false') {
       this.captureHTTPsRequests = false;
-      return;
     }
   }
 

--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -867,7 +867,7 @@ class Tracer extends Utility implements TracerInterface {
    *
    * @param options - Configuration passed to the tracer
    */
-  private setOptions(options: TracerOptions): Tracer {
+  private setOptions(options: TracerOptions): this {
     const { enabled, serviceName, captureHTTPsRequests, customConfigService } =
       options;
 

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -975,7 +975,7 @@ describe('Class: Tracer', () => {
       createCaptureAsyncFuncMock(tracer.provider, newSubsegment);
 
       class Lambda implements LambdaInterface {
-        private memberVariable: string;
+        readonly memberVariable: string;
 
         public constructor(memberVariable: string) {
           this.memberVariable = memberVariable;

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -19,7 +19,7 @@ const createCaptureAsyncFuncMock = (
   vi
     .spyOn(provider, 'captureAsyncFunc')
     .mockImplementation(async (methodName, callBackFn) => {
-      const newSubsegment = subsegment ?? new Subsegment(`### ${methodName}`);
+      const newSubsegment = subsegment || new Subsegment(`### ${methodName}`);
       vi.spyOn(newSubsegment, 'flush').mockImplementation(() => null);
       return await callBackFn(newSubsegment);
     });

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -19,7 +19,7 @@ const createCaptureAsyncFuncMock = (
   vi
     .spyOn(provider, 'captureAsyncFunc')
     .mockImplementation(async (methodName, callBackFn) => {
-      const newSubsegment = subsegment || new Subsegment(`### ${methodName}`);
+      const newSubsegment = subsegment ?? new Subsegment(`### ${methodName}`);
       vi.spyOn(newSubsegment, 'flush').mockImplementation(() => null);
       return await callBackFn(newSubsegment);
     });
@@ -692,9 +692,7 @@ describe('Class: Tracer', () => {
         .mockImplementation(() => ({}));
 
       // Act
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-        '## foo.bar'
-      );
+      const newSubsegment = new Subsegment('## foo.bar');
       tracer.setSegment(newSubsegment);
 
       // Assess
@@ -961,9 +959,7 @@ describe('Class: Tracer', () => {
     it('awaits async methods correctly', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-        '### dummyMethod'
-      );
+      const newSubsegment = new Subsegment('### dummyMethod');
 
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => newSubsegment
@@ -1021,8 +1017,7 @@ describe('Class: Tracer', () => {
     it('catches the error and logs a warning when a segment fails to close/serialize', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const handlerSubsegment: Segment | Subsegment | undefined =
-        new Subsegment('### dummyMethod');
+      const handlerSubsegment = new Subsegment('### dummyMethod');
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => handlerSubsegment
       );
@@ -1192,9 +1187,7 @@ describe('Class: Tracer', () => {
     it('captures the exception correctly', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-        '### dummyMethod'
-      );
+      const newSubsegment = new Subsegment('### dummyMethod');
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => newSubsegment
       );
@@ -1237,9 +1230,7 @@ describe('Class: Tracer', () => {
     it('preserves the this scope correctly when used as decorator', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-        '### dummyMethod'
-      );
+      const newSubsegment = new Subsegment('### dummyMethod');
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => newSubsegment
       );
@@ -1274,9 +1265,7 @@ describe('Class: Tracer', () => {
     it('awaits the async method correctly when used as decorator', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-        '### dummyMethod'
-      );
+      const newSubsegment = new Subsegment('### dummyMethod');
 
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => newSubsegment
@@ -1375,9 +1364,7 @@ describe('Class: Tracer', () => {
     it('sets the correct name for the subsegment when used as decorator and with a custom subSegmentName', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const newSubsegment: Segment | Subsegment | undefined = new Subsegment(
-        '### dummyMethod'
-      );
+      const newSubsegment = new Subsegment('### dummyMethod');
       vi.spyOn(newSubsegment, 'flush').mockImplementation(() => null);
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => newSubsegment
@@ -1412,8 +1399,7 @@ describe('Class: Tracer', () => {
     it('catches the error and logs a warning when a segment fails to close/serialize', async () => {
       // Prepare
       const tracer: Tracer = new Tracer();
-      const handlerSubsegment: Segment | Subsegment | undefined =
-        new Subsegment('### dummyMethod');
+      const handlerSubsegment = new Subsegment('### dummyMethod');
       vi.spyOn(tracer.provider, 'getSegment').mockImplementation(
         () => handlerSubsegment
       );


### PR DESCRIPTION
## Summary

### Changes

This PR fixes the code quality issues found by SonarCube mentioned in [this ticket](https://github.com/aws-powertools/powertools-lambda-typescript/issues/4257) by refactoring the following:

Tracer.test.ts:
- Mark the `memberVariable` of `Lambda` as `readonly`
- Remove union type aliases on `Subsegment` instantiations
 
Tracer.ts:
- Remove redundant return statement in `setCaptureHTTPsRequests`
- Replace explicit return type from private method `setOptions` with `this`

**Issue number:** #4257

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
