### PR TITLE
improv(ci): Fixed the Make Release workflow permission issue

### DIFF
--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -91,7 +91,8 @@ jobs:
     needs: [deploy-prod]
     uses: ./.github/workflows/update_ssm.yml
     permissions:
-      contents: read
+      contents: write
+      id-token: write
     with:
       environment: prod
       package_version: ${{ inputs.latest_published_version }}


### PR DESCRIPTION
## Summary

This PR fixes the permission issue that caused the Make Release workflow to fail.

### Changes

> Please provide a summary of what's being changed

- Adds the `content: write, id-token: write` permissions to the parent job as needed by the reusable workflow

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4384 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
