### PR TITLE
fix(event-handler): handle nullable fields in APIGatewayProxyEvent

### DIFF
--- a/packages/event-handler/src/rest/utils.ts
+++ b/packages/event-handler/src/rest/utils.ts
@@ -75,10 +75,17 @@ export const isAPIGatewayProxyEvent = (
     isString(event.httpMethod) &&
     isString(event.path) &&
     isString(event.resource) &&
-    isRecord(event.headers) &&
+    (event.headers == null || isRecord(event.headers)) &&
+    (event.multiValueHeaders == null || isRecord(event.multiValueHeaders)) &&
     isRecord(event.requestContext) &&
     typeof event.isBase64Encoded === 'boolean' &&
-    (event.body === null || isString(event.body))
+    (event.body === null || isString(event.body)) &&
+    (event.pathParameters === null || isRecord(event.pathParameters)) &&
+    (event.queryStringParameters === null ||
+      isRecord(event.queryStringParameters)) &&
+    (event.multiValueQueryStringParameters === null ||
+      isRecord(event.multiValueQueryStringParameters)) &&
+    (event.stageVariables === null || isRecord(event.stageVariables))
   );
 };
 


### PR DESCRIPTION
## Summary
Improves the type guard that checks whether we have received a valid`APIGatewayProxyEvent` by handling all its nullable fields.

### Changes

- Updated the `isAPIGatewayProxyEvent` function
- Added new tests to ensure we catch all possible nullable fields.

**Issue number:** closes #4454

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
