### PR TITLE
chore(ci): update layer ARN on documentation

### DIFF
--- a/docs/getting-started/lambda-layers.md
+++ b/docs/getting-started/lambda-layers.md
@@ -19,41 +19,41 @@ We publish the Lambda Layer for Powertools for AWS Lambda in all commercial regi
 
 | Region           | Layer ARN                                                                                                  |
 | ---------------- | ---------------------------------------------------------------------------------------------------------- |
-| `us-east-1`      | [arn:aws:lambda:us-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `us-east-2`      | [arn:aws:lambda:us-east-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `us-west-1`      | [arn:aws:lambda:us-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `us-west-2`      | [arn:aws:lambda:us-west-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `ap-south-1`     | [arn:aws:lambda:ap-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `ap-south-2`     | [arn:aws:lambda:ap-south-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `ap-east-1`      | [arn:aws:lambda:ap-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `ap-northeast-1` | [arn:aws:lambda:ap-northeast-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-northeast-2` | [arn:aws:lambda:ap-northeast-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-northeast-3` | [arn:aws:lambda:ap-northeast-3:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-southeast-1` | [arn:aws:lambda:ap-southeast-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-southeast-2` | [arn:aws:lambda:ap-southeast-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-southeast-3` | [arn:aws:lambda:ap-southeast-3:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-southeast-4` | [arn:aws:lambda:ap-southeast-4:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-southeast-5` | [arn:aws:lambda:ap-southeast-5:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `ap-southeast-7` | [arn:aws:lambda:ap-southeast-7:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}        |
-| `eu-central-1`   | [arn:aws:lambda:eu-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}          |
-| `eu-central-2`   | [arn:aws:lambda:eu-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}          |
-| `eu-west-1`      | [arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `eu-west-2`      | [arn:aws:lambda:eu-west-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `eu-west-3`      | [arn:aws:lambda:eu-west-3:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `eu-north-1`     | [arn:aws:lambda:eu-north-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `eu-south-1`     | [arn:aws:lambda:eu-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `eu-south-2`     | [arn:aws:lambda:eu-south-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `ca-central-1`   | [arn:aws:lambda:ca-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}          |
-| `ca-west-1`      | [arn:aws:lambda:ca-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `sa-east-1`      | [arn:aws:lambda:sa-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}             |
-| `af-south-1`     | [arn:aws:lambda:af-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `me-south-1`     | [arn:aws:lambda:me-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}            |
-| `me-central-1`   | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}          |
-| `il-central-1`   | [arn:aws:lambda:il-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}          |
-| `mx-central-1`   | [arn:aws:lambda:mx-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}          |
-| `us-gov-west-1`  | [arn:aws-us-gov:lambda:us-gov-west-1:165093116878:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}  |
-| `us-gov-east-1`  | [arn:aws-us-gov:lambda:us-gov-east-1:165087284144:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}  |
-| `cn-north-1`     | [arn:aws-aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:33](#){: .copyMe}     |
+| `us-east-1`      | [arn:aws:lambda:us-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `us-east-2`      | [arn:aws:lambda:us-east-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `us-west-1`      | [arn:aws:lambda:us-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `us-west-2`      | [arn:aws:lambda:us-west-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `ap-south-1`     | [arn:aws:lambda:ap-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `ap-south-2`     | [arn:aws:lambda:ap-south-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `ap-east-1`      | [arn:aws:lambda:ap-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `ap-northeast-1` | [arn:aws:lambda:ap-northeast-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-northeast-2` | [arn:aws:lambda:ap-northeast-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-northeast-3` | [arn:aws:lambda:ap-northeast-3:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-southeast-1` | [arn:aws:lambda:ap-southeast-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-southeast-2` | [arn:aws:lambda:ap-southeast-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-southeast-3` | [arn:aws:lambda:ap-southeast-3:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-southeast-4` | [arn:aws:lambda:ap-southeast-4:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-southeast-5` | [arn:aws:lambda:ap-southeast-5:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `ap-southeast-7` | [arn:aws:lambda:ap-southeast-7:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}        |
+| `eu-central-1`   | [arn:aws:lambda:eu-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}          |
+| `eu-central-2`   | [arn:aws:lambda:eu-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}          |
+| `eu-west-1`      | [arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `eu-west-2`      | [arn:aws:lambda:eu-west-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `eu-west-3`      | [arn:aws:lambda:eu-west-3:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `eu-north-1`     | [arn:aws:lambda:eu-north-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `eu-south-1`     | [arn:aws:lambda:eu-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `eu-south-2`     | [arn:aws:lambda:eu-south-2:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `ca-central-1`   | [arn:aws:lambda:ca-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}          |
+| `ca-west-1`      | [arn:aws:lambda:ca-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `sa-east-1`      | [arn:aws:lambda:sa-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}             |
+| `af-south-1`     | [arn:aws:lambda:af-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `me-south-1`     | [arn:aws:lambda:me-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}            |
+| `me-central-1`   | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}          |
+| `il-central-1`   | [arn:aws:lambda:il-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}          |
+| `mx-central-1`   | [arn:aws:lambda:mx-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}          |
+| `us-gov-west-1`  | [arn:aws-us-gov:lambda:us-gov-west-1:165093116878:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}  |
+| `us-gov-east-1`  | [arn:aws-us-gov:lambda:us-gov-east-1:165087284144:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}  |
+| `cn-north-1`     | [arn:aws-aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:34](#){: .copyMe}     |
 
 ### Lookup Layer ARN via AWS SSM Parameter Store
 
@@ -71,7 +71,7 @@ Parameter:
   LastModifiedDate: '2025-02-11T11:08:45.070000+01:00'
   Name: /aws/service/powertools/typescript/generic/all/2.14.0
   Type: String
-  Value: arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33
+  Value: arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34
   Version: 1
 ```
 
@@ -91,7 +91,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
 === "AWS CLI command to download Lambda Layer content"
 
     ```bash
-    aws lambda get-layer-version-by-arn --arn arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33 --region {aws::region}
+    aws lambda get-layer-version-by-arn --arn arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34 --region {aws::region}
     ```
 
 === "AWS CLI output"
@@ -104,7 +104,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
             "CodeSize": 3548324
         },
         "LayerArn": "arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2",
-        "LayerVersionArn": "arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33",
+        "LayerVersionArn": "arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34",
         "Description": "Powertools for AWS Lambda (TypeScript) version 2.18.0",
         "CreatedDate": "2025-04-08T07:38:30.424+0000",
         "Version": 24,
@@ -138,7 +138,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
         const powertoolsLayer = LayerVersion.fromLayerVersionArn(
           this,
           'PowertoolsLayer',
-          `arn:aws:lambda:${Stack.of(this).region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33`
+          `arn:aws:lambda:${Stack.of(this).region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34`
         );
         
         new NodejsFunction(this, 'Function', {
@@ -208,7 +208,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
       Type: AWS::Serverless::Function
         Properties:
           Layers:
-            - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33
+            - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34
     ```
 
     You can also use AWS SSM Parameter Store to dynamically add Powertools for AWS Lambda and resolve the Layer ARN from SSM Parameter Store in your code, allowing you to pin to `latest` or a specific Powertools for AWS Lambda version.
@@ -247,7 +247,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
       hello:
         handler: lambda_function.lambda_handler
         layers:
-          - arn:aws:lambda:${aws:region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33
+          - arn:aws:lambda:${aws:region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34
     ```
 
     If you use `esbuild` to bundle your code, make sure to exclude `@aws-lambda-powertools/*` and `@aws-sdk/*` from being bundled since the packages are already present the layer:
@@ -282,7 +282,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
       role          = ...
       handler       = "index.handler"
       runtime 		= "nodejs22.x"
-      layers 		= ["arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33"]
+      layers 		= ["arn:aws:lambda:{aws::region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34"]
       source_code_hash = filebase64sha256("lambda_function_payload.zip")
     }
     ```
@@ -317,7 +317,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
 
     const lambdaFunction = new aws.lambda.Function('function', {
         layers: [
-            pulumi.interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33`
+            pulumi.interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34`
         ],
         code: new pulumi.asset.FileArchive('lambda_function_payload.zip'),
         tracingConfig: {
@@ -341,7 +341,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
       name: "my-function",
       layers: {
         "@aws-lambda-powertools/*":
-          "arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33",
+          "arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34",
       },
     });
     ```

--- a/examples/app/cdk/example-stack.ts
+++ b/examples/app/cdk/example-stack.ts
@@ -39,7 +39,7 @@ export class PowertoolsExampleStack extends Stack {
       'powertools-layer',
       `arn:aws:lambda:${
         Stack.of(this).region
-      }:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33`
+      }:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34`
     );
 
     // Items table

--- a/examples/app/template.yaml
+++ b/examples/app/template.yaml
@@ -130,7 +130,7 @@ Resources:
         - DynamoDBReadPolicy:
             TableName: !Ref itemsTable
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:33
+        - !Sub arn:aws:lambda:${AWS::Region}:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:34
       Environment:
         Variables:
           TABLE_NAME: !Ref itemsTable


### PR DESCRIPTION
Bumps the layer version as the old layer version number was given to the GitHub action so the automated PR was never created.

**Issue number** closes #4338

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Disclaimer: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.