### PR TITLE
chore(event-handler): rename variables to reflect that options object is now a RequestContext

### DIFF
--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -79,7 +79,7 @@ class Router {
    * Registers a custom error handler for specific error types.
    *
    * @param errorType - The error constructor(s) to handle
-   * @param handler - The error handler function that returns an ErrorResponse
+   * @param handler - The error handler function that returns a Promise<ErrorResponse>
    */
   public errorHandler<T extends Error>(
     errorType: ErrorConstructor<T> | ErrorConstructor<T>[],
@@ -106,7 +106,7 @@ class Router {
   /**
    * Registers a custom handler for 404 Not Found errors.
    *
-   * @param handler - The error handler function for NotFoundError
+   * @param handler - The error handler function that returns a Promise<ErrorResponse>
    */
   public notFound(handler: ErrorHandler<NotFoundError>): void;
   public notFound(): MethodDecorator;
@@ -127,7 +127,7 @@ class Router {
   /**
    * Registers a custom handler for 405 Method Not Allowed errors.
    *
-   * @param handler - The error handler function for MethodNotAllowedError
+   * @param handler - The error handler function that returns a Promise<ErrorResponse>
    */
   public methodNotAllowed(handler: ErrorHandler<MethodNotAllowedError>): void;
   public methodNotAllowed(): MethodDecorator;
@@ -158,9 +158,9 @@ class Router {
    *
    * @example
    * ```typescript
-   * const authMiddleware: Middleware = async (params, options, next) => {
+   * const authMiddleware: Middleware = async (params, reqCtx, next) => {
    *   // Authentication logic
-   *   if (!isAuthenticated(options.request)) {
+   *   if (!isAuthenticated(reqCtx.request)) {
    *     return new Response('Unauthorized', { status: 401 });
    *   }
    *   await next();
@@ -211,7 +211,7 @@ class Router {
 
     const request = proxyEventToWebRequest(event);
 
-    const handlerOptions: RequestContext = {
+    const requestContext: RequestContext = {
       event,
       context,
       request,
@@ -234,11 +234,11 @@ class Router {
           ? route.handler.bind(options.scope)
           : route.handler;
 
-      const handlerMiddleware: Middleware = async (params, options, next) => {
-        const handlerResult = await handler(params, options);
-        options.res = handlerResultToWebResponse(
+      const handlerMiddleware: Middleware = async (params, reqCtx, next) => {
+        const handlerResult = await handler(params, reqCtx);
+        reqCtx.res = handlerResultToWebResponse(
           handlerResult,
-          options.res.headers
+          reqCtx.res.headers
         );
 
         await next();
@@ -252,18 +252,18 @@ class Router {
 
       const middlewareResult = await middleware(
         route.params,
-        handlerOptions,
+        requestContext,
         () => Promise.resolve()
       );
 
       // middleware result takes precedence to allow short-circuiting
-      const result = middlewareResult ?? handlerOptions.res;
+      const result = middlewareResult ?? requestContext.res;
 
       return handlerResultToProxyResult(result);
     } catch (error) {
       this.logger.debug(`There was an error processing the request: ${error}`);
       const result = await this.handleError(error as Error, {
-        ...handlerOptions,
+        ...requestContext,
         scope: options?.scope,
       });
       return await webResponseToProxyResult(result);
@@ -284,7 +284,7 @@ class Router {
    * back to a default handler.
    *
    * @param error - The error to handle
-   * @param options - Optional resolve options for scope binding
+   * @param options - Error resolve options including request context and scope
    * @returns A Response object with appropriate status code and error details
    */
   protected async handleError(
@@ -294,11 +294,8 @@ class Router {
     const handler = this.errorHandlerRegistry.resolve(error);
     if (handler !== null) {
       try {
-        const { scope, ...handlerOptions } = options;
-        const body = await handler.apply(scope ?? this, [
-          error,
-          handlerOptions,
-        ]);
+        const { scope, ...reqCtx } = options;
+        const body = await handler.apply(scope ?? this, [error, reqCtx]);
         return new Response(JSON.stringify(body), {
           status: body.statusCode,
           headers: { 'Content-Type': 'application/json' },

--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -79,8 +79,7 @@ class Router {
    * Registers a custom error handler for specific error types.
    *
    * @param errorType - The error constructor(s) to handle
-   * @param handler - The error handler that returns an
-   * error response>
+   * @param handler - The error handler that returns an error response
    */
   public errorHandler<T extends Error>(
     errorType: ErrorConstructor<T> | ErrorConstructor<T>[],

--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -79,7 +79,8 @@ class Router {
    * Registers a custom error handler for specific error types.
    *
    * @param errorType - The error constructor(s) to handle
-   * @param handler - The error handler function that returns a Promise<ErrorResponse>
+   * @param handler - The error handler that returns an
+   * error response>
    */
   public errorHandler<T extends Error>(
     errorType: ErrorConstructor<T> | ErrorConstructor<T>[],
@@ -106,7 +107,8 @@ class Router {
   /**
    * Registers a custom handler for 404 Not Found errors.
    *
-   * @param handler - The error handler function that returns a Promise<ErrorResponse>
+   * @param handler - The error handler that returns an error
+   * response
    */
   public notFound(handler: ErrorHandler<NotFoundError>): void;
   public notFound(): MethodDecorator;
@@ -127,7 +129,7 @@ class Router {
   /**
    * Registers a custom handler for 405 Method Not Allowed errors.
    *
-   * @param handler - The error handler function that returns a Promise<ErrorResponse>
+   * @param handler - The error handler that returns an error response
    */
   public methodNotAllowed(handler: ErrorHandler<MethodNotAllowedError>): void;
   public methodNotAllowed(): MethodDecorator;
@@ -216,7 +218,7 @@ class Router {
       context,
       request,
       // this response should be overwritten by the handler, if it isn't
-      // it means somthing went wrong with the middleware chain
+      // it means something went wrong with the middleware chain
       res: new Response('', { status: 500 }),
     };
 

--- a/packages/event-handler/src/rest/utils.ts
+++ b/packages/event-handler/src/rest/utils.ts
@@ -153,7 +153,7 @@ export const isAPIGatewayProxyResult = (
 export const composeMiddleware = (middleware: Middleware[]): Middleware => {
   return async (
     params: Record<string, string>,
-    options: RequestContext,
+    reqCtx: RequestContext,
     next: () => Promise<HandlerResponse | void>
   ): Promise<HandlerResponse | void> => {
     let index = -1;
@@ -172,7 +172,7 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
       }
 
       const middlewareFn = middleware[i];
-      const middlewareResult = await middlewareFn(params, options, () =>
+      const middlewareResult = await middlewareFn(params, reqCtx, () =>
         dispatch(i + 1)
       );
 

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -25,7 +25,7 @@ type ErrorResolveOptions = RequestContext & ResolveOptions;
 
 type ErrorHandler<T extends Error = Error> = (
   error: T,
-  options: RequestContext
+  reqCtx: RequestContext
 ) => Promise<ErrorResponse>;
 
 interface ErrorConstructor<T extends Error = Error> {
@@ -59,7 +59,7 @@ type HandlerResponse = Response | JSONObject;
 type RouteHandler<
   TParams = Record<string, unknown>,
   TReturn = HandlerResponse,
-> = (args: TParams, options: RequestContext) => Promise<TReturn>;
+> = (args: TParams, reqCtx: RequestContext) => Promise<TReturn>;
 
 type HttpMethod = keyof typeof HttpVerbs;
 
@@ -84,7 +84,7 @@ type NextFunction = () => Promise<HandlerResponse | void>;
 
 type Middleware = (
   params: Record<string, string>,
-  options: RequestContext,
+  reqCtx: RequestContext,
   next: NextFunction
 ) => Promise<void | HandlerResponse>;
 

--- a/packages/event-handler/tests/unit/rest/ErrorHandlerRegistry.test.ts
+++ b/packages/event-handler/tests/unit/rest/ErrorHandlerRegistry.test.ts
@@ -8,7 +8,7 @@ import type {
 
 const createErrorHandler =
   (statusCode: HttpStatusCode, message?: string) =>
-  async (error: Error, _options: RequestContext) => ({
+  async (error: Error, _reqCtx: RequestContext) => ({
     statusCode,
     error: error.name,
     message: message ?? error.message,

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -89,11 +89,11 @@ describe('Class: Router - Basic Routing', () => {
     const app = new Router();
     const testEvent = createTestEvent('/test', 'GET');
 
-    app.get('/test', async (_params, options) => {
+    app.get('/test', async (_params, reqCtx) => {
       return {
-        hasRequest: options.request instanceof Request,
-        hasEvent: options.event === testEvent,
-        hasContext: options.context === context,
+        hasRequest: reqCtx.request instanceof Request,
+        hasEvent: reqCtx.event === testEvent,
+        hasContext: reqCtx.context === context,
       };
     });
 

--- a/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
@@ -395,11 +395,11 @@ describe('Class: Router - Decorators', () => {
 
       class Lambda {
         @app.get('/test')
-        public async getTest(_params: any, options: any) {
+        public async getTest(_params: any, reqCtx: any) {
           return {
-            hasRequest: options.request instanceof Request,
-            hasEvent: options.event === testEvent,
-            hasContext: options.context === context,
+            hasRequest: reqCtx.request instanceof Request,
+            hasEvent: reqCtx.event === testEvent,
+            hasContext: reqCtx.context === context,
           };
         }
 
@@ -427,14 +427,14 @@ describe('Class: Router - Decorators', () => {
 
       class Lambda {
         @app.errorHandler(BadRequestError)
-        public async handleBadRequest(error: BadRequestError, options: any) {
+        public async handleBadRequest(error: BadRequestError, reqCtx: any) {
           return {
             statusCode: HttpErrorCodes.BAD_REQUEST,
             error: 'Bad Request',
             message: error.message,
-            hasRequest: options.request instanceof Request,
-            hasEvent: options.event === testEvent,
-            hasContext: options.context === context,
+            hasRequest: reqCtx.request instanceof Request,
+            hasEvent: reqCtx.event === testEvent,
+            hasContext: reqCtx.context === context,
           };
         }
 

--- a/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
@@ -371,13 +371,13 @@ describe('Class: Router - Error Handling', () => {
     const app = new Router();
     const testEvent = createTestEvent('/test', 'GET');
 
-    app.errorHandler(BadRequestError, async (error, options) => ({
+    app.errorHandler(BadRequestError, async (error, reqCtx) => ({
       statusCode: HttpErrorCodes.BAD_REQUEST,
       error: 'Bad Request',
       message: error.message,
-      hasRequest: options.request instanceof Request,
-      hasEvent: options.event === testEvent,
-      hasContext: options.context === context,
+      hasRequest: reqCtx.request instanceof Request,
+      hasEvent: reqCtx.event === testEvent,
+      hasContext: reqCtx.context === context,
     }));
 
     app.get('/test', () => {

--- a/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
@@ -44,13 +44,13 @@ describe('Class: Router - Middleware', () => {
       const app = new Router();
       const executionOrder: string[] = [];
 
-      app.use(async (_params, _options, next) => {
+      app.use(async (_params, _reqCtx, next) => {
         executionOrder.push('global-middleware');
         await next();
       });
 
       const middleware: Middleware[] = middlewareNames.map(
-        (name) => async (_params, _options, next) => {
+        (name) => async (_params, _reqCtx, next) => {
           executionOrder.push(name);
           await next();
         }
@@ -137,9 +137,9 @@ describe('Class: Router - Middleware', () => {
       let middlewareParams: Record<string, string> | undefined;
       let middlewareOptions: RequestContext | undefined;
 
-      app.use(async (params, options, next) => {
+      app.use(async (params, reqCtx, next) => {
         middlewareParams = params;
-        middlewareOptions = options;
+        middlewareOptions = reqCtx;
         await next();
       });
 
@@ -161,7 +161,7 @@ describe('Class: Router - Middleware', () => {
       vi.stubEnv('POWERTOOLS_DEV', 'true');
       const app = new Router();
 
-      app.use(async (_params, _options, next) => {
+      app.use(async (_params, _reqCtx, next) => {
         await next();
         await next();
       });
@@ -215,7 +215,7 @@ describe('Class: Router - Middleware', () => {
       const app = new Router();
       const executionOrder: string[] = [];
 
-      app.use(async (_params, _options, next) => {
+      app.use(async (_params, _reqCtx, next) => {
         executionOrder.push('middleware1-start');
         await next();
         executionOrder.push('middleware1-end');
@@ -336,10 +336,10 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, options, next) => {
+      app.use(async (_params, reqCtx, next) => {
         await next();
-        options.res.headers.set('x-custom-header', 'middleware-value');
-        options.res.headers.set('x-request-id', '12345');
+        reqCtx.res.headers.set('x-custom-header', 'middleware-value');
+        reqCtx.res.headers.set('x-request-id', '12345');
       });
 
       app.get('/test', async () => ({ success: true }));
@@ -367,10 +367,10 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, options, next) => {
+      app.use(async (_params, reqCtx, next) => {
         await next();
-        const originalBody = await options.res.text();
-        options.res = new Response(`Modified: ${originalBody}`, {
+        const originalBody = await reqCtx.res.text();
+        reqCtx.res = new Response(`Modified: ${originalBody}`, {
           headers: { 'content-type': 'text/plain' },
         });
       });
@@ -396,8 +396,8 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, options, next) => {
-        options.res.headers.set('x-before-handler', 'middleware-value');
+      app.use(async (_params, reqCtx, next) => {
+        reqCtx.res.headers.set('x-before-handler', 'middleware-value');
         await next();
       });
 
@@ -425,14 +425,14 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, options, next) => {
-        options.res.headers.set('x-test-header', 'before-next');
+      app.use(async (_params, reqCtx, next) => {
+        reqCtx.res.headers.set('x-test-header', 'before-next');
         await next();
       });
 
-      app.use(async (_params, options, next) => {
+      app.use(async (_params, reqCtx, next) => {
         await next();
-        options.res.headers.set('x-test-header', 'after-next');
+        reqCtx.res.headers.set('x-test-header', 'after-next');
       });
 
       app.get('/test', async () => ({ success: true }));
@@ -460,7 +460,7 @@ describe('Class: Router - Middleware', () => {
       const app = new Router();
       const executionOrder: string[] = [];
 
-      app.use(async (_params, _options, next) => {
+      app.use(async (_params, _reqCtx, next) => {
         executionOrder.push('middleware-start');
         await next();
         executionOrder.push('middleware-end');

--- a/packages/event-handler/tests/unit/rest/utils.test.ts
+++ b/packages/event-handler/tests/unit/rest/utils.test.ts
@@ -449,12 +449,12 @@ describe('Path Utilities', () => {
     it('executes middleware in order', async () => {
       const executionOrder: string[] = [];
       const middleware: Middleware[] = [
-        async (_params, _options, next) => {
+        async (_params, _reqCtx, next) => {
           executionOrder.push('middleware1-start');
           await next();
           executionOrder.push('middleware1-end');
         },
-        async (_params, _options, next) => {
+        async (_params, _reqCtx, next) => {
           executionOrder.push('middleware2-start');
           await next();
           executionOrder.push('middleware2-end');
@@ -477,10 +477,10 @@ describe('Path Utilities', () => {
 
     it('returns result from middleware that short-circuits', async () => {
       const middleware: Middleware[] = [
-        async (_params, _options, next) => {
+        async (_params, _reqCtx, next) => {
           await next();
         },
-        async (_params, _options, _next) => {
+        async (_params, _reqCtx, _next) => {
           return { shortCircuit: true };
         },
       ];
@@ -495,7 +495,7 @@ describe('Path Utilities', () => {
 
     it('returns result from next function when middleware does not return', async () => {
       const middleware: Middleware[] = [
-        async (_params, _options, next) => {
+        async (_params, _reqCtx, next) => {
           await next();
         },
       ];
@@ -510,7 +510,7 @@ describe('Path Utilities', () => {
 
     it('throws error when next() is called multiple times', async () => {
       const middleware: Middleware[] = [
-        async (_params, _options, next) => {
+        async (_params, _reqCtx, next) => {
           await next();
           await next();
         },
@@ -534,7 +534,7 @@ describe('Path Utilities', () => {
 
     it('returns undefined when next function returns undefined', async () => {
       const middleware: Middleware[] = [
-        async (_params, _options, next) => {
+        async (_params, _reqCtx, next) => {
           await next();
         },
       ];


### PR DESCRIPTION
## Summary
This PR reflects the change of type from `HandlerOptions` to `RequestContext` made in #4439 by updating class variables, JSDocs and the tests.

### Changes

- Update all unit tests that define handlers or middleware to use `reqCtx` instead of `options` as the name for any parameter of type `RequestContext`
- Updated the type definitions `reqCtx` instead of `options` as the name for any parameter of type `RequestContext`
- Updated the JSDocs and examples to reflect this change

**Issue number:** closes #4459

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
