### PR TITLE
fix(event-handler): pass event, context and request objects into handler

### DIFF
--- a/packages/event-handler/src/rest/BaseRouter.ts
+++ b/packages/event-handler/src/rest/BaseRouter.ts
@@ -8,6 +8,7 @@ import type { ResolveOptions } from '../types/index.js';
 import type {
   ErrorConstructor,
   ErrorHandler,
+  ErrorResolveOptions,
   HttpMethod,
   Path,
   RouteHandler,
@@ -157,12 +158,19 @@ abstract class BaseRouter {
    */
   protected async handleError(
     error: Error,
-    options?: ResolveOptions
+    options: ErrorResolveOptions
   ): Promise<Response> {
     const handler = this.errorHandlerRegistry.resolve(error);
     if (handler !== null) {
       try {
-        const body = await handler.apply(options?.scope ?? this, [error]);
+        const body = await handler.apply(options.scope ?? this, [
+          error,
+          {
+            request: options.request,
+            event: options.event,
+            context: options.context,
+          },
+        ]);
         return new Response(JSON.stringify(body), {
           status: body.statusCode,
           headers: { 'Content-Type': 'application/json' },
@@ -272,24 +280,6 @@ abstract class BaseRouter {
     handler?: RouteHandler
   ): MethodDecorator | undefined {
     return this.#handleHttpMethod(HttpVerbs.OPTIONS, path, handler);
-  }
-
-  public connect(path: Path, handler: RouteHandler): void;
-  public connect(path: Path): MethodDecorator;
-  public connect(
-    path: Path,
-    handler?: RouteHandler
-  ): MethodDecorator | undefined {
-    return this.#handleHttpMethod(HttpVerbs.CONNECT, path, handler);
-  }
-
-  public trace(path: Path, handler: RouteHandler): void;
-  public trace(path: Path): MethodDecorator;
-  public trace(
-    path: Path,
-    handler?: RouteHandler
-  ): MethodDecorator | undefined {
-    return this.#handleHttpMethod(HttpVerbs.TRACE, path, handler);
   }
 }
 

--- a/packages/event-handler/src/rest/constants.ts
+++ b/packages/event-handler/src/rest/constants.ts
@@ -1,6 +1,4 @@
 export const HttpVerbs = {
-  CONNECT: 'CONNECT',
-  TRACE: 'TRACE',
   GET: 'GET',
   POST: 'POST',
   PUT: 'PUT',

--- a/packages/event-handler/tests/unit/rest/ErrorHandlerRegistry.test.ts
+++ b/packages/event-handler/tests/unit/rest/ErrorHandlerRegistry.test.ts
@@ -4,7 +4,7 @@ import { ErrorHandlerRegistry } from '../../../src/rest/ErrorHandlerRegistry.js'
 import type { HttpStatusCode } from '../../../src/types/rest.js';
 
 const createErrorHandler =
-  (statusCode: HttpStatusCode, message?: string) => (error: Error) => ({
+  (statusCode: HttpStatusCode, message?: string) => async (error: Error) => ({
     statusCode,
     error: error.name,
     message: message ?? error.message,


### PR DESCRIPTION
## Summary
This begins the work for for repsonse handling piece of the REST API event handler. As with other event handlers we need to pass the raw event and the lambda context as option into the handler. We will also pass a `Request` object in, should users prefer to use this web standard when defining their handlers.

### Changes

- Updated the type definition of `RouteHandler` and `ErrorHandler` to support passing the new parameters in.
- Tightened the return type of `RouteHandler` from `any` to `Response | JSONObject`
- Updated the unit tests to reflect these new changes
- Added factory function to unit tests for creating events of type `APIGatewayProxyEvent`
- Removed `trace` and `connect` HTTP methods [see note]

### Note
When attempting to create a `Request` object for the `trace` and `connect` tests, I received an error from the constructor saying they were not supported. On investigation I discovered that these methods are forbidden by the [Fetch specification](https://fetch.spec.whatwg.org/#methods) due to security concerns. I do not think we should support these methods in the event handler so have removed them.

**Issue number:** closes #4340

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
