### PR TITLE
improv(tests): fixed the logger test breaking with Nodejs v22.19.0

### DIFF
--- a/packages/logger/tests/unit/formatters.test.ts
+++ b/packages/logger/tests/unit/formatters.test.ts
@@ -371,7 +371,7 @@ describe('Formatters', () => {
         operator: 'strictEqual',
         code: 'ERR_ASSERTION',
         generatedMessage: true,
-        diff: 'simple',
+        diff: process.versions.node >= '22.19.0' ? 'simple' : undefined,
       },
     },
     {


### PR DESCRIPTION
## Summary

This PR fixes the breaking tests in Nodejs v22.19.0 by replacing the deep checking of error properties with subset checking of the error properties.

### Changes

> Please provide a summary of what's being changed

- Added the `diff` property in the expected object if running on Nodejs version >=22.19.0

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4409 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
