### PR TITLE
feat(parser): Exported the parse function from the parser

### DIFF
--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,2 +1,3 @@
 export { ParseError } from './errors.js';
+export { parse } from './parser.js';
 export { parser } from './parserDecorator.js';

--- a/packages/parser/tests/unit/parser.test.ts
+++ b/packages/parser/tests/unit/parser.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { EventBridgeEnvelope } from '../../src/envelopes/eventbridge.js';
+import { SqsEnvelope } from '../../src/envelopes/sqs.js';
+import { ParseError } from '../../src/errors.js';
+import { parse } from '../../src/parser.js';
+import type { EventBridgeEvent, SqsEvent } from '../../src/types/index.js';
+import { getTestEvent } from './helpers/utils.js';
+
+describe('Parser', () => {
+  const schema = z
+    .object({
+      name: z.string(),
+      age: z.number(),
+    })
+    .strict();
+  const baseSqsEvent = getTestEvent<SqsEvent>({
+    eventsPath: 'sqs',
+    filename: 'base',
+  });
+  const baseEventBridgeEvent = getTestEvent<EventBridgeEvent>({
+    eventsPath: 'eventbridge',
+    filename: 'base',
+  });
+  const JSONPayload = { name: 'John', age: 18 };
+
+  it('parses an event with schema and envelope', async () => {
+    // Prepare
+    const event = structuredClone(baseSqsEvent);
+    event.Records[1].body = 'bar';
+
+    // Act
+
+    const result = parse(event, SqsEnvelope, z.string());
+
+    // Assess
+    expect(result).toStrictEqual(['Test message.', 'bar']);
+  });
+
+  it('throws when envelope does not match', async () => {
+    // Prepare
+    const event = structuredClone(baseEventBridgeEvent);
+
+    // Act & Assess
+    expect(() => parse(event, SqsEnvelope, z.string())).toThrow();
+  });
+
+  it('throws when schema does not match', async () => {
+    // Prepare
+    const event = structuredClone(baseSqsEvent);
+    // @ts-expect-error - setting an invalid body
+    event.Records[1].body = undefined;
+
+    // Act & Assess
+    expect(() => parse(event, SqsEnvelope, z.string())).toThrow();
+  });
+
+  it('parses the event successfully', async () => {
+    // Prepare
+    const event = 42;
+
+    // Act
+    const result = parse(event, undefined, z.number());
+
+    // Assess
+    expect(result).toEqual(event);
+  });
+
+  it('throws when the event does not match the schema', async () => {
+    // Prepare
+    const event = structuredClone(JSONPayload);
+
+    // Act & Assess
+    expect(() => parse(event, undefined, z.number())).toThrow();
+  });
+
+  it('returns the payload when using safeParse', async () => {
+    // Prepare
+    const event = structuredClone(JSONPayload);
+
+    // Act
+    const result = parse(event, undefined, schema, true);
+
+    // Assess
+    expect(result).toEqual({
+      success: true,
+      data: event,
+    });
+  });
+
+  it('returns the error when using safeParse and the payload is invalid', async () => {
+    // Prepare
+    const event = structuredClone(JSONPayload);
+
+    // Act
+    const result = parse(event, undefined, z.string(), true);
+
+    // Assess
+    expect(result).toEqual({
+      success: false,
+      error: expect.any(ParseError),
+      originalEvent: event,
+    });
+  });
+
+  it('returns the payload when using safeParse with envelope', async () => {
+    // Prepare
+    const detail = structuredClone(JSONPayload);
+    const event = structuredClone(baseEventBridgeEvent);
+    event.detail = detail;
+
+    // Act
+    const result = parse(event, EventBridgeEnvelope, schema, true);
+
+    // Assess
+    expect(result).toStrictEqual({
+      success: true,
+      data: detail,
+    });
+  });
+
+  it('returns an error when using safeParse with envelope and the payload is invalid', async () => {
+    // Prepare
+    const event = structuredClone(baseEventBridgeEvent);
+
+    // Act
+    const result = parse(event, EventBridgeEnvelope, z.string(), true);
+
+    // Assess
+    expect(result).toStrictEqual({
+      success: false,
+      error: expect.any(ParseError),
+      originalEvent: event,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR exports the `parse` function from the `parser` package and adds unit tests to check the functionality of the parse function when invoked directly. This was done to be able to do manual parsing if needed

### Changes

> Please provide a summary of what's being changed

- Added an export for the parse function
- Added the same test cases as the tests for the middleware but directly invoking the `parse` function

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4263 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
