### PR TITLE
feat(event-handler): Add includeRouter and context sharing support to AppSync GraphQL resolver

### DIFF
--- a/docs/features/event-handler/appsync-graphql.md
+++ b/docs/features/event-handler/appsync-graphql.md
@@ -140,7 +140,7 @@ Let's assume you have `app.ts` as your Lambda function entrypoint and routes in 
 
     We use `includeRouter` method and include all operations registered in the router instances.
 
-    ```typescript hl_lines="2-3 7"
+    ```typescript hl_lines="3-4 8"
     --8<-- "examples/snippets/event-handler/appsync-graphql/splitRouter.ts"
     ```
 
@@ -156,7 +156,7 @@ You can use `appendContext` when you want to share data between your App and Rou
 
 === "app.ts"
 
-    ```typescript hl_lines="9"
+    ```typescript hl_lines="10"
     --8<-- "examples/snippets/event-handler/appsync-graphql/appendContext.ts"
     ```
 

--- a/docs/features/event-handler/appsync-graphql.md
+++ b/docs/features/event-handler/appsync-graphql.md
@@ -114,6 +114,64 @@ Here's a table with their related scalar as a quick reference:
 
 ## Advanced
 
+### Split operations with Router
+
+As you grow the number of related GraphQL operations a given Lambda function should handle, it is natural to split them into separate files to ease maintenance - That's when the `Router` feature comes handy.
+
+Let's assume you have `app.ts` as your Lambda function entrypoint and routes in `postRouter.ts` and `userRouter.ts`. This is how you'd use the `Router` feature.
+
+=== "postRouter.ts"
+
+    We import **Router** instead of **AppSyncGraphQLResolver**; syntax wise is exactly the same.
+
+    ```typescript hl_lines="1 3"
+    --8<-- "examples/snippets/event-handler/appsync-graphql/postRouter.ts"
+    ```
+
+=== "userRouter.ts"
+
+    We import **Router** instead of **AppSyncGraphQLResolver**; syntax wise is exactly the same.
+
+    ```typescript hl_lines="1 3"
+    --8<-- "examples/snippets/event-handler/appsync-graphql/userRouter.ts"
+    ```
+
+=== "app.ts"
+
+    We use `includeRouter` method and include all operations registered in the router instances.
+
+    ```typescript hl_lines="2-3 7"
+    --8<-- "examples/snippets/event-handler/appsync-graphql/splitRouter.ts"
+    ```
+
+#### Sharing contextual data
+
+You can use `appendContext` when you want to share data between your App and Router instances. Any data you share will be available via the `sharedContext` parameter in your resolver handlers.
+
+???+ warning
+    For safety, we clear the context after each invocation.
+
+???+ tip
+    This can also be useful for injecting contextual information before a request is processed.
+
+=== "app.ts"
+
+    ```typescript hl_lines="9"
+    --8<-- "examples/snippets/event-handler/appsync-graphql/appendContext.ts"
+    ```
+
+=== "postRouter.ts"
+
+    ```typescript hl_lines="5-8"
+    --8<-- "examples/snippets/event-handler/appsync-graphql/postRouterWithContext.ts"
+    ```
+
+=== "userRouter.ts"
+
+    ```typescript hl_lines="5-8"
+    --8<-- "examples/snippets/event-handler/appsync-graphql/userRouterWithContext.ts"
+    ```
+
 ### Nested mappings
 
 !!! note

--- a/examples/snippets/event-handler/appsync-graphql/appendContext.ts
+++ b/examples/snippets/event-handler/appsync-graphql/appendContext.ts
@@ -1,11 +1,13 @@
 import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+import type { Context } from 'aws-lambda/handler';
 import { postRouter } from './postRouter';
-import { usersRouter } from './userRouter';
+import { userRouter } from './userRouter';
 
 const app = new AppSyncGraphQLResolver();
 
-app.includeRouter([postRouter, usersRouter]);
+app.includeRouter([postRouter, userRouter]);
 
 app.appendContext({ requestId: crypto.randomUUID() });
 
-export const handler = async (event, context) => app.resolve(event, context);
+export const handler = async (event: unknown, context: Context) =>
+  app.resolve(event, context);

--- a/examples/snippets/event-handler/appsync-graphql/appendContext.ts
+++ b/examples/snippets/event-handler/appsync-graphql/appendContext.ts
@@ -1,0 +1,11 @@
+import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+import { postRouter } from './postRouter';
+import { usersRouter } from './userRouter';
+
+const app = new AppSyncGraphQLResolver();
+
+app.includeRouter([postRouter, usersRouter]);
+
+app.appendContext({ requestId: crypto.randomUUID() });
+
+export const handler = async (event, context) => app.resolve(event, context);

--- a/examples/snippets/event-handler/appsync-graphql/postRouter.ts
+++ b/examples/snippets/event-handler/appsync-graphql/postRouter.ts
@@ -1,0 +1,18 @@
+import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+
+const postRouter = new Router();
+
+postRouter.onQuery('getPosts', async () => {
+  return [{ id: 1, title: 'First post', content: 'Hello world!' }];
+});
+
+postRouter.onMutation('createPost', async ({ title, content }) => {
+  return {
+    id: Date.now(),
+    title,
+    content,
+    createdAt: new Date().toISOString(),
+  };
+});
+
+export { postRouter };

--- a/examples/snippets/event-handler/appsync-graphql/postRouterWithContext.ts
+++ b/examples/snippets/event-handler/appsync-graphql/postRouterWithContext.ts
@@ -1,0 +1,10 @@
+import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+
+const postRouter = new Router();
+
+postRouter.onQuery('getPosts', async (args, { sharedContext }) => {
+  const requestId = sharedContext?.get('requestId');
+  return [{ id: 1, title: 'First post', content: 'Hello world!', requestId }];
+});
+
+export { postRouter };

--- a/examples/snippets/event-handler/appsync-graphql/splitRouter.ts
+++ b/examples/snippets/event-handler/appsync-graphql/splitRouter.ts
@@ -1,0 +1,9 @@
+import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+import { postRouter } from './postRouter';
+import { userRouter } from './userRouter';
+
+const app = new AppSyncGraphQLResolver();
+
+app.includeRouter([postRouter, userRouter]);
+
+export const handler = async (event, context) => app.resolve(event, context);

--- a/examples/snippets/event-handler/appsync-graphql/splitRouter.ts
+++ b/examples/snippets/event-handler/appsync-graphql/splitRouter.ts
@@ -1,4 +1,5 @@
 import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+import type { Context } from 'aws-lambda';
 import { postRouter } from './postRouter';
 import { userRouter } from './userRouter';
 
@@ -6,4 +7,5 @@ const app = new AppSyncGraphQLResolver();
 
 app.includeRouter([postRouter, userRouter]);
 
-export const handler = async (event, context) => app.resolve(event, context);
+export const handler = async (event: unknown, context: Context) =>
+  app.resolve(event, context);

--- a/examples/snippets/event-handler/appsync-graphql/userRouter.ts
+++ b/examples/snippets/event-handler/appsync-graphql/userRouter.ts
@@ -1,0 +1,9 @@
+import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+
+const userRouter = new Router();
+
+userRouter.onQuery('getUsers', async () => {
+  return [{ id: 1, name: 'John Doe', email: 'john@example.com' }];
+});
+
+export { userRouter };

--- a/examples/snippets/event-handler/appsync-graphql/userRouterWithContext.ts
+++ b/examples/snippets/event-handler/appsync-graphql/userRouterWithContext.ts
@@ -1,0 +1,10 @@
+import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+
+const usersRouter = new Router();
+
+usersRouter.onQuery('getUsers', async (args, { sharedContext }) => {
+  const requestId = sharedContext?.get('requestId');
+  return [{ id: 1, name: 'John Doe', email: 'john@example.com', requestId }];
+});
+
+export { usersRouter };

--- a/examples/snippets/event-handler/appsync-graphql/userRouterWithContext.ts
+++ b/examples/snippets/event-handler/appsync-graphql/userRouterWithContext.ts
@@ -1,10 +1,10 @@
 import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
 
-const usersRouter = new Router();
+const userRouter = new Router();
 
-usersRouter.onQuery('getUsers', async (args, { sharedContext }) => {
+userRouter.onQuery('getUsers', async (args, { sharedContext }) => {
   const requestId = sharedContext?.get('requestId');
   return [{ id: 1, name: 'John Doe', email: 'john@example.com', requestId }];
 });
 
-export { usersRouter };
+export { userRouter };

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -46,11 +46,11 @@ class AppSyncGraphQLResolver extends Router {
   /**
    * A map to hold contextual data that can be shared across all resolver handlers.
    */
-  public readonly context: Map<string, unknown>;
+  public readonly sharedContext: Map<string, unknown>;
 
   public constructor(options?: GraphQlRouterOptions) {
     super(options);
-    this.context = new Map<string, unknown>();
+    this.sharedContext = new Map<string, unknown>();
   }
 
   /**
@@ -183,7 +183,7 @@ class AppSyncGraphQLResolver extends Router {
           options
         );
       } finally {
-        this.context.clear();
+        this.sharedContext.clear();
       }
     }
     if (!isAppSyncGraphQLEvent(event)) {
@@ -200,7 +200,7 @@ class AppSyncGraphQLResolver extends Router {
         options
       );
     } finally {
-      this.context.clear();
+      this.sharedContext.clear();
     }
   }
 
@@ -287,7 +287,7 @@ class AppSyncGraphQLResolver extends Router {
    */
   public appendContext(data: Record<string, unknown>): void {
     Object.entries(data).forEach(([key, value]) => {
-      this.context.set(key, value);
+      this.sharedContext.set(key, value);
     });
   }
 
@@ -429,7 +429,9 @@ class AppSyncGraphQLResolver extends Router {
         {
           event: events,
           context,
-          ...(this.context.size > 0 && { sharedContext: this.context }),
+          ...(this.sharedContext.size > 0 && {
+            sharedContext: this.sharedContext,
+          }),
         },
       ]);
 
@@ -452,7 +454,9 @@ class AppSyncGraphQLResolver extends Router {
           {
             event,
             context,
-            ...(this.context.size > 0 && { sharedContext: this.context }),
+            ...(this.sharedContext.size > 0 && {
+              sharedContext: this.sharedContext,
+            }),
           },
         ]);
         results.push(result);
@@ -467,7 +471,9 @@ class AppSyncGraphQLResolver extends Router {
           {
             event: events[i],
             context,
-            ...(this.context.size > 0 && { sharedContext: this.context }),
+            ...(this.sharedContext.size > 0 && {
+              sharedContext: this.sharedContext,
+            }),
           },
         ]);
         results.push(result);
@@ -515,7 +521,9 @@ class AppSyncGraphQLResolver extends Router {
           {
             event,
             context,
-            ...(this.context.size > 0 && { sharedContext: this.context }),
+            ...(this.sharedContext.size > 0 && {
+              sharedContext: this.sharedContext,
+            }),
           },
         ]
       );

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -184,7 +184,7 @@ class AppSyncGraphQLResolver extends Router {
         );
       } finally {
         /**
-         * Clear shared context after batch processing to avoid data leakage between invocations.
+         * Clear shared context after batch processing for safety
          */
         this.sharedContext.clear();
       }
@@ -204,7 +204,7 @@ class AppSyncGraphQLResolver extends Router {
       );
     } finally {
       /**
-       * Clear shared context after single event processing to avoid data leakage between invocations.
+       * Clear shared context after batch processing for safety
        */
       this.sharedContext.clear();
     }
@@ -222,19 +222,15 @@ class AppSyncGraphQLResolver extends Router {
    * ```ts
    * import { AppSyncGraphQLResolver, Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
    *
-   * const postsRouter = new Router();
-   * postsRouter.onQuery('getPosts', async () => {
-   *   return [{ id: 1, title: 'Post 1' }];
-   * });
+   * const postRouter = new Router();
+   * postRouter.onQuery('getPosts', async () => [{ id: 1, title: 'Post 1' }]);
    *
-   * const usersRouter = new Router();
-   * usersRouter.onQuery('getUsers', async () => {
-   *   return [{ id: 1, name: 'John Doe' }];
-   * });
+   * const userRouter = new Router();
+   * userRouter.onQuery('getUsers', async () => [{ id: 1, name: 'John Doe' }]);
    *
    * const app = new AppSyncGraphQLResolver();
    *
-   * app.includeRouter([usersRouter, postsRouter]);
+   * app.includeRouter([userRouter, postRouter]);
    *
    * export const handler = async (event, context) =>
    *   app.resolve(event, context);
@@ -244,10 +240,11 @@ class AppSyncGraphQLResolver extends Router {
    */
   public includeRouter(router: Router | Router[]): void {
     const routers = Array.isArray(router) ? router : [router];
+
     this.logger.debug('Including router');
-    routers.forEach((router) => {
-      this.mergeRegistriesFrom(router);
-    });
+    for (const routerToBeIncluded of routers) {
+      this.mergeRegistriesFrom(routerToBeIncluded);
+    }
     this.logger.debug('Router included successfully');
   }
 
@@ -262,21 +259,21 @@ class AppSyncGraphQLResolver extends Router {
    * ```ts
    * import { AppSyncGraphQLResolver, Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
    *
-   * const postsRouter = new Router();
-   * postsRouter.onQuery('getPosts', async ({ sharedContext }) => {
+   * const postRouter = new Router();
+   * postRouter.onQuery('getPosts', async ({ sharedContext }) => {
    *   const requestId = sharedContext?.get('requestId');
    *   return [{ id: 1, title: 'Post 1', requestId }];
    * });
    *
-   * const usersRouter = new Router();
-   * usersRouter.onQuery('getUsers', async ({ sharedContext }) => {
+   * const userRouter = new Router();
+   * userRouter.onQuery('getUsers', async ({ sharedContext }) => {
    *   const requestId = sharedContext?.get('requestId');
    *   return [{ id: 1, name: 'John Doe', requestId }];
    * });
    *
    * const app = new AppSyncGraphQLResolver();
    *
-   * app.includeRouter([usersRouter, postsRouter]);
+   * app.includeRouter([userRouter, postRouter]);
    * app.appendContext({ requestId: '12345' });
    *
    * export const handler = async (event, context) =>
@@ -286,9 +283,9 @@ class AppSyncGraphQLResolver extends Router {
    * @param data - A record of key-value pairs to add to the shared context
    */
   public appendContext(data: Record<string, unknown>): void {
-    Object.entries(data).forEach(([key, value]) => {
+    for (const [key, value] of Object.entries(data)) {
       this.sharedContext.set(key, value);
-    });
+    }
   }
 
   /**

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -2,6 +2,7 @@ import type { AppSyncResolverEvent, Context } from 'aws-lambda';
 import type {
   BatchResolverAggregateHandlerFn,
   BatchResolverHandlerFn,
+  GraphQlRouterOptions,
   ResolverHandler,
   RouteHandlerOptions,
 } from '../types/appsync-graphql.js';
@@ -42,6 +43,16 @@ import { isAppSyncGraphQLEvent } from './utils.js';
  * ```
  */
 class AppSyncGraphQLResolver extends Router {
+  /**
+   * A map to hold contextual data that can be shared across all resolver handlers.
+   */
+  public readonly context: Map<string, unknown>;
+
+  public constructor(options?: GraphQlRouterOptions) {
+    super(options);
+    this.context = new Map<string, unknown>();
+  }
+
   /**
    * Resolve the response based on the provided event and route handlers configured.
    *
@@ -164,11 +175,16 @@ class AppSyncGraphQLResolver extends Router {
         );
         return;
       }
-      return this.#withErrorHandling(
-        () => this.#executeBatchResolvers(event, context, options),
-        event[0],
-        options
-      );
+
+      try {
+        return await this.#withErrorHandling(
+          () => this.#executeBatchResolvers(event, context, options),
+          event[0],
+          options
+        );
+      } finally {
+        this.context.clear();
+      }
     }
     if (!isAppSyncGraphQLEvent(event)) {
       this.logger.warn(
@@ -177,11 +193,15 @@ class AppSyncGraphQLResolver extends Router {
       return;
     }
 
-    return this.#withErrorHandling(
-      () => this.#executeSingleResolver(event, context, options),
-      event,
-      options
-    );
+    try {
+      return await this.#withErrorHandling(
+        () => this.#executeSingleResolver(event, context, options),
+        event,
+        options
+      );
+    } finally {
+      this.context.clear();
+    }
   }
 
   /**
@@ -196,6 +216,52 @@ class AppSyncGraphQLResolver extends Router {
     this.logger.debug('Including router');
     this.mergeRegistriesFrom(router);
     this.logger.debug('Router included successfully');
+  }
+
+  /**
+   * Appends contextual data to be shared with all resolver handlers.
+   *
+   * This method allows you to add key-value pairs to the shared context that will be
+   * accessible to all resolver handlers through the `sharedContext` parameter. The context
+   * is automatically cleared after each invocation for safety.
+   *
+   * @example
+   * ```ts
+   * import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+   * import type { Context } from 'aws-lambda';
+   *
+   * const app = new AppSyncGraphQLResolver();
+   *
+   * export const handler = async (event: unknown, context: Context) => {
+   *   // Share context between main app and routers
+   *   app.appendContext({
+   *     isAdmin: true,
+   *     requestId: context.awsRequestId,
+   *     timestamp: Date.now()
+   *   });
+   *
+   *   return app.resolve(event, context);
+   * };
+   *
+   * // Resolver handlers can access shared context
+   * app.onQuery('getUser', async ({ id }, { sharedContext }) => {
+   *   const isAdmin = sharedContext?.get('isAdmin');
+   *   const requestId = sharedContext?.get('requestId');
+   *
+   *   return {
+   *     id,
+   *     name: 'John Doe',
+   *     email: isAdmin ? 'john@example.com' : 'hidden'
+   *   };
+   * });
+   * ```
+   *
+   * @param data - A record of key-value pairs to add to the shared context
+   */
+  public appendContext(data: Record<string, unknown>): void {
+    Object.entries(data).forEach(([key, value]) => {
+      this.context.set(key, value);
+    });
   }
 
   /**
@@ -333,7 +399,11 @@ class AppSyncGraphQLResolver extends Router {
         options.handler as BatchResolverAggregateHandlerFn
       ).apply(resolveOptions?.scope ?? this, [
         events,
-        { event: events, context },
+        {
+          event: events,
+          context,
+          ...(this.context.size > 0 && { sharedContext: this.context }),
+        },
       ]);
 
       if (!Array.isArray(response)) {
@@ -352,7 +422,11 @@ class AppSyncGraphQLResolver extends Router {
       for (const event of events) {
         const result = await handler.apply(resolveOptions?.scope ?? this, [
           event.arguments,
-          { event, context },
+          {
+            event,
+            context,
+            ...(this.context.size > 0 && { sharedContext: this.context }),
+          },
         ]);
         results.push(result);
       }
@@ -363,7 +437,11 @@ class AppSyncGraphQLResolver extends Router {
       try {
         const result = await handler.apply(resolveOptions?.scope ?? this, [
           events[i].arguments,
-          { event: events[i], context },
+          {
+            event: events[i],
+            context,
+            ...(this.context.size > 0 && { sharedContext: this.context }),
+          },
         ]);
         results.push(result);
       } catch (error) {
@@ -405,7 +483,14 @@ class AppSyncGraphQLResolver extends Router {
     if (resolverHandlerOptions) {
       return (resolverHandlerOptions.handler as ResolverHandler).apply(
         options?.scope ?? this,
-        [event.arguments, { event, context }]
+        [
+          event.arguments,
+          {
+            event,
+            context,
+            ...(this.context.size > 0 && { sharedContext: this.context }),
+          },
+        ]
       );
     }
 

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -44,7 +44,7 @@ import { isAppSyncGraphQLEvent } from './utils.js';
  */
 class AppSyncGraphQLResolver extends Router {
   /**
-   * A map to hold contextual data that can be shared across all resolver handlers.
+   * A map to hold shared contextual data accessible to all resolver handlers.
    */
   public readonly sharedContext: Map<string, unknown>;
 
@@ -254,33 +254,26 @@ class AppSyncGraphQLResolver extends Router {
    *
    * @example
    * ```ts
-   * import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
-   * import type { Context } from 'aws-lambda';
+   * import { AppSyncGraphQLResolver, Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+   *
+   * const postsRouter = new Router();
+   * postsRouter.onQuery('getPosts', async ({ sharedContext }) => {
+   *   const requestId = sharedContext?.get('requestId');
+   *   return [{ id: 1, title: 'Post 1', requestId }];
+   * });
+   *
+   * const usersRouter = new Router();
+   * usersRouter.onQuery('getUsers', async ({ sharedContext }) => {
+   *   const requestId = sharedContext?.get('requestId');
+   *   return [{ id: 1, name: 'John Doe', requestId }];
+   * });
    *
    * const app = new AppSyncGraphQLResolver();
+   * app.includeRouter([usersRouter, postsRouter]);
+   * app.appendContext({ requestId: '12345' });
    *
-   * export const handler = async (event: unknown, context: Context) => {
-   *   // Share context between main app and routers
-   *   app.appendContext({
-   *     isAdmin: true,
-   *     requestId: context.awsRequestId,
-   *     timestamp: Date.now()
-   *   });
-   *
-   *   return app.resolve(event, context);
-   * };
-   *
-   * // Resolver handlers can access shared context
-   * app.onQuery('getUser', async ({ id }, { sharedContext }) => {
-   *   const isAdmin = sharedContext?.get('isAdmin');
-   *   const requestId = sharedContext?.get('requestId');
-   *
-   *   return {
-   *     id,
-   *     name: 'John Doe',
-   *     email: isAdmin ? 'john@example.com' : 'hidden'
-   *   };
-   * });
+   * export const handler = async (event, context) =>
+   *   app.resolve(event, context);
    * ```
    *
    * @param data - A record of key-value pairs to add to the shared context

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -205,17 +205,45 @@ class AppSyncGraphQLResolver extends Router {
   }
 
   /**
-   * Includes a router and merges its registries into the current resolver.
+   * Includes one or more routers and merges their registries into the current resolver.
    *
    * This method allows you to compose multiple routers by merging their
    * route registries into the current AppSync GraphQL resolver instance.
+   * All resolver handlers, batch resolver handlers, and exception handlers
+   * from the included routers will be available in the current resolver.
    *
-   * @param router - The router instance whose registries will be merged
+   * @example
+   * ```ts
+   * import { AppSyncGraphQLResolver, Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';
+   *
+   * const postsRouter = new Router();
+   * postsRouter.onQuery('getPosts', async () => {
+   *   return [{ id: 1, title: 'Post 1' }];
+   * });
+   *
+   * const usersRouter = new Router();
+   * usersRouter.onQuery('getUsers', async () => {
+   *   return [{ id: 1, name: 'John Doe' }];
+   * });
+   *
+   * const app = new AppSyncGraphQLResolver();
+   *
+   * app.includeRouter([usersRouter, postsRouter]);
+   *
+   * export const handler = async (event, context) =>
+   *   app.resolve(event, context);
+   * ```
+   *
+   * @param router - The router instance or array of router instances whose registries will be merged
    */
-  public includeRouter(router: Router): void {
-    this.logger.debug('Including router');
-    this.mergeRegistriesFrom(router);
-    this.logger.debug('Router included successfully');
+  public includeRouter(router: Router | Router[]): void {
+    const routers = Array.isArray(router) ? router : [router];
+
+    routers.forEach((router) => {
+      this.logger.debug('Including router');
+      this.mergeRegistriesFrom(router);
+      this.logger.debug('Router included successfully');
+    });
   }
 
   /**

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -238,12 +238,11 @@ class AppSyncGraphQLResolver extends Router {
    */
   public includeRouter(router: Router | Router[]): void {
     const routers = Array.isArray(router) ? router : [router];
-
+    this.logger.debug('Including router');
     routers.forEach((router) => {
-      this.logger.debug('Including router');
       this.mergeRegistriesFrom(router);
-      this.logger.debug('Router included successfully');
     });
+    this.logger.debug('Router included successfully');
   }
 
   /**

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -426,9 +426,7 @@ class AppSyncGraphQLResolver extends Router {
         {
           event: events,
           context,
-          ...(this.sharedContext.size > 0 && {
-            sharedContext: this.sharedContext,
-          }),
+          ...this.#getSharedContextOnlyIfNotEmpty(),
         },
       ]);
 
@@ -451,9 +449,7 @@ class AppSyncGraphQLResolver extends Router {
           {
             event,
             context,
-            ...(this.sharedContext.size > 0 && {
-              sharedContext: this.sharedContext,
-            }),
+            ...this.#getSharedContextOnlyIfNotEmpty(),
           },
         ]);
         results.push(result);
@@ -468,9 +464,7 @@ class AppSyncGraphQLResolver extends Router {
           {
             event: events[i],
             context,
-            ...(this.sharedContext.size > 0 && {
-              sharedContext: this.sharedContext,
-            }),
+            ...this.#getSharedContextOnlyIfNotEmpty(),
           },
         ]);
         results.push(result);
@@ -518,9 +512,7 @@ class AppSyncGraphQLResolver extends Router {
           {
             event,
             context,
-            ...(this.sharedContext.size > 0 && {
-              sharedContext: this.sharedContext,
-            }),
+            ...this.#getSharedContextOnlyIfNotEmpty(),
           },
         ]
       );
@@ -544,6 +536,19 @@ class AppSyncGraphQLResolver extends Router {
     }
     return {
       error: 'An unknown error occurred',
+    };
+  }
+
+  /**
+   * Returns an object containing the shared context only if it has entries.
+   * This helps avoid passing an empty map to handlers.
+   */
+  #getSharedContextOnlyIfNotEmpty(): {
+    sharedContext: Map<string, unknown> | undefined;
+  } {
+    return {
+      sharedContext:
+        this.sharedContext.size > 0 ? this.sharedContext : undefined,
     };
   }
 }

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -185,6 +185,20 @@ class AppSyncGraphQLResolver extends Router {
   }
 
   /**
+   * Includes a router and merges its registries into the current resolver.
+   *
+   * This method allows you to compose multiple routers by merging their
+   * route registries into the current AppSync GraphQL resolver instance.
+   *
+   * @param router - The router instance whose registries will be merged
+   */
+  public includeRouter(router: Router): void {
+    this.logger.debug('Including router');
+    this.mergeRegistriesFrom(router);
+    this.logger.debug('Router included successfully');
+  }
+
+  /**
    * Executes the provided asynchronous function with error handling.
    * If the function throws an error, it delegates error processing to `#handleError`
    * and returns the formatted error response.

--- a/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
+++ b/packages/event-handler/src/appsync-graphql/AppSyncGraphQLResolver.ts
@@ -183,6 +183,9 @@ class AppSyncGraphQLResolver extends Router {
           options
         );
       } finally {
+        /**
+         * Clear shared context after batch processing to avoid data leakage between invocations.
+         */
         this.sharedContext.clear();
       }
     }
@@ -200,6 +203,9 @@ class AppSyncGraphQLResolver extends Router {
         options
       );
     } finally {
+      /**
+       * Clear shared context after single event processing to avoid data leakage between invocations.
+       */
       this.sharedContext.clear();
     }
   }
@@ -269,6 +275,7 @@ class AppSyncGraphQLResolver extends Router {
    * });
    *
    * const app = new AppSyncGraphQLResolver();
+   *
    * app.includeRouter([usersRouter, postsRouter]);
    * app.appendContext({ requestId: '12345' });
    *

--- a/packages/event-handler/src/appsync-graphql/ExceptionHandlerRegistry.ts
+++ b/packages/event-handler/src/appsync-graphql/ExceptionHandlerRegistry.ts
@@ -70,7 +70,6 @@ class ExceptionHandlerRegistry {
    * @param otherRegistry - The registry to merge handlers from.
    */
   public merge(otherRegistry: ExceptionHandlerRegistry): void {
-    this.#logger.debug('Merging exception handler registries');
     for (const [errorName, handlerOptions] of otherRegistry.handlers) {
       if (this.handlers.has(errorName)) {
         this.#warnHandlerOverriding(errorName);

--- a/packages/event-handler/src/appsync-graphql/ExceptionHandlerRegistry.ts
+++ b/packages/event-handler/src/appsync-graphql/ExceptionHandlerRegistry.ts
@@ -37,34 +37,8 @@ class ExceptionHandlerRegistry {
     const errors = Array.isArray(error) ? error : [error];
 
     for (const err of errors) {
-      this.registerErrorHandler(err, handler);
+      this.#registerErrorHandler(err, handler);
     }
-  }
-
-  /**
-   * Registers a error handler for a specific error class.
-   *
-   * @param errorClass - The error class to register the handler for.
-   * @param handler - The exception handler function.
-   */
-  private registerErrorHandler(
-    errorClass: ErrorClass<Error>,
-    handler: ExceptionHandler
-  ): void {
-    const errorName = errorClass.name;
-
-    this.#logger.debug(`Adding exception handler for error class ${errorName}`);
-
-    if (this.handlers.has(errorName)) {
-      this.#logger.warn(
-        `An exception handler for error class '${errorName}' is already registered. The previous handler will be replaced.`
-      );
-    }
-
-    this.handlers.set(errorName, {
-      error: errorClass,
-      handler,
-    });
   }
 
   /**
@@ -87,6 +61,61 @@ class ExceptionHandlerRegistry {
 
     this.#logger.debug(`No exception handler found for error: ${errorName}`);
     return null;
+  }
+
+  /**
+   * Merges handlers from another ExceptionHandlerRegistry into this registry.
+   * Existing handlers for the same error class will be replaced and a warning will be logged.
+   *
+   * @param otherRegistry - The registry to merge handlers from.
+   */
+  public merge(otherRegistry: ExceptionHandlerRegistry): void {
+    this.#logger.debug('Merging exception handler registries');
+    for (const [errorName, handlerOptions] of otherRegistry.handlers) {
+      if (this.handlers.has(errorName)) {
+        this.#warnHandlerOverriding(errorName);
+      }
+      this.handlers.set(errorName, handlerOptions);
+    }
+  }
+
+  /**
+   * Registers a error handler for a specific error class.
+   *
+   * @param errorClass - The error class to register the handler for.
+   * @param handler - The exception handler function.
+   */
+  #registerErrorHandler(
+    errorClass: ErrorClass<Error>,
+    handler: ExceptionHandler
+  ): void {
+    const errorName = errorClass.name;
+
+    this.#logger.debug(`Adding exception handler for error class ${errorName}`);
+
+    if (this.handlers.has(errorName)) {
+      this.#warnHandlerOverriding(errorName);
+    }
+
+    this.handlers.set(errorName, {
+      error: errorClass,
+      handler,
+    });
+  }
+
+  /**
+   * Logs a warning message when an exception handler is being overridden.
+   *
+   * This method is called internally when registering a new exception handler
+   * for an error class that already has a handler registered. It warns the user
+   * that the previous handler will be replaced with the new one.
+   *
+   * @param errorName - The name of the error class for which a handler is being overridden
+   */
+  #warnHandlerOverriding(errorName: string): void {
+    this.#logger.warn(
+      `An exception handler for error class '${errorName}' is already registered. The previous handler will be replaced.`
+    );
   }
 }
 

--- a/packages/event-handler/src/appsync-graphql/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/appsync-graphql/RouteHandlerRegistry.ts
@@ -50,9 +50,7 @@ class RouteHandlerRegistry {
     this.#logger.debug(`Adding resolver for field ${typeName}.${fieldName}`);
     const cacheKey = this.#makeKey(typeName, fieldName);
     if (this.resolvers.has(cacheKey)) {
-      this.#logger.warn(
-        `A resolver for field '${fieldName}' is already registered for '${typeName}'. The previous resolver will be replaced.`
-      );
+      this.#warnResolverOverriding(fieldName, typeName);
     }
     this.resolvers.set(cacheKey, {
       fieldName,
@@ -82,6 +80,22 @@ class RouteHandlerRegistry {
   }
 
   /**
+   * Merges handlers from another RouteHandlerRegistry into this registry.
+   * Existing handlers with the same key will be replaced and a warning will be logged.
+   *
+   * @param otherRegistry - The registry to merge handlers from.
+   */
+  public merge(otherRegistry: RouteHandlerRegistry): void {
+    this.#logger.debug('Merging route handler registries');
+    for (const [key, handler] of otherRegistry.resolvers) {
+      if (this.resolvers.has(key)) {
+        this.#warnResolverOverriding(handler.fieldName, handler.typeName);
+      }
+      this.resolvers.set(key, handler);
+    }
+  }
+
+  /**
    * Generates a unique key by combining the provided GraphQL type name and field name.
    *
    * @param typeName - The name of the GraphQL type.
@@ -89,6 +103,19 @@ class RouteHandlerRegistry {
    */
   #makeKey(typeName: string, fieldName: string): string {
     return `${typeName}.${fieldName}`;
+  }
+
+  /**
+   * Logs a warning message indicating that a resolver for the specified field and type
+   * is already registered and will be replaced by a new resolver.
+   *
+   * @param fieldName - The name of the field for which the resolver is being overridden.
+   * @param typeName - The name of the type associated with the field.
+   */
+  #warnResolverOverriding(fieldName: string, typeName: string): void {
+    this.#logger.warn(
+      `A resolver for field '${fieldName}' is already registered for '${typeName}'. The previous resolver will be replaced.`
+    );
   }
 }
 

--- a/packages/event-handler/src/appsync-graphql/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/appsync-graphql/RouteHandlerRegistry.ts
@@ -86,7 +86,6 @@ class RouteHandlerRegistry {
    * @param otherRegistry - The registry to merge handlers from.
    */
   public merge(otherRegistry: RouteHandlerRegistry): void {
-    this.#logger.debug('Merging route handler registries');
     for (const [key, handler] of otherRegistry.resolvers) {
       if (this.resolvers.has(key)) {
         this.#warnResolverOverriding(handler.fieldName, handler.typeName);

--- a/packages/event-handler/src/appsync-graphql/Router.ts
+++ b/packages/event-handler/src/appsync-graphql/Router.ts
@@ -65,6 +65,20 @@ class Router {
   }
 
   /**
+   * Merges resolver registries from another router into this router.
+   *
+   * This method combines the resolver registry, batch resolver registry, and exception handler registry
+   * from the provided router with the current router's registries.
+   *
+   * @param router - The source router whose registries will be merged into this router
+   */
+  protected mergeRegistriesFrom(router: Router): void {
+    this.resolverRegistry.merge(router.resolverRegistry);
+    this.batchResolverRegistry.merge(router.batchResolverRegistry);
+    this.exceptionHandlerRegistry.merge(router.exceptionHandlerRegistry);
+  }
+
+  /**
    * Register a resolver function for any GraphQL event.
    *
    * Registers a handler for a specific GraphQL field. The handler will be invoked when a request is made

--- a/packages/event-handler/src/appsync-graphql/Router.ts
+++ b/packages/event-handler/src/appsync-graphql/Router.ts
@@ -73,13 +73,8 @@ class Router {
    * @param router - The source router whose registries will be merged into this router
    */
   protected mergeRegistriesFrom(router: Router): void {
-    this.logger.debug('Merging route handler registries');
     this.resolverRegistry.merge(router.resolverRegistry);
-
-    this.logger.debug('Merging batch route handler registries');
     this.batchResolverRegistry.merge(router.batchResolverRegistry);
-
-    this.logger.debug('Merging exception handler registries');
     this.exceptionHandlerRegistry.merge(router.exceptionHandlerRegistry);
   }
 

--- a/packages/event-handler/src/appsync-graphql/Router.ts
+++ b/packages/event-handler/src/appsync-graphql/Router.ts
@@ -73,8 +73,13 @@ class Router {
    * @param router - The source router whose registries will be merged into this router
    */
   protected mergeRegistriesFrom(router: Router): void {
+    this.logger.debug('Merging route handler registries');
     this.resolverRegistry.merge(router.resolverRegistry);
+
+    this.logger.debug('Merging batch route handler registries');
     this.batchResolverRegistry.merge(router.batchResolverRegistry);
+
+    this.logger.debug('Merging exception handler registries');
     this.exceptionHandlerRegistry.merge(router.exceptionHandlerRegistry);
   }
 

--- a/packages/event-handler/src/appsync-graphql/index.ts
+++ b/packages/event-handler/src/appsync-graphql/index.ts
@@ -1,8 +1,9 @@
 export { AppSyncGraphQLResolver } from './AppSyncGraphQLResolver.js';
 export {
-  ResolverNotFoundException,
   InvalidBatchResponseException,
+  ResolverNotFoundException,
 } from './errors.js';
+export { Router } from './Router.js';
 export {
   awsDate,
   awsDateTime,

--- a/packages/event-handler/src/types/appsync-graphql.ts
+++ b/packages/event-handler/src/types/appsync-graphql.ts
@@ -14,6 +14,7 @@ type BatchResolverSyncHandlerFn<
   options: {
     event: AppSyncResolverEvent<TParams, TSource>;
     context: Context;
+    sharedContext?: Map<string, unknown>;
   }
 ) => unknown;
 
@@ -25,6 +26,7 @@ type BatchResolverHandlerFn<
   options: {
     event: AppSyncResolverEvent<TParams, TSource>;
     context: Context;
+    sharedContext?: Map<string, unknown>;
   }
 ) => Promise<unknown>;
 
@@ -36,6 +38,7 @@ type BatchResolverAggregateHandlerFn<
   options: {
     event: AppSyncResolverEvent<TParams, TSource>[];
     context: Context;
+    sharedContext?: Map<string, unknown>;
   }
 ) => Promise<unknown>;
 
@@ -47,6 +50,7 @@ type BatchResolverSyncAggregateHandlerFn<
   options: {
     event: AppSyncResolverEvent<TParams, TSource>[];
     context: Context;
+    sharedContext?: Map<string, unknown>;
   }
 ) => unknown;
 
@@ -70,6 +74,7 @@ type ResolverSyncHandlerFn<TParams = Record<string, unknown>> = (
   options: {
     event: AppSyncResolverEvent<TParams>;
     context: Context;
+    sharedContext?: Map<string, unknown>;
   }
 ) => unknown;
 
@@ -78,6 +83,7 @@ type ResolverHandlerFn<TParams = Record<string, unknown>> = (
   options: {
     event: AppSyncResolverEvent<TParams>;
     context: Context;
+    sharedContext?: Map<string, unknown>;
   }
 ) => Promise<unknown>;
 

--- a/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
+++ b/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
@@ -2003,7 +2003,7 @@ describe('Class: AppSyncGraphQLResolver', () => {
       expect.objectContaining({
         event: expect.any(Object),
         context,
-        sharedContext: expect.any(Map),
+        sharedContext: new Map([['requestId', 'test-123']]),
       })
     );
   });
@@ -2031,7 +2031,7 @@ describe('Class: AppSyncGraphQLResolver', () => {
       expect.objectContaining({
         event: expect.any(Object),
         context,
-        sharedContext: expect.any(Map),
+        sharedContext: new Map([['requestId', 'test-456']]),
       })
     );
   });

--- a/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
+++ b/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
@@ -1926,5 +1926,116 @@ describe('Class: AppSyncGraphQLResolver', () => {
     });
   });
 
+  it('does not include sharedContext when context is empty for batch resolvers with throwOnError=true', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+    const handlerSpy = vi.fn().mockResolvedValue({ id: '1', processed: true });
+
+    app.batchResolver(handlerSpy, {
+      fieldName: 'batchProcess',
+      aggregate: false,
+      throwOnError: true,
+    });
+
+    // Act
+    await app.resolve(
+      [onGraphqlEventFactory('batchProcess', 'Query', { id: '1' })],
+      context
+    );
+
+    // Assess
+    expect(handlerSpy).toHaveBeenCalledWith(
+      { id: '1' },
+      {
+        event: expect.any(Object),
+        context,
+      }
+    );
+  });
+
+  it('does not include sharedContext when context is empty for batch resolvers with throwOnError=false', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+    const handlerSpy = vi.fn().mockResolvedValue({ id: '1', processed: true });
+
+    app.batchResolver(handlerSpy, {
+      fieldName: 'batchProcess',
+      aggregate: false,
+      throwOnError: false,
+    });
+
+    // Act
+    await app.resolve(
+      [onGraphqlEventFactory('batchProcess', 'Query', { id: '1' })],
+      context
+    );
+
+    // Assess
+    expect(handlerSpy).toHaveBeenCalledWith(
+      { id: '1' },
+      {
+        event: expect.any(Object),
+        context,
+      }
+    );
+  });
+
+  it('includes sharedContext when context has data for batch resolvers with throwOnError=true', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+    const handlerSpy = vi.fn().mockResolvedValue({ id: '1', processed: true });
+    app.batchResolver(handlerSpy, {
+      fieldName: 'batchProcess',
+      aggregate: false,
+      throwOnError: true,
+    });
+
+    // Act
+    app.appendContext({ requestId: 'test-123' });
+
+    await app.resolve(
+      [onGraphqlEventFactory('batchProcess', 'Query', { id: '1' })],
+      context
+    );
+
+    // Assess
+    expect(handlerSpy).toHaveBeenCalledWith(
+      { id: '1' },
+      expect.objectContaining({
+        event: expect.any(Object),
+        context,
+        sharedContext: expect.any(Map),
+      })
+    );
+  });
+
+  it('includes sharedContext when context has data for batch resolvers with throwOnError=false', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+    const handlerSpy = vi.fn().mockResolvedValue({ id: '1', processed: true });
+    app.batchResolver(handlerSpy, {
+      fieldName: 'batchProcess',
+      aggregate: false,
+      throwOnError: false,
+    });
+
+    // Act
+    app.appendContext({ requestId: 'test-456' });
+    await app.resolve(
+      [onGraphqlEventFactory('batchProcess', 'Query', { id: '1' })],
+      context
+    );
+
+    // Assess
+    expect(handlerSpy).toHaveBeenCalledWith(
+      { id: '1' },
+      expect.objectContaining({
+        event: expect.any(Object),
+        context,
+        sharedContext: expect.any(Map),
+      })
+    );
+  });
+
   // #endregion appendContext
 });

--- a/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
+++ b/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
@@ -1366,8 +1366,7 @@ describe('Class: AppSyncGraphQLResolver', () => {
     }));
 
     const app = new AppSyncGraphQLResolver({ logger: console });
-    app.includeRouter(userRouter);
-    app.includeRouter(todoRouter);
+    app.includeRouter([userRouter, todoRouter]);
 
     // Act
     const getUserResult = await app.resolve(

--- a/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
+++ b/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
@@ -5,7 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppSyncGraphQLResolver } from '../../../src/appsync-graphql/AppSyncGraphQLResolver.js';
 import {
   InvalidBatchResponseException,
+  makeId,
   ResolverNotFoundException,
+  Router,
 } from '../../../src/appsync-graphql/index.js';
 import type { ErrorClass } from '../../../src/types/appsync-graphql.js';
 import { onGraphqlEventFactory } from '../../helpers/factories.js';
@@ -1336,4 +1338,239 @@ describe('Class: AppSyncGraphQLResolver', () => {
   });
 
   // #endregion Exception handling
+
+  // #region includeRouter
+
+  it('handles multiple routers and resolves their handlers correctly', async () => {
+    // Prepare
+    const userRouter = new Router();
+    userRouter.onQuery<{ id: string }>('getUser', async ({ id }) => ({
+      id,
+      name: 'John Doe',
+    }));
+
+    userRouter.onMutation<{ name: string; email: string }>(
+      'createUser',
+      async ({ name, email }) => ({
+        id: makeId(),
+        name,
+        email,
+      })
+    );
+
+    const todoRouter = new Router();
+    todoRouter.onQuery<{ id: string }>('getTodo', async ({ id }) => ({
+      id,
+      title: 'Sample Todo',
+      completed: false,
+    }));
+
+    const app = new AppSyncGraphQLResolver({ logger: console });
+    app.includeRouter(userRouter);
+    app.includeRouter(todoRouter);
+
+    // Act
+    const getUserResult = await app.resolve(
+      onGraphqlEventFactory('getUser', 'Query', { id: '123' }),
+      context
+    );
+    const createUserResult = await app.resolve(
+      onGraphqlEventFactory('createUser', 'Mutation', {
+        name: 'Jane Doe',
+        email: 'jane.doe@example.com',
+      }),
+      context
+    );
+    const todoResult = await app.resolve(
+      onGraphqlEventFactory('getTodo', 'Query', { id: '456' }),
+      context
+    );
+
+    // Assess
+    expect(getUserResult).toEqual({ id: '123', name: 'John Doe' });
+    expect(createUserResult).toEqual({
+      id: expect.any(String),
+      name: 'Jane Doe',
+      email: 'jane.doe@example.com',
+    });
+    expect(todoResult).toEqual({
+      id: '456',
+      title: 'Sample Todo',
+      completed: false,
+    });
+  });
+
+  it('handles multiple routers with batch resolvers and resolves their handlers correctly', async () => {
+    // Prepare
+    const postRouter = new Router();
+    postRouter.onBatchQuery('getPosts', async (events) =>
+      events.map((event) => ({
+        id: event.arguments.id,
+        title: `Post ${event.arguments.id}`,
+      }))
+    );
+
+    const todoRouter = new Router();
+    todoRouter.onBatchQuery('getTodos', async (events) =>
+      events.map((event) => ({
+        id: event.arguments.id,
+        title: `Todo ${event.arguments.id}`,
+      }))
+    );
+
+    const app = new AppSyncGraphQLResolver({ logger: console });
+    app.includeRouter(postRouter);
+    app.includeRouter(todoRouter);
+
+    // Act
+    const postResults = await app.resolve(
+      [
+        onGraphqlEventFactory('getPosts', 'Query', { id: '1' }),
+        onGraphqlEventFactory('getPosts', 'Query', { id: '2' }),
+      ],
+      context
+    );
+    const todoResults = await app.resolve(
+      [
+        onGraphqlEventFactory('getTodos', 'Query', { id: '1' }),
+        onGraphqlEventFactory('getTodos', 'Query', { id: '2' }),
+      ],
+      context
+    );
+
+    // Assess
+    expect(postResults).toEqual([
+      { id: '1', title: 'Post 1' },
+      { id: '2', title: 'Post 2' },
+    ]);
+    expect(todoResults).toEqual([
+      { id: '1', title: 'Todo 1' },
+      { id: '2', title: 'Todo 2' },
+    ]);
+  });
+
+  it('handles multiple routers with exception handlers', async () => {
+    // Prepare
+    const firstRouter = new Router();
+    firstRouter.exceptionHandler(ValidationError, async (error) => ({
+      error: `Handled: ${error.message}`,
+      type: 'validation',
+    }));
+    firstRouter.resolver(
+      async () => {
+        throw new ValidationError('Test validation error');
+      },
+      { fieldName: 'firstHandler' }
+    );
+
+    const secondRouter = new Router();
+    secondRouter.exceptionHandler(EvalError, async (error) => ({
+      error: `Handled: ${error.message}`,
+      type: 'evaluation',
+    }));
+    secondRouter.resolver(
+      async () => {
+        throw new EvalError('Test evaluation error');
+      },
+      { fieldName: 'secondHandler' }
+    );
+
+    const app = new AppSyncGraphQLResolver({ logger: console });
+    app.includeRouter(firstRouter);
+    app.includeRouter(secondRouter);
+
+    // Act
+    const firstResult = await app.resolve(
+      onGraphqlEventFactory('firstHandler', 'Query', { shouldThrow: true }),
+      context
+    );
+    const secondResult = await app.resolve(
+      onGraphqlEventFactory('secondHandler', 'Query', { shouldThrow: true }),
+      context
+    );
+
+    // Assess
+    expect(firstResult).toEqual({
+      error: 'Handled: Test validation error',
+      type: 'validation',
+    });
+    expect(secondResult).toEqual({
+      error: 'Handled: Test evaluation error',
+      type: 'evaluation',
+    });
+  });
+
+  it('handles conflicts when including multiple routers with same resolver', async () => {
+    // Prepare
+    const firstRouter = new Router();
+    firstRouter.onQuery('getTest', () => ({
+      source: 'first',
+    }));
+
+    const secondRouter = new Router();
+    secondRouter.onQuery('getTest', () => ({
+      source: 'second',
+    }));
+
+    const app = new AppSyncGraphQLResolver({ logger: console });
+    app.includeRouter(firstRouter);
+    app.includeRouter(secondRouter);
+
+    // Act
+    const result = await app.resolve(
+      onGraphqlEventFactory('getTest', 'Query', {}),
+      context
+    );
+
+    // Assess
+    expect(result).toEqual({ source: 'second' });
+    expect(console.warn).toHaveBeenCalledWith(
+      "A resolver for field 'getTest' is already registered for 'Query'. The previous resolver will be replaced."
+    );
+  });
+
+  it('handles conflicts when including multiple routers with same exception handler', async () => {
+    // Prepare
+    const firstRouter = new Router();
+    firstRouter.exceptionHandler(ValidationError, async (error) => ({
+      source: 'first',
+      message: error.message,
+      type: 'first_validation',
+    }));
+    firstRouter.onQuery('testError', async () => {
+      throw new ValidationError('Test validation error');
+    });
+
+    const secondRouter = new Router();
+    secondRouter.exceptionHandler(ValidationError, async (error) => ({
+      source: 'second',
+      message: error.message,
+      type: 'second_validation',
+    }));
+    secondRouter.onQuery('testError', async () => {
+      throw new ValidationError('Test validation error');
+    });
+
+    const app = new AppSyncGraphQLResolver({ logger: console });
+    app.includeRouter(firstRouter);
+    app.includeRouter(secondRouter);
+
+    // Act
+    const result = await app.resolve(
+      onGraphqlEventFactory('testError', 'Query', {}),
+      context
+    );
+
+    // Assess
+    expect(result).toEqual({
+      source: 'second',
+      message: 'Test validation error',
+      type: 'second_validation',
+    });
+    expect(console.warn).toHaveBeenCalledWith(
+      "An exception handler for error class 'ValidationError' is already registered. The previous handler will be replaced."
+    );
+  });
+
+  // #endregion includeRouters
 });

--- a/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
+++ b/packages/event-handler/tests/unit/appsync-graphql/AppSyncGraphQLResolver.test.ts
@@ -1572,5 +1572,359 @@ describe('Class: AppSyncGraphQLResolver', () => {
     );
   });
 
+  it('works as a method decorator for `includeRouter`', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+
+    const userRouter = new Router();
+    const todoRouter = new Router();
+
+    class Lambda {
+      public scope = 'scoped';
+
+      @userRouter.onQuery('getUser')
+      async getUserById({ id }: { id: string }) {
+        if (id.length === 0)
+          throw new ValidationError('User ID cannot be empty');
+        return { id, name: 'John Doe', scope: this.scope };
+      }
+
+      @userRouter.onMutation('createUser')
+      async createUser({ name, email }: { name: string; email: string }) {
+        return { id: makeId(), name, email, scope: this.scope };
+      }
+
+      @userRouter.exceptionHandler(ValidationError)
+      async handleValidationError(error: ValidationError) {
+        return {
+          message: 'UserRouter validation error',
+          details: error.message,
+          type: 'user_validation_error',
+          scope: this.scope,
+        };
+      }
+
+      @todoRouter.onQuery('getTodo')
+      async getTodoById({ id }: { id: string }) {
+        if (id === 'eval-error') {
+          throw new EvalError('Todo evaluation error');
+        }
+        return {
+          id,
+          title: 'Sample Todo',
+          completed: false,
+          scope: this.scope,
+        };
+      }
+
+      @todoRouter.exceptionHandler(EvalError)
+      async handleEvalError(error: EvalError) {
+        return {
+          message: 'TodoRouter evaluation error',
+          details: error.message,
+          type: 'todo_evaluation_error',
+          scope: this.scope,
+        };
+      }
+      async handler(event: unknown, context: Context) {
+        app.includeRouter(userRouter);
+        app.includeRouter(todoRouter);
+        return app.resolve(event, context, {
+          scope: this,
+        });
+      }
+    }
+
+    const lambda = new Lambda();
+    const handler = lambda.handler.bind(lambda);
+
+    // Act
+    const getUserResult = await handler(
+      onGraphqlEventFactory('getUser', 'Query', { id: '123' }),
+      context
+    );
+    const createUserResult = await handler(
+      onGraphqlEventFactory('createUser', 'Mutation', {
+        name: 'Jane Doe',
+        email: 'jane.doe@example.com',
+      }),
+      context
+    );
+    const userValidationError = await handler(
+      onGraphqlEventFactory('getUser', 'Query', { id: '' }),
+      context
+    );
+
+    const getTodoResult = await handler(
+      onGraphqlEventFactory('getTodo', 'Query', { id: '456' }),
+      context
+    );
+    const todoEvalError = await handler(
+      onGraphqlEventFactory('getTodo', 'Query', { id: 'eval-error' }),
+      context
+    );
+
+    // Assess
+    expect(getUserResult).toEqual({
+      id: '123',
+      name: 'John Doe',
+      scope: 'scoped',
+    });
+    expect(createUserResult).toEqual({
+      id: expect.any(String),
+      name: 'Jane Doe',
+      email: 'jane.doe@example.com',
+      scope: 'scoped',
+    });
+    expect(getTodoResult).toEqual({
+      id: '456',
+      title: 'Sample Todo',
+      completed: false,
+      scope: 'scoped',
+    });
+    expect(userValidationError).toEqual({
+      message: 'UserRouter validation error',
+      details: 'User ID cannot be empty',
+      type: 'user_validation_error',
+      scope: 'scoped',
+    });
+    expect(todoEvalError).toEqual({
+      details: 'Todo evaluation error',
+      message: 'TodoRouter evaluation error',
+      type: 'todo_evaluation_error',
+      scope: 'scoped',
+    });
+  });
+
   // #endregion includeRouters
+
+  // #region appendContext
+
+  it('allows sharing context data with resolver handlers', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+
+    app.onQuery<{ id: string }>(
+      'getUser',
+      async ({ id }, { sharedContext }) => {
+        const isAdmin = sharedContext?.get('isAdmin');
+        const requestId = sharedContext?.get('requestId');
+
+        return {
+          id,
+          name: 'John Doe',
+          email: isAdmin ? 'john@example.com' : 'hidden',
+          requestId,
+        };
+      }
+    );
+
+    // Act
+    app.appendContext({
+      isAdmin: true,
+      requestId: 'test-request-123',
+      timestamp: Date.now(),
+    });
+
+    const result = await app.resolve(
+      onGraphqlEventFactory('getUser', 'Query', { id: '1' }),
+      context
+    );
+
+    // Assess
+    expect(result).toEqual({
+      id: '1',
+      name: 'John Doe',
+      email: 'john@example.com',
+      requestId: 'test-request-123',
+    });
+  });
+
+  it('allows context sharing with included routers', async () => {
+    // Prepare
+    const userRouter = new Router();
+    userRouter.onQuery<{ id: string }>(
+      'getUser',
+      async ({ id }, { sharedContext }) => {
+        const isAdmin = sharedContext?.get('isAdmin');
+        const requestId = sharedContext?.get('requestId');
+
+        return {
+          id,
+          name: 'John Doe',
+          role: isAdmin ? 'admin' : 'user',
+          requestId,
+        };
+      }
+    );
+
+    const todoRouter = new Router();
+    todoRouter.onQuery<{ id: string }>(
+      'getTodo',
+      async ({ id }, { sharedContext }) => {
+        const isAdmin = sharedContext?.get('isAdmin');
+        const requestId = sharedContext?.get('requestId');
+
+        return {
+          id,
+          title: 'Sample Todo',
+          completed: false,
+          role: isAdmin ? 'admin' : 'user',
+          requestId,
+        };
+      }
+    );
+
+    const app = new AppSyncGraphQLResolver();
+    app.includeRouter(userRouter);
+    app.includeRouter(todoRouter);
+    app.appendContext({
+      isAdmin: false,
+      requestId: 'router-test-456',
+    });
+
+    // Act
+    const userResult = await app.resolve(
+      onGraphqlEventFactory('getUser', 'Query', { id: '2' }),
+      context
+    );
+
+    // Assess
+    expect(userResult).toEqual({
+      id: '2',
+      name: 'John Doe',
+      role: 'user',
+      requestId: 'router-test-456',
+    });
+  });
+
+  it('clears context after each invocation for single events', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+
+    app.onQuery<{ id: string }>(
+      'getUser',
+      async ({ id }, { sharedContext }) => {
+        const requestId = sharedContext?.get('requestId');
+
+        return {
+          id,
+          requestId: requestId || 'no-request-id',
+        };
+      }
+    );
+
+    // Act
+    app.appendContext({ requestId: 'first-request' });
+    const firstResult = await app.resolve(
+      onGraphqlEventFactory('getUser', 'Query', { id: '1' }),
+      context
+    );
+
+    // Assess
+    expect(firstResult).toEqual({
+      id: '1',
+      requestId: 'first-request',
+    });
+
+    // Act
+    const secondResult = await app.resolve(
+      onGraphqlEventFactory('getUser', 'Query', { id: '2' }),
+      context
+    );
+
+    // Assess
+    expect(secondResult).toEqual({
+      id: '2',
+      requestId: 'no-request-id',
+    });
+  });
+
+  it('clears context after each invocation for batch events', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+
+    app.batchResolver<{ id: string }>(
+      async (events, { sharedContext }) => {
+        const requestId = sharedContext?.get('requestId');
+
+        return events.map((event) => ({
+          id: event.arguments.id,
+          requestId: requestId || 'no-request-id',
+        }));
+      },
+      {
+        fieldName: 'getUsers',
+      }
+    );
+
+    // Act
+    app.appendContext({ requestId: 'batch-request' });
+    const firstResult = await app.resolve(
+      [
+        onGraphqlEventFactory('getUsers', 'Query', { id: '1' }),
+        onGraphqlEventFactory('getUsers', 'Query', { id: '2' }),
+      ],
+      context
+    );
+
+    // Assess
+    expect(firstResult).toEqual([
+      { id: '1', requestId: 'batch-request' },
+      { id: '2', requestId: 'batch-request' },
+    ]);
+
+    // Act
+    const secondResult = await app.resolve(
+      [
+        onGraphqlEventFactory('getUsers', 'Query', { id: '3' }),
+        onGraphqlEventFactory('getUsers', 'Query', { id: '4' }),
+      ],
+      context
+    );
+
+    // Assess
+    expect(secondResult).toEqual([
+      { id: '3', requestId: 'no-request-id' },
+      { id: '4', requestId: 'no-request-id' },
+    ]);
+  });
+
+  it('allows updating context data multiple times before invocation', async () => {
+    // Prepare
+    const app = new AppSyncGraphQLResolver();
+
+    app.onQuery<{ id: string }>(
+      'getUser',
+      async ({ id }, { sharedContext }) => {
+        const role = sharedContext?.get('role');
+        const permissions = sharedContext?.get('permissions');
+
+        return {
+          id,
+          role,
+          permissions,
+        };
+      }
+    );
+
+    // Act
+    app.appendContext({ role: 'user' });
+    app.appendContext({ permissions: ['read'] });
+    app.appendContext({ role: 'admin' });
+
+    const result = await app.resolve(
+      onGraphqlEventFactory('getUser', 'Query', { id: '1' }),
+      context
+    );
+
+    // Assess
+    expect(result).toEqual({
+      id: '1',
+      role: 'admin',
+      permissions: ['read'],
+    });
+  });
+
+  // #endregion appendContext
 });


### PR DESCRIPTION
## Summary
This PR adds the ability for router composition and sharing context data between routes
### Changes

Follows the impmentation provided in the linked issue description.

- `includeRouter` method for router composition
- `appendContext` method for appending context that is shared with all the routes
-  new context option is set as `sharedContext`, this is up for debate
-  100% unit test coverage
-  Documentation added, mostly followed what we have in python [documentation](https://docs.powertools.aws.dev/lambda/python/latest/core/event_handler/appsync/#split-operations-with-router)

```graphql
// Schema
type Post {
	id: ID
	title: String
	content: String
	requestId: String
}

type User {
	id: ID
	name: String
	email: AWSEmail
	requestId: String
}

type Query {
	getUsers: [User]
	getPosts: [Post]
}

schema {
	query: Query
}
```

```typescript
//postRouter.ts
import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';

const postRouter = new Router();

postRouter.onQuery('getPosts', async (args, { sharedContext }) => {
  const requestId = sharedContext?.get('requestId');
  return [{ id: 1, title: 'First post', content: 'Hello world!', requestId }];
});

export { postRouter };
```

```typescript
// userRouter.ts
import { Router } from '@aws-lambda-powertools/event-handler/appsync-graphql';

const userRouter = new Router();

userRouter.onQuery('getUsers', async (args, { sharedContext }) => {
  const requestId = sharedContext?.get('requestId');
  return [{ id: 1, name: 'John Doe', email: 'john@example.com', requestId }];
});

export { userRouter };
```

```typescript
// app.ts
import { AppSyncGraphQLResolver } from '@aws-lambda-powertools/event-handler/appsync-graphql';
import { Logger } from '@aws-lambda-powertools/logger';
import type { Context } from 'aws-lambda';
import { userRouter } from './userRouter.js';
import { postRouter } from './todoRouter.js';

const logger = new Logger({ serviceName: 'GraphQLAPI' });
const app = new AppSyncGraphQLResolver({ logger });

app.includeRouter([userRouter, postRouter]);

export const handler = async (event: unknown, context: Context) => {
  app.appendContext({ 
    isAdmin: true, 
    requestId: 'request-123',
    timestamp: Date.now()
  });
  
  return app.resolve(event, context);
};
```

```graphql
query MyQuery {
  getUsers {
    id,
    name,
    email,
    requestId
  }
}
```

```json
{
  "data": {
    "getUsers": [
      {
        "id": "1",
        "name": "John Doe",
        "email": "john@example.com",
        "requestId": "request-123"
      }
    ]
  }
}
```

```graphql
query MyQuery {
  getPosts {
    id,
    title,
    content,
    requestId
  }
}
```

```json
{
  "data": {
    "getPosts": [
      {
        "id": "1",
        "title": "First post",
        "content": "Hello world!",
        "requestId": "request-123"
      }
    ]
  }
}
```
**Issue number:** closes #4131

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
