### PR TITLE
improv(idempotency): Prevent error when AWS_LAMBDA_FUNCTION_NAME is not passed in the Idempotency Persistence Layer

### DIFF
--- a/packages/idempotency/src/persistence/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/BasePersistenceLayer.ts
@@ -1,7 +1,7 @@
 import { createHash, type Hash } from 'node:crypto';
 import type { JSONValue } from '@aws-lambda-powertools/commons/types';
-import { LRUCache } from '@aws-lambda-powertools/commons/utils/lru-cache';
 import { getStringFromEnv } from '@aws-lambda-powertools/commons/utils/env';
+import { LRUCache } from '@aws-lambda-powertools/commons/utils/lru-cache';
 import { search } from '@aws-lambda-powertools/jmespath';
 import type { JMESPathParsingOptions } from '@aws-lambda-powertools/jmespath/types';
 import { IdempotencyRecordStatus } from '../constants.js';
@@ -39,7 +39,7 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
   public constructor() {
     this.idempotencyKeyPrefix = getStringFromEnv({
       key: 'AWS_LAMBDA_FUNCTION_NAME',
-      errorMessage: 'AWS_LAMBDA_FUNCTION_NAME environment variable is required',
+      defaultValue: '',
     });
   }
 

--- a/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
+++ b/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
@@ -63,6 +63,27 @@ describe('Class: BasePersistenceLayer', () => {
         })
       );
     });
+
+    it('initializes with empty key prefix if AWS_LAMBDA_FUNCTION_NAME is not in the environment variable', () => {
+      // Prepare
+      vi.stubEnv('AWS_LAMBDA_FUNCTION_NAME', undefined);
+
+      // Act
+      const persistenceLayer = new PersistenceLayerTestClass();
+
+      // Assess
+      expect(persistenceLayer.idempotencyKeyPrefix).toBe('');
+      expect(persistenceLayer).toEqual(
+        expect.objectContaining({
+          configured: false,
+          expiresAfterSeconds: 3600,
+          hashFunction: 'md5',
+          payloadValidationEnabled: false,
+          throwOnNoIdempotencyKey: false,
+          useLocalCache: false,
+        })
+      );
+    });
   });
 
   describe('Method: configure', () => {


### PR DESCRIPTION
## Summary

This PR prevents errors when initializing the persistence layer class in non Lambda execution environment (eg: test environments where AWS_LAMBDA_FUNCTION_NAME is not defined)

### Changes

> Please provide a summary of what's being changed

- Passed an empty string as the default value when setting the value of `idempotencyKeyPrefix` and removed the required error message
- Added test to verify the fallback behaviour

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4326 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
