### PR TITLE
chore(deps): update typedoc to v0.28.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "markdownlint-cli2": "^0.18.1",
         "middy5": "npm:@middy/core@^5.4.3",
         "middy6": "npm:@middy/core@^6.0.0",
-        "typedoc": "^0.28.8",
+        "typedoc": "^0.28.9",
         "typedoc-plugin-missing-exports": "^4.0.0",
         "typescript": "^5.8.3",
         "vitest": "^3.0.9"
@@ -11689,15 +11689,16 @@
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.7.0.tgz",
-      "integrity": "sha512-7iY9wg4FWXmeoFJpUL2u+tsmh0d0jcEJHAIzVxl3TG4KL493JNnisdLAILZ77zcD+z3J0keEXZ+lFzUgzQzPDg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.9.2.tgz",
+      "integrity": "sha512-Tvsj+AOO4Z8xLRJK900WkyfxHsZQu+Zm1//oT1w443PO6RiYMoq/4NGOhaNuZoUMYsjKIAPVQ6eOFMddj6yphQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/engine-oniguruma": "^3.7.0",
-        "@shikijs/langs": "^3.7.0",
-        "@shikijs/themes": "^3.7.0",
-        "@shikijs/types": "^3.7.0",
+        "@shikijs/engine-oniguruma": "^3.9.2",
+        "@shikijs/langs": "^3.9.2",
+        "@shikijs/themes": "^3.9.2",
+        "@shikijs/types": "^3.9.2",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
@@ -12293,38 +12294,42 @@
       ]
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.7.0.tgz",
-      "integrity": "sha512-5BxcD6LjVWsGu4xyaBC5bu8LdNgPCVBnAkWTtOCs/CZxcB22L8rcoWfv7Hh/3WooVjBZmFtyxhgvkQFedPGnFw==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.9.2.tgz",
+      "integrity": "sha512-Vn/w5oyQ6TUgTVDIC/BrpXwIlfK6V6kGWDVVz2eRkF2v13YoENUvaNwxMsQU/t6oCuZKzqp9vqtEtEzKl9VegA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0",
+        "@shikijs/types": "3.9.2",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.7.0.tgz",
-      "integrity": "sha512-1zYtdfXLr9xDKLTGy5kb7O0zDQsxXiIsw1iIBcNOO8Yi5/Y1qDbJ+0VsFoqTlzdmneO8Ij35g7QKF8kcLyznCQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.9.2.tgz",
+      "integrity": "sha512-X1Q6wRRQXY7HqAuX3I8WjMscjeGjqXCg/Sve7J2GWFORXkSrXud23UECqTBIdCSNKJioFtmUGJQNKtlMMZMn0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.9.2"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.7.0.tgz",
-      "integrity": "sha512-VJx8497iZPy5zLiiCTSIaOChIcKQwR0FebwE9S3rcN0+J/GTWwQ1v/bqhTbpbY3zybPKeO8wdammqkpXc4NVjQ==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.9.2.tgz",
+      "integrity": "sha512-6z5lBPBMRfLyyEsgf6uJDHPa6NAGVzFJqH4EAZ+03+7sedYir2yJBRu2uPZOKmj43GyhVHWHvyduLDAwJQfDjA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.7.0"
+        "@shikijs/types": "3.9.2"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-MGaLeaRlSWpnP0XSAum3kP3a8vtcTsITqoEPYdt3lQG3YCdQH4DnEhodkYcNMcU0uW0RffhoD1O3e0vG5eSBBg==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.9.2.tgz",
+      "integrity": "sha512-/M5L0Uc2ljyn2jKvj4Yiah7ow/W+DJSglVafvWAJ/b8AZDeeRAdMu3c2riDzB7N42VD+jSnWxeP9AKtd4TfYVw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
@@ -12334,7 +12339,8 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
@@ -13180,6 +13186,7 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
       }
@@ -18358,13 +18365,13 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.8",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.8.tgz",
-      "integrity": "sha512-16GfLopc8icHfdvqZDqdGBoS2AieIRP2rpf9mU+MgN+gGLyEQvAO0QgOa6NJ5QNmQi0LFrDY9in4F2fUNKgJKA==",
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.9.tgz",
+      "integrity": "sha512-aw45vwtwOl3QkUAmWCnLV9QW1xY+FSX2zzlit4MAfE99wX+Jij4ycnpbAWgBXsRrxmfs9LaYktg/eX5Bpthd3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.7.0",
+        "@gerrit0/mini-shiki": "^3.9.0",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
@@ -18378,7 +18385,7 @@
         "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
       }
     },
     "node_modules/typedoc-plugin-missing-exports": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "markdownlint-cli2": "^0.18.1",
     "middy5": "npm:@middy/core@^5.4.3",
     "middy6": "npm:@middy/core@^6.0.0",
-    "typedoc": "^0.28.8",
+    "typedoc": "^0.28.9",
     "typedoc-plugin-missing-exports": "^4.0.0",
     "typescript": "^5.8.3",
     "vitest": "^3.0.9"


### PR DESCRIPTION
## Summary

Updates Typedoc to v0.28.9.

### Changes

`package.json` and `package-lock.json` files have been updated.

**Issue number:** closes #4266

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
