### PR TITLE
docs: update copyright notice to align with AWS documentation standards

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,7 +144,14 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
 
-copyright: Copyright &copy; 2025 Amazon Web Services
+copyright: |
+  <div id="awsdocs-legal-zone-copyright">
+      <a href="https://aws.amazon.com/privacy" target="_blank" rel="nofollow">Privacy</a> |
+      <a href="https://aws.amazon.com/terms/" target="_blank" rel="nofollow">Site terms</a> |
+      <span class="copyright">
+        © 2025, Amazon Web Services, Inc. or its affiliates. All rights reserved.
+      </span>
+  </div>
 
 plugins:
   - privacy


### PR DESCRIPTION
## Summary

This PR updates the documentation copyright notice in `mkdocs.yml` to align with AWS documentation standards as requested in issue #4417.

## Changes Made

- Replace simple copyright line with comprehensive footer
- Add Privacy and Site terms links with proper `target="_blank"` and `rel="nofollow"` attributes  
- Update copyright format to match AWS documentation patterns
- Align with Java implementation for consistency across Powertools languages

## Before
```yaml
copyright: Copyright &copy; 2025 Amazon Web Services
```

## After
```yaml
copyright: |
  <div id="awsdocs-legal-zone-copyright">
      <a href="https://aws.amazon.com/privacy" target="_blank" rel="nofollow">Privacy</a> |
      <a href="https://aws.amazon.com/terms/" target="_blank" rel="nofollow">Site terms</a> |
      <span class="copyright">
        © 2025, Amazon Web Services, Inc. or its affiliates. All rights reserved.
      </span>
  </div>
```

## Cross-Project Consistency

I verified the copyright format across all Powertools projects:
- ✅ **TypeScript** (this PR): Updated to new format
- ✅ **Java**: Already has the new format (matches this implementation exactly)
- ❌ **Python**: Still has old format - needs similar update
- ❌ **.NET**: Still has old format - needs similar update

## Testing

- ✅ Documentation builds successfully with `npm run docs:local:run`
- ✅ MkDocs processes the new copyright format without errors
- ✅ New footer will display Privacy and Site terms links as required

Fixes #4417