### PR TITLE
improv(ci): Automate the layer version tracking during the Make Release workflow

### DIFF
--- a/.github/scripts/update_layer_arn.sh
+++ b/.github/scripts/update_layer_arn.sh
@@ -8,10 +8,13 @@
 # see .github/workflows/publish_layer.yml
 
 
-# Get the current layer version from SSM Parameter
-current_layer_arn=$(aws ssm get-parameter --name /aws/service/powertools/typescript/generic/all/latest --query Parameter.Value --output text --region us-east-1)
-current_layer_version=$(echo $current_layer_arn | sed 's/.*://')
-new_version=$((current_layer_version + 1))
+# Get the new layer arn from the first command-line argument
+new_layer_arn=$1
+if [ -z "$new_layer_arn" ]; then
+    echo "Usage: $0 <new_layer_arn>"
+    exit 1
+fi
+new_version=$(echo $new_layer_arn | sed 's/.*://')
 
 # Find all files with specified extensions in ./docs and ./examples directories
 # -type f: only find files (not directories)

--- a/.github/scripts/update_layer_arn.sh
+++ b/.github/scripts/update_layer_arn.sh
@@ -9,12 +9,9 @@
 
 
 # Get the current layer version from SSM Parameter
-if [ -z "$1" ]; then
-    echo "Usage: $0 <new_version>"
-    exit 1
-fi
-current_layer_arn=$(aws ssm get-parameter --name /aws/service/powertools/typescript/generic/all/$1 --query Parameter.Value --output text --region us-east-1)
+current_layer_arn=$(aws ssm get-parameter --name /aws/service/powertools/typescript/generic/all/latest --query Parameter.Value --output text --region us-east-1)
 current_layer_version=$(echo $current_layer_arn | sed 's/.*://')
+new_version=$((current_layer_version + 1))
 
 # Find all files with specified extensions in ./docs and ./examples directories
 # -type f: only find files (not directories)
@@ -29,7 +26,7 @@ find ./docs ./examples -type f \( -name "*.md" -o -name "*.ts" -o -name "*.yaml"
     # -E: use extended regular expressions
     # IF TESTING IN MAC, replace `-i` with `-i ''`
     # The regex matches the layer name and replaces only the version number at the end
-    sed -i -E "s/AWSLambdaPowertoolsTypeScriptV2:[0-9]+/AWSLambdaPowertoolsTypeScriptV2:$current_layer_version/g" "$file"
+    sed -i -E "s/AWSLambdaPowertoolsTypeScriptV2:[0-9]+/AWSLambdaPowertoolsTypeScriptV2:$new_version/g" "$file"
     if [ $? -eq 0 ]; then
         echo "Updated $file successfully"
         grep "arn:aws:lambda:" "$file"

--- a/.github/scripts/update_layer_arn.sh
+++ b/.github/scripts/update_layer_arn.sh
@@ -8,8 +8,10 @@
 # see .github/workflows/publish_layer.yml
 
 
-# Get the new version number from the first command-line argument
-new_version=$1
+# Get the current layer version from SSM Parameter
+current_layer_arn=$(aws ssm get-parameter --name /aws/service/powertools/typescript/generic/all/latest --query Parameter.Value --output text --region us-east-1)
+current_layer_version=$(echo $current_layer_arn | sed 's/.*://')
+new_version=$((current_layer_version + 1))
 if [ -z "$new_version" ]; then
     echo "Usage: $0 <new_version>"
     exit 1

--- a/.github/scripts/update_layer_arn.sh
+++ b/.github/scripts/update_layer_arn.sh
@@ -9,13 +9,12 @@
 
 
 # Get the current layer version from SSM Parameter
-current_layer_arn=$(aws ssm get-parameter --name /aws/service/powertools/typescript/generic/all/latest --query Parameter.Value --output text --region us-east-1)
-current_layer_version=$(echo $current_layer_arn | sed 's/.*://')
-new_version=$((current_layer_version + 1))
-if [ -z "$new_version" ]; then
+if [ -z "$1" ]; then
     echo "Usage: $0 <new_version>"
     exit 1
 fi
+current_layer_arn=$(aws ssm get-parameter --name /aws/service/powertools/typescript/generic/all/$1 --query Parameter.Value --output text --region us-east-1)
+current_layer_version=$(echo $current_layer_arn | sed 's/.*://')
 
 # Find all files with specified extensions in ./docs and ./examples directories
 # -type f: only find files (not directories)
@@ -30,7 +29,7 @@ find ./docs ./examples -type f \( -name "*.md" -o -name "*.ts" -o -name "*.yaml"
     # -E: use extended regular expressions
     # IF TESTING IN MAC, replace `-i` with `-i ''`
     # The regex matches the layer name and replaces only the version number at the end
-    sed -i -E "s/AWSLambdaPowertoolsTypeScriptV2:[0-9]+/AWSLambdaPowertoolsTypeScriptV2:$new_version/g" "$file"
+    sed -i -E "s/AWSLambdaPowertoolsTypeScriptV2:[0-9]+/AWSLambdaPowertoolsTypeScriptV2:$current_layer_version/g" "$file"
     if [ $? -eq 0 ]; then
         echo "Updated $file successfully"
         grep "arn:aws:lambda:" "$file"

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -17,13 +17,7 @@ name: Make Release
 # 4. Merge the PR created by the `publish_layer` workflow to update the documentation
 # 5. Update draft release notes with the latest changes and publish the release on GitHub
 
-on:
-  workflow_dispatch:
-    inputs:
-      layer_documentation_version:
-        description: "Lambda layer version to be updated in our documentation. e.g. if the current layer number is 3, this value must be 4."
-        type: string
-        required: true
+on: workflow_dispatch
 
 permissions:
   contents: read
@@ -106,4 +100,3 @@ jobs:
     uses: ./.github/workflows/publish_layer.yml
     with:
       latest_published_version: ${{ needs.publish-npm.outputs.RELEASE_VERSION }}
-      layer_documentation_version: ${{ inputs.layer_documentation_version }}

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -104,7 +104,7 @@ jobs:
           mask-aws-account-id: true
       - name: Replace layer versions in documentation
         run: |
-          ./.github/scripts/update_layer_arn.sh ${{ inputs.latest_published_version }}
+          ./.github/scripts/update_layer_arn.sh
       - name: Stage changes
         run: git add .
       - name: Create PR

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -11,9 +11,6 @@ on:
         description: "Latest npm published version to rebuild corresponding layer for, e.g. 1.0.2"
         default: "1.0.2"
         required: true
-      layer_documentation_version:
-        description: "Version to be updated in our documentation. e.g. if the current layer number is 3, this value must be 4."
-        required: true
 
   workflow_call:
     inputs:
@@ -26,10 +23,6 @@ on:
         default: false
         type: boolean
         required: false
-      layer_documentation_version:
-        description: "Version to be updated in our documentation. e.g. if the current layer number is 3, this value must be 4."
-        required: true
-        type: string
 
 jobs:
   # Build layer by running cdk synth in layer-publisher directory and uploading cdk.out for deployment
@@ -97,7 +90,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: none
+      id-token: write
     steps:
       - name: Checkout repository # reusable workflows start clean, so we need to checkout again
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
@@ -105,7 +98,7 @@ jobs:
           ref: ${{ github.sha }}
       - name: Replace layer versions in documentation
         run: |
-          ./.github/scripts/update_layer_arn.sh ${{ inputs.layer_documentation_version }}
+          ./.github/scripts/update_layer_arn.sh
       - name: Stage changes
         run: git add .
       - name: Create PR

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -96,15 +96,9 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           ref: ${{ github.sha }}
-      - id: creds
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
-        with:
-          aws-region: us-east-1
-          role-to-assume: ${{ secrets.US_EAST_1 }}
-          mask-aws-account-id: true
       - name: Replace layer versions in documentation
         run: |
-          ./.github/scripts/update_layer_arn.sh
+          ./.github/scripts/update_layer_arn.sh ${{ needs.deploy-prod.outputs.layer-arn }}
       - name: Stage changes
         run: git add .
       - name: Create PR

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -104,7 +104,7 @@ jobs:
           mask-aws-account-id: true
       - name: Replace layer versions in documentation
         run: |
-          ./.github/scripts/update_layer_arn.sh
+          ./.github/scripts/update_layer_arn.sh ${{ inputs.latest_published_version }}
       - name: Stage changes
         run: git add .
       - name: Create PR

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -90,12 +90,18 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write
+      id-token: none
     steps:
       - name: Checkout repository # reusable workflows start clean, so we need to checkout again
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
           ref: ${{ github.sha }}
+      - id: creds
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.US_EAST_1 }}
+          mask-aws-account-id: true
       - name: Replace layer versions in documentation
         run: |
           ./.github/scripts/update_layer_arn.sh

--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -15,6 +15,10 @@ on:
         description: "Latest version that is published"
         required: true
         type: string
+    outputs:
+      layer-arn:
+        description: "The latest deployed Layer ARN"
+        value: ${{ jobs.deploy-cdk-stack.outputs.layer-arn }}
     secrets:
       target-account-role:
         required: true
@@ -65,6 +69,8 @@ jobs:
             "il-central-1",
             "mx-central-1"
           ]
+    outputs:
+      layer-arn: ${{ steps.store-latest-layer-arn.outputs.layer-arn }}
     steps:
       - name: checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
@@ -89,11 +95,12 @@ jobs:
       - name: Deploy Layer
         run: npm run cdk -w layers -- deploy --app cdk.out --context region=${{ matrix.region }} 'LayerPublisherStack' --require-approval never --verbose --outputs-file cdk-outputs.json
       - name: Store latest Layer ARN
+        id: store-latest-layer-arn
         if: ${{ inputs.stage == 'PROD' }}
         run: |
           mkdir cdk-layer-stack
           jq -r -c '.LayerPublisherStack.LatestLayerArn' layers/cdk-outputs.json > cdk-layer-stack/${{ matrix.region }}-layer-version.txt
-          cat cdk-layer-stack/${{ matrix.region }}-layer-version.txt
+          echo "layer-arn=$(cat cdk-layer-stack/${{ matrix.region }}-layer-version.txt)" | tee -a "$GITHUB_OUTPUT"
       - name: Save Layer ARN artifact
         if: ${{ inputs.stage == 'PROD' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -100,7 +100,11 @@ jobs:
         run: |
           mkdir cdk-layer-stack
           jq -r -c '.LayerPublisherStack.LatestLayerArn' layers/cdk-outputs.json > cdk-layer-stack/${{ matrix.region }}-layer-version.txt
-          echo "layer-arn=$(cat cdk-layer-stack/${{ matrix.region }}-layer-version.txt)" | tee -a "$GITHUB_OUTPUT"
+          if [ "${{ matrix.region }}" = "us-east-1" ]; then
+            echo "layer-arn=$(cat cdk-layer-stack/${{ matrix.region }}-layer-version.txt)" | tee -a "$GITHUB_OUTPUT"
+          else
+            cat cdk-layer-stack/${{ matrix.region }}-layer-version.txt
+          fi
       - name: Save Layer ARN artifact
         if: ${{ inputs.stage == 'PROD' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Summary

This PR automated the manual process of checking the current layer version, increment the version and input it to the release workflow. Instead, it makes use of an SSM Parameter to automate the process.

### Changes

> Please provide a summary of what's being changed

This PR updates the layer arn update script to retrieve the current layer arn from SSM Parameter and increment it by 1 to use it as a new layer version instead of getting it passed from the workflow input. Manually doing the increment and passing it to the workflow can be error prone, so it automates that step.

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4339 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
