### PR TITLE
improv(ci): Inherited the secrets for update ssm workflow

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -94,9 +94,8 @@ jobs:
   publish_layer:
     needs: publish-npm
     secrets:
-      AWS_LAYERS_BETA_ROLE_ARN: ${{ secrets.AWS_LAYERS_BETA_ROLE_ARN }}
-      AWS_LAYERS_PROD_ROLE_ARN: ${{ secrets.AWS_LAYERS_PROD_ROLE_ARN }}
-      TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+      # The update_ssm workflow called from the publish_layer workflow needs the secrets for all the regions. This will trigger a SonarQube warning.
+      inherit
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -97,6 +97,9 @@ jobs:
       environment: prod
       package_version: ${{ inputs.latest_published_version }}
       layer-version: ${{ needs.deploy-prod.outputs.layer-version }}
+    secrets:
+      # The update_ssm workflow needs the secrets for all the regions. This will trigger a SonarQube warning.
+      inherit
 
   update_layer_arn_docs:
     needs: [deploy-prod]


### PR DESCRIPTION
## Summary

This PR allows the secrets to be inherited from the parent workflow to the Update SSM workflow to fix [the issue during running the release workflow](https://github.com/aws-powertools/powertools-lambda-typescript/actions/runs/17234513302/job/48897479827)
The inheritance was previously updated because of a security finding.

### Changes

> Please provide a summary of what's being changed

- Reverted the explicit specification of secrets to use `inherit` keyword since the update parameter SSM would use secrets for each regions

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4387 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
