### PR TITLE
ci: bump version-n-release GitHub Action and modify input values

### DIFF
--- a/.github/workflows/make-version.yml
+++ b/.github/workflows/make-version.yml
@@ -4,10 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       release-type:
-        description: 'Release type (major, minor, patch)'
+        description: 'Release type, if auto it will be determined by the changes since the last tag'
         required: false
         type: choice
         options: 
+        - auto
         - major
         - minor
         - patch
@@ -39,13 +40,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "npm"
       - name: Setup dependencies
-        uses: aws-powertools/actions/.github/actions/cached-node-modules@743fa57a003787b157991ea5c6e3cf0d40468676 # v1.4.0
+        uses: aws-powertools/actions/.github/actions/cached-node-modules@3b5b8e2e58b7af07994be982e83584a94e8c76c5 # v1.5.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           build: "false"
       - name: Version and changelog
         id: version-n-changelog
-        uses: aws-powertools/actions/.github/actions/version-n-changelog@743fa57a003787b157991ea5c6e3cf0d40468676 # v1.4.0
+        uses: aws-powertools/actions/.github/actions/version-n-changelog@3b5b8e2e58b7af07994be982e83584a94e8c76c5 # v1.5.0
         with:
           release-type: ${{ github.event.inputs.release-type }}
       - name: Update user agent version
@@ -55,7 +56,7 @@ jobs:
         run: git add .
       - name: Create PR
         id: create-pr
-        uses: aws-powertools/actions/.github/actions/create-pr@743fa57a003787b157991ea5c6e3cf0d40468676 # v1.4.0
+        uses: aws-powertools/actions/.github/actions/create-pr@3b5b8e2e58b7af07994be982e83584a94e8c76c5 # v1.5.0
         with:
           temp_branch_prefix: "ci-bump"
           pull_request_title: "chore(ci): bump version to ${{ steps.version-n-changelog.outputs.new-version  }}"


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR bumps the version of `version-n-changelog` used in the `make-version.yml` workflow so that it should fix the issue described in the linked issue, and updates the `release-type` input values to include a `auto` one, which should be the default one used in most cases.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4309

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
