### PR TITLE
fix(tracer): pass args of decorated method as they are

### DIFF
--- a/packages/tracer/src/Tracer.ts
+++ b/packages/tracer/src/Tracer.ts
@@ -428,9 +428,12 @@ class Tracer extends Utility implements TracerInterface {
       const tracerRef = this;
       // Use a function() {} instead of an () => {} arrow function so that we can
       // access `myClass` as `this` in a decorated `myClass.myMethod()`.
-      descriptor.value = function (this: Handler, event, context, callback) {
+      descriptor.value = function (
+        this: Handler,
+        ...args: Parameters<Handler>
+      ) {
         if (!tracerRef.isTracingEnabled()) {
-          return originalMethod.apply(this, [event, context, callback]);
+          return originalMethod.apply(this, args);
         }
 
         return tracerRef.provider.captureAsyncFunc(
@@ -440,11 +443,7 @@ class Tracer extends Utility implements TracerInterface {
             tracerRef.addServiceNameAnnotation();
             let result: unknown;
             try {
-              result = await originalMethod.apply(this, [
-                event,
-                context,
-                callback,
-              ]);
+              result = await originalMethod.apply(this, args);
               if (options?.captureResponse ?? true) {
                 tracerRef.addResponseAsMetadata(result, process.env._HANDLER);
               }


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the internal implementation of the `captureLambdaHandler` class method decorator in Tracer so that it forwards the `args` of the decorated handler method as they appear at runtime rather than destructuring them and forcing the third parameter (`callback`) to be `undefined`.

Its presence, even when not defined, caused the runtime to interpret the handler as using callback style, which in turn caused deprecation warnings to show up.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4306

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
