### PR TITLE
chore(event-handler): rename BaseRouter class to Router

### DIFF
--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -39,7 +39,7 @@ import {
   isHttpMethod,
 } from './utils.js';
 
-abstract class BaseRouter {
+class Router {
   protected context: Record<string, unknown>;
 
   protected readonly routeRegistry: RouteHandlerRegistry;
@@ -57,7 +57,7 @@ abstract class BaseRouter {
    */
   protected readonly isDev: boolean = false;
 
-  protected constructor(options?: RouterOptions) {
+  public constructor(options?: RouterOptions) {
     this.context = {};
     const alcLogLevel = getStringFromEnv({
       key: 'AWS_LAMBDA_LOG_LEVEL',
@@ -515,4 +515,4 @@ abstract class BaseRouter {
   }
 }
 
-export { BaseRouter };
+export { Router };

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -3,9 +3,9 @@ import type {
   JSONObject,
 } from '@aws-lambda-powertools/commons/types';
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import type { BaseRouter } from '../rest/BaseRouter.js';
 import type { HttpErrorCodes, HttpVerbs } from '../rest/constants.js';
 import type { Route } from '../rest/Route.js';
+import type { Router } from '../rest/Router.js';
 import type { ResolveOptions } from './common.js';
 
 type ErrorResponse = {
@@ -34,7 +34,7 @@ interface ErrorConstructor<T extends Error = Error> {
 }
 
 /**
- * Options for the {@link BaseRouter} class
+ * Options for the {@link Router} class
  */
 type RouterOptions = {
   /**


### PR DESCRIPTION
## Summary
Renames the `BaseRouter` class to `Router` to bring it inline with the naming convention of the other event handlers.

### Changes

- Renames the `BaseRouter.ts` file to `Router.ts`
- Renames the exported class `BaseRouter` to `Router`
- Updates all the tests to use the new class name

**Issue number:** closes #4447

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
