### PR TITLE
feat(event-handler): remove undefined from Router's resolve type signature

### DIFF
--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -185,13 +185,13 @@ class Router {
    * @param event - The Lambda event to resolve
    * @param context - The Lambda context
    * @param options - Optional resolve options for scope binding
-   * @returns An API Gateway proxy result or undefined for incompatible events
+   * @returns An API Gateway proxy result
    */
   public async resolve(
     event: unknown,
     context: Context,
     options?: ResolveOptions
-  ): Promise<APIGatewayProxyResult | undefined> {
+  ): Promise<APIGatewayProxyResult> {
     if (!isAPIGatewayProxyEvent(event)) {
       this.logger.error(
         'Received an event that is not compatible with this resolver'

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -50,8 +50,8 @@ describe('Class: Router - Basic Routing', () => {
         context
       );
 
-      expect(result?.statusCode).toBe(HttpErrorCodes.METHOD_NOT_ALLOWED);
-      expect(result?.body).toEqual('');
+      expect(result.statusCode).toBe(HttpErrorCodes.METHOD_NOT_ALLOWED);
+      expect(result.body).toEqual('');
     }
   );
 
@@ -99,7 +99,7 @@ describe('Class: Router - Basic Routing', () => {
 
     // Act
     const result = await app.resolve(testEvent, context);
-    const actual = JSON.parse(result?.body ?? '{}');
+    const actual = JSON.parse(result.body);
 
     // Assess
     expect(actual.hasRequest).toBe(true);

--- a/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
@@ -412,7 +412,7 @@ describe('Class: Router - Decorators', () => {
 
       // Act
       const result = await lambda.handler(testEvent, context);
-      const actual = JSON.parse(result?.body ?? '{}');
+      const actual = JSON.parse(result.body);
 
       // Assess
       expect(actual.hasRequest).toBe(true);
@@ -452,7 +452,7 @@ describe('Class: Router - Decorators', () => {
 
       // Act
       const result = await lambda.handler(testEvent, context);
-      const body = JSON.parse(result?.body ?? '{}');
+      const body = JSON.parse(result.body);
 
       // Assess
       expect(body.hasRequest).toBe(true);

--- a/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
@@ -120,8 +120,8 @@ describe('Class: Router - Error Handling', () => {
     const result = await app.resolve(createTestEvent('/test', 'GET'), context);
 
     // Assess
-    expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
-    const body = JSON.parse(result?.body ?? '{}');
+    expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+    const body = JSON.parse(result.body);
     expect(body.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     expect(body.error).toBe('Internal Server Error');
     expect(body.message).toBe('Internal Server Error');
@@ -140,8 +140,8 @@ describe('Class: Router - Error Handling', () => {
     const result = await app.resolve(createTestEvent('/test', 'GET'), context);
 
     // Assess
-    expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
-    const body = JSON.parse(result?.body ?? '{}');
+    expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+    const body = JSON.parse(result.body);
     expect(body.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     expect(body.error).toBe('Internal Server Error');
     expect(body.message).toBe('Internal Server Error');
@@ -220,8 +220,8 @@ describe('Class: Router - Error Handling', () => {
     const result = await app.resolve(createTestEvent('/test', 'GET'), context);
 
     // Assess
-    expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
-    const body = JSON.parse(result?.body ?? '{}');
+    expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+    const body = JSON.parse(result.body);
     expect(body.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     expect(body.error).toBe('Internal Server Error');
     expect(body.message).toBe('Internal Server Error');
@@ -242,8 +242,8 @@ describe('Class: Router - Error Handling', () => {
     const result = await app.resolve(createTestEvent('/test', 'GET'), context);
 
     // Assess
-    expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
-    const body = JSON.parse(result?.body ?? '{}');
+    expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+    const body = JSON.parse(result.body);
     expect(body.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     expect(body.error).toBe('Internal Server Error');
     expect(body.message).toBe('debug error details');
@@ -363,7 +363,7 @@ describe('Class: Router - Error Handling', () => {
     const result = await app.resolve(createTestEvent('/test', 'GET'), context);
 
     // Assess
-    expect(result?.headers?.['content-type']).toBe('application/json');
+    expect(result.headers?.['content-type']).toBe('application/json');
   });
 
   it('passes request, event, and context to functional error handlers', async () => {
@@ -386,7 +386,7 @@ describe('Class: Router - Error Handling', () => {
 
     // Act
     const result = await app.resolve(testEvent, context);
-    const body = JSON.parse(result?.body ?? '{}');
+    const body = JSON.parse(result.body);
 
     // Assess
     expect(body.hasRequest).toBe(true);

--- a/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
@@ -127,8 +127,8 @@ describe('Class: Router - Middleware', () => {
         'middleware2',
         'middleware1-end',
       ]);
-      expect(result?.statusCode).toBe(401);
-      expect(result?.body).toBe('Short-circuited');
+      expect(result.statusCode).toBe(401);
+      expect(result.body).toBe('Short-circuited');
     });
 
     it('passes params and options to middleware', async () => {
@@ -175,8 +175,8 @@ describe('Class: Router - Middleware', () => {
       );
 
       // Assess
-      expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
-      const body = JSON.parse(result?.body ?? '{}');
+      expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+      const body = JSON.parse(result.body);
       expect(body.message).toContain('next() called multiple times');
     });
 
@@ -207,7 +207,7 @@ describe('Class: Router - Middleware', () => {
 
       // Assess
       expect(executionOrder).toEqual(['middleware1']);
-      expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+      expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     });
 
     it('handles errors thrown in middleware after next()', async () => {
@@ -239,7 +239,7 @@ describe('Class: Router - Middleware', () => {
         'handler',
         'middleware1-end',
       ]);
-      expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+      expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     });
 
     it('propagates handler errors through middleware chain', async () => {
@@ -267,7 +267,7 @@ describe('Class: Router - Middleware', () => {
         'middleware2-start',
         'handler',
       ]);
-      expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+      expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     });
 
     it('handles middleware not calling next()', async () => {
@@ -291,7 +291,7 @@ describe('Class: Router - Middleware', () => {
 
       // Assess
       expect(executionOrder).toEqual(['middleware1']);
-      expect(result?.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
+      expect(result.statusCode).toBe(HttpErrorCodes.INTERNAL_SERVER_ERROR);
     });
 
     it('handles middleware returning JSON objects', async () => {
@@ -324,8 +324,8 @@ describe('Class: Router - Middleware', () => {
         'middleware2',
         'middleware1-end',
       ]);
-      expect(result?.statusCode).toBe(200);
-      const body = JSON.parse(result?.body ?? '{}');
+      expect(result.statusCode).toBe(200);
+      const body = JSON.parse(result.body);
       expect(body).toEqual({
         statusCode: 202,
         message: 'Accepted by middleware',
@@ -619,8 +619,8 @@ describe('Class: Router - Middleware', () => {
         'route-middleware',
         'global-middleware-end',
       ]);
-      expect(result?.statusCode).toBe(403);
-      expect(result?.body).toBe('Route middleware response');
+      expect(result.statusCode).toBe(403);
+      expect(result.body).toBe('Route middleware response');
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR removes `undefined` from the `resolve` methid in the Router class. This was a legacy of the initial implementation that no longer holds.

### Changes

- Updated the `resolve` method's type signature
- Updated all tests that we're using optional chaining or the `??` operator due to the old signature

**Issue number:** closes #4462

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
