### PR TITLE
chore(commons): concatenate PT UA to AWS_SDK_UA_APP_ID when one is set

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,7 +1,9 @@
 import { PT_VERSION } from './version.js';
 
 if (!process.env.AWS_SDK_UA_APP_ID) {
-  process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}`;
+  process.env.AWS_SDK_UA_APP_ID = `PT/TEST/${PT_VERSION}`;
+} else {
+  process.env.AWS_SDK_UA_APP_ID = `${process.env.AWS_SDK_UA_APP_ID}/PT/TEST/${PT_VERSION}`;
 }
 
 export { addUserAgentMiddleware, isSdkClient } from './awsSdkUtils.js';

--- a/packages/commons/tests/unit/awsSdkUtils.test.ts
+++ b/packages/commons/tests/unit/awsSdkUtils.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { customUserAgentMiddleware } from '../../src/awsSdkUtils.js';
 import {
   addUserAgentMiddleware,
@@ -8,14 +8,11 @@ import {
 
 vi.hoisted(() => {
   process.env.AWS_EXECUTION_ENV = '';
+  process.env.AWS_SDK_UA_APP_ID = 'test';
 });
 
 describe('Helpers: awsSdk', () => {
   describe('Function: userAgentMiddleware', () => {
-    beforeAll(() => {
-      vi.spyOn(console, 'warn').mockImplementation(() => ({}));
-    });
-
     it('handles gracefully failures in adding a middleware and only log a warning', () => {
       // Prepare
       const client = {
@@ -25,13 +22,10 @@ describe('Helpers: awsSdk', () => {
           },
         },
       };
-      const warningSpy = vi
-        .spyOn(console, 'warn')
-        .mockImplementation(() => ({}));
 
       // Act & Assess
       expect(() => addUserAgentMiddleware(client, 'my-feature')).not.toThrow();
-      expect(warningSpy).toHaveBeenCalledTimes(1);
+      expect(console.warn).toHaveBeenCalledTimes(1);
     });
 
     it('should return and do nothing if the client already has a Powertools UA middleware', async () => {
@@ -86,6 +80,11 @@ describe('Helpers: awsSdk', () => {
         }
       );
     });
+  });
+
+  it('concatenates the PT AWS_SDK_UA_APP_ID when one is already set', () => {
+    // Assess
+    expect(process.env.AWS_SDK_UA_APP_ID).toEqual('test/PT/TEST/2.25.1');
   });
 
   describe('Function: customUserAgentMiddleware', () => {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the logic for the user agent string so that when the `AWS_SDK_UA_APP_ID` environment variable is already set, it concatenates the Powertools for AWS UA string to the existing one.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4373

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
