### PR TITLE
improv: decorate methods without destructuring args

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -13,7 +13,7 @@ import {
   getXRayTraceIdFromEnv,
   isDevMode,
 } from '@aws-lambda-powertools/commons/utils/env';
-import type { Context, Handler } from 'aws-lambda';
+import type { Callback, Context, Handler } from 'aws-lambda';
 import merge from 'lodash.merge';
 import {
   LogJsonIndent,
@@ -493,19 +493,17 @@ class Logger extends Utility implements LoggerInterface {
       // access `myClass` as `this` in a decorated `myClass.myMethod()`.
       descriptor.value = async function (
         this: Handler,
-        event,
-        context,
-        callback
+        ...args: [unknown, Context, Callback]
       ) {
         loggerRef.refreshSampleRateCalculation();
-        loggerRef.addContext(context);
-        loggerRef.logEventIfEnabled(event, options?.logEvent);
+        loggerRef.addContext(args[1]);
+        loggerRef.logEventIfEnabled(args[0], options?.logEvent);
         if (options?.correlationIdPath) {
-          loggerRef.setCorrelationId(event, options?.correlationIdPath);
+          loggerRef.setCorrelationId(args[0], options?.correlationIdPath);
         }
 
         try {
-          return await originalMethod.apply(this, [event, context, callback]);
+          return await originalMethod.apply(this, args);
         } catch (error) {
           if (options?.flushBufferOnUncaughtError) {
             loggerRef.flushBuffer();

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -598,17 +598,15 @@ class Metrics extends Utility implements MetricsInterface {
       // access `myClass` as `this` in a decorated `myClass.myMethod()`.
       descriptor.value = async function (
         this: Handler,
-        event: unknown,
-        context: Context,
-        callback: Callback
+        ...args: [unknown, Context, Callback]
       ): Promise<unknown> {
         if (captureColdStartMetric) {
-          metricsRef.captureColdStartMetric(context.functionName);
+          metricsRef.captureColdStartMetric(args[1].functionName);
         }
 
         let result: unknown;
         try {
-          result = await originalMethod.apply(this, [event, context, callback]);
+          result = await originalMethod.apply(this, args);
         } finally {
           metricsRef.publishStoredMetrics();
         }


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR continues the refactor started in #4312 and refactors the implementation of the class method decorators in the repository to avoid accessing the arguments of the decorated method that are not used, so that they don't trigger the callback deprecation warning when not actually using a callback-based Lambda handler.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4306

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
