### PR TITLE
improv(ci): Added comments in workflow files triggering Excessive Secret Exposure Alert

### DIFF
--- a/.github/workflows/layers_partition_verify.yml
+++ b/.github/workflows/layers_partition_verify.yml
@@ -1,6 +1,14 @@
 # Partition Layer Verification
 # ---
 # This workflow queries the Partition layer info in production only
+#
+# CodeQL Security Note:
+# This workflow uses dynamic secret access via secrets[format(...)] which triggers
+# an "Excessive Secrets Exposure" alert. However, this is safe because:
+# - Secrets are scoped per environment (China/GovCloud Gamma/Prod)
+# - Each job only accesses secrets for its specific partition and region
+# - No global secrets array containing mixed credentials (API keys, PEM files, etc.)
+# - The secrets object is already minimally scoped to the environment being used
 
 on:
   workflow_dispatch:
@@ -102,7 +110,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    # Environment should interperlate as "GovCloud Prod" or "China Beta"
+    # Environment should interpolate as "GovCloud Prod" or "China Beta"
     environment: ${{ inputs.partition }} ${{ inputs.environment }}
     strategy:
       matrix:
@@ -118,6 +126,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
+          # Dynamic secret access is safe here - secrets are scoped per environment
           role-to-assume: ${{ secrets[format('IAM_ROLE_{0}', steps.transform.outputs.CONVERTED_REGION)] }}
           aws-region: ${{ matrix.region}}
           mask-aws-account-id: true
@@ -129,6 +138,7 @@ jobs:
       - name: Verify Layer
         run: |
           export layer_output='AWSLambdaPowertoolsTypeScriptV2-${{matrix.region}}.json'
+          # Dynamic secret access is safe here - secrets are scoped per environment
           aws --region ${{ matrix.region}} lambda get-layer-version-by-arn --arn "arn:${{ needs.setup.outputs.partition }}:lambda:${{ matrix.region}}:${{ secrets[format('AWS_ACCOUNT_{0}', steps.transform.outputs.CONVERTED_REGION)] }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ steps.partition_version.outputs.partition_version }}" > $layer_output
           REMOTE_SHA=$(jq -r '.Content.CodeSha256' $layer_output)
           LOCAL_SHA=$(jq -r '.Content.CodeSha256' AWSLambdaPowertoolsTypeScriptV2.json)

--- a/.github/workflows/layers_partitions.yml
+++ b/.github/workflows/layers_partitions.yml
@@ -15,6 +15,14 @@
 # 1. After the `make-release` workflow finishes and the PR for the documentation update gets created, trigger this workflow manually via `workflow_dispatch` with environment, version, and partition inputs for each Gamma and Prod environment in the China and GovCloud partitions
 # 2. Monitor deployment progress and verify successful layer publication across all target regions
 # 3. Once this workflow is completed, the PR for the documentation update can me merged
+#
+# CodeQL Security Note:
+# This workflow uses dynamic secret access via secrets[format(...)] which triggers
+# an "Excessive Secrets Exposure" alert. However, this is safe because:
+# - Secrets are scoped per environment (China/GovCloud Gamma/Prod)
+# - Each job only accesses secrets for its specific partition and region
+# - No global secrets array containing mixed credentials (API keys, PEM files, etc.)
+# - The secrets object is already minimally scoped to the environment being used
 
 on:
   workflow_dispatch:
@@ -142,6 +150,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
+          # Dynamic secret access is safe here - secrets are scoped per environment
           role-to-assume: ${{ secrets[format('IAM_ROLE_{0}', steps.transform.outputs.CONVERTED_REGION)] }}
           aws-region: ${{ matrix.region}}
           mask-aws-account-id: true
@@ -175,6 +184,7 @@ jobs:
           LAYER_VERSION: ${{ steps.create-layer.outputs.LAYER_VERSION }}
         run: |
           export layer_output='AWSLambdaPowertoolsTypeScriptV2-${{matrix.region}}.json'
+          # Dynamic secret access is safe here - secrets are scoped per environment
           aws --region ${{ matrix.region}} lambda get-layer-version-by-arn --arn 'arn:${{ needs.setup.outputs.partition }}:lambda:${{ matrix.region}}:${{ secrets[format('AWS_ACCOUNT_{0}', steps.transform.outputs.CONVERTED_REGION)] }}:layer:AWSLambdaPowertoolsTypeScriptV2:${{ env.LAYER_VERSION }}' > $layer_output
           REMOTE_SHA=$(jq -r '.Content.CodeSha256' $layer_output)
           LOCAL_SHA=$(jq -r '.Content.CodeSha256' AWSLambdaPowertoolsTypeScriptV2.json)

--- a/.github/workflows/update_ssm.yml
+++ b/.github/workflows/update_ssm.yml
@@ -11,6 +11,14 @@
 #   /aws/service/powertools/python/arm64/python3.8/3.1.0
 # And will have a value of:
 #   arn:aws:lambda:eu-west-1:094274105915:layer:AWSLambdaPowertoolsPythonV3-python38-arm64:4
+#
+# CodeQL Security Note:
+# This workflow uses dynamic secret access via secrets[format(...)] which triggers
+# an "Excessive Secrets Exposure" alert. However, this is safe because:
+# - Secrets are scoped per environment (SSM)
+# - Each job only accesses secrets for SSM
+# - No global secrets array containing mixed credentials (API keys, PEM files, etc.)
+# - The secrets object is already minimally scoped to the environment being used
 
 on:
   workflow_dispatch:
@@ -96,6 +104,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
           aws-region: ${{ matrix.region }}
+          # Dynamic secret access is safe here - secrets are scoped per environment
           role-to-assume: ${{ secrets[format('{0}', steps.transform.outputs.CONVERTED_REGION)] }}
           mask-aws-account-id: true
       - id: write-version


### PR DESCRIPTION
## Summary

This PR adds comments for the justification of the excessive secret exposure alert as [identified by CodeQL](https://github.com/aws-powertools/powertools-lambda-typescript/security/code-scanning/195). The finding is a false positive since the secrets are scoped down to specific environments which has only the secrets that it needs.

### Changes

> Please provide a summary of what's being changed

- Added comments in the workflow file about the justification of the use of dynamically accessed secrets

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4365 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
