### PR TITLE
feat(event-handler): added compress middleware for the REST API event handler

### DIFF
--- a/packages/event-handler/package.json
+++ b/packages/event-handler/package.json
@@ -77,6 +77,16 @@
         "types": "./lib/esm/rest/index.d.ts",
         "default": "./lib/esm/rest/index.js"
       }
+    },
+    "./experimental-rest/middleware": {
+      "require": {
+        "types": "./lib/cjs/rest/middleware/index.d.ts",
+        "default": "./lib/cjs/rest/middleware/index.js"
+      },
+      "import": {
+        "types": "./lib/esm/rest/middleware/index.d.ts",
+        "default": "./lib/esm/rest/middleware/index.js"
+      }
     }
   },
   "typesVersions": {

--- a/packages/event-handler/src/rest/constants.ts
+++ b/packages/event-handler/src/rest/constants.ts
@@ -87,3 +87,17 @@ export const PARAM_PATTERN = /:([a-zA-Z_]\w*)(?=\/|$)/g;
 export const SAFE_CHARS = "-._~()'!*:@,;=+&$";
 
 export const UNSAFE_CHARS = '%<> \\[\\]{}|^';
+
+/**
+ * Match for compressible content type.
+ */
+export const COMPRESSIBLE_CONTENT_TYPE_REGEX =
+  /^\s*(?:text\/(?!event-stream(?:[;\s]|$))[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-virtualbox-hdd|x-virtualbox-ova|x-virtualbox-ovf|x-virtualbox-vbox|x-virtualbox-vdi|x-virtualbox-vhd|x-virtualbox-vmdk|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i;
+
+export const CACHE_CONTROL_NO_TRANSFORM_REGEX =
+  /(?:^|,)\s*?no-transform\s*?(?:,|$)/i;
+
+export const COMPRESSION_ENCODING_TYPES = {
+  GZIP: 'gzip',
+  DEFLATE: 'deflate',
+} as const;

--- a/packages/event-handler/src/rest/middleware/compress.ts
+++ b/packages/event-handler/src/rest/middleware/compress.ts
@@ -21,7 +21,8 @@ const compress = (options?: CompressionOptions): Middleware => {
       reqCtx.request.method === 'HEAD' || // HEAD request
       (contentLength && Number(contentLength) < threshold) || // content-length below threshold
       !shouldCompress(reqCtx.res) || // not compressible type
-      !shouldTransform(reqCtx.res) // cache-control: no-transform
+      !shouldTransform(reqCtx.res) || // cache-control: no-transform
+      !reqCtx.res.body
     ) {
       return;
     }
@@ -33,9 +34,6 @@ const compress = (options?: CompressionOptions): Middleware => {
         acceptedEncoding?.includes(encoding)
       ) ??
       COMPRESSION_ENCODING_TYPES.GZIP;
-    if (!encoding || !reqCtx.res.body) {
-      return;
-    }
 
     // Compress the response
     const stream = new CompressionStream(encoding);

--- a/packages/event-handler/src/rest/middleware/compress.ts
+++ b/packages/event-handler/src/rest/middleware/compress.ts
@@ -1,0 +1,60 @@
+import type { Middleware } from '@aws-lambda-powertools/event-handler/types';
+import type { CompressionOptions } from 'src/types/rest.js';
+import {
+  CACHE_CONTROL_NO_TRANSFORM_REGEX,
+  COMPRESSIBLE_CONTENT_TYPE_REGEX,
+  COMPRESSION_ENCODING_TYPES,
+} from '../constants.js';
+
+const compress = (options?: CompressionOptions): Middleware => {
+  const threshold = options?.threshold ?? 1024;
+
+  return async (_, reqCtx, next) => {
+    await next();
+
+    const contentLength = reqCtx.res.headers.get('Content-Length');
+
+    // Check if response should be compressed
+    if (
+      reqCtx.res.headers.has('Content-Encoding') || // already encoded
+      reqCtx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
+      reqCtx.request.method === 'HEAD' || // HEAD request
+      (contentLength && Number(contentLength) < threshold) || // content-length below threshold
+      !shouldCompress(reqCtx.res) || // not compressible type
+      !shouldTransform(reqCtx.res) // cache-control: no-transform
+    ) {
+      return;
+    }
+
+    const acceptedEncoding = reqCtx.request.headers.get('Accept-Encoding');
+    const encoding =
+      options?.encoding ??
+      Object.values(COMPRESSION_ENCODING_TYPES).find((encoding) =>
+        acceptedEncoding?.includes(encoding)
+      ) ??
+      COMPRESSION_ENCODING_TYPES.GZIP;
+    if (!encoding || !reqCtx.res.body) {
+      return;
+    }
+
+    // Compress the response
+    const stream = new CompressionStream(encoding);
+    reqCtx.res = new Response(reqCtx.res.body.pipeThrough(stream), reqCtx.res);
+    reqCtx.res.headers.delete('Content-Length');
+    reqCtx.res.headers.set('Content-Encoding', encoding);
+  };
+};
+
+const shouldCompress = (res: Response) => {
+  const type = res.headers.get('Content-Type');
+  return type && COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type);
+};
+
+const shouldTransform = (res: Response) => {
+  const cacheControl = res.headers.get('Cache-Control');
+  // Don't compress for Cache-Control: no-transform
+  // https://tools.ietf.org/html/rfc7234#section-5.2.2.4
+  return !cacheControl || !CACHE_CONTROL_NO_TRANSFORM_REGEX.test(cacheControl);
+};
+
+export { compress };

--- a/packages/event-handler/src/rest/middleware/compress.ts
+++ b/packages/event-handler/src/rest/middleware/compress.ts
@@ -12,12 +12,12 @@ const compress = (options?: CompressionOptions): Middleware => {
   return async (_, reqCtx, next) => {
     await next();
 
-    const contentLength = reqCtx.res.headers.get('Content-Length');
+    const contentLength = reqCtx.res.headers.get('content-length');
 
     // Check if response should be compressed
     if (
-      reqCtx.res.headers.has('Content-Encoding') || // already encoded
-      reqCtx.res.headers.has('Transfer-Encoding') || // already encoded or chunked
+      reqCtx.res.headers.has('content-encoding') || // already encoded
+      reqCtx.res.headers.has('transfer-encoding') || // already encoded or chunked
       reqCtx.request.method === 'HEAD' || // HEAD request
       (contentLength && Number(contentLength) < threshold) || // content-length below threshold
       !shouldCompress(reqCtx.res) || // not compressible type
@@ -26,7 +26,7 @@ const compress = (options?: CompressionOptions): Middleware => {
       return;
     }
 
-    const acceptedEncoding = reqCtx.request.headers.get('Accept-Encoding');
+    const acceptedEncoding = reqCtx.request.headers.get('accept-encoding');
     const encoding =
       options?.encoding ??
       Object.values(COMPRESSION_ENCODING_TYPES).find((encoding) =>
@@ -40,18 +40,18 @@ const compress = (options?: CompressionOptions): Middleware => {
     // Compress the response
     const stream = new CompressionStream(encoding);
     reqCtx.res = new Response(reqCtx.res.body.pipeThrough(stream), reqCtx.res);
-    reqCtx.res.headers.delete('Content-Length');
-    reqCtx.res.headers.set('Content-Encoding', encoding);
+    reqCtx.res.headers.delete('content-length');
+    reqCtx.res.headers.set('content-encoding', encoding);
   };
 };
 
 const shouldCompress = (res: Response) => {
-  const type = res.headers.get('Content-Type');
+  const type = res.headers.get('content-type');
   return type && COMPRESSIBLE_CONTENT_TYPE_REGEX.test(type);
 };
 
 const shouldTransform = (res: Response) => {
-  const cacheControl = res.headers.get('Cache-Control');
+  const cacheControl = res.headers.get('cache-control');
   // Don't compress for Cache-Control: no-transform
   // https://tools.ietf.org/html/rfc7234#section-5.2.2.4
   return !cacheControl || !CACHE_CONTROL_NO_TRANSFORM_REGEX.test(cacheControl);

--- a/packages/event-handler/src/rest/middleware/index.ts
+++ b/packages/event-handler/src/rest/middleware/index.ts
@@ -1,0 +1,1 @@
+export { compress } from './compress.js';

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -3,7 +3,11 @@ import type {
   JSONObject,
 } from '@aws-lambda-powertools/commons/types';
 import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
-import type { HttpErrorCodes, HttpVerbs } from '../rest/constants.js';
+import type {
+  COMPRESSION_ENCODING_TYPES,
+  HttpErrorCodes,
+  HttpVerbs,
+} from '../rest/constants.js';
 import type { Route } from '../rest/Route.js';
 import type { Router } from '../rest/Router.js';
 import type { ResolveOptions } from './common.js';
@@ -111,6 +115,11 @@ type ValidationResult = {
   issues: string[];
 };
 
+type CompressionOptions = {
+  encoding?: (typeof COMPRESSION_ENCODING_TYPES)[keyof typeof COMPRESSION_ENCODING_TYPES];
+  threshold?: number;
+};
+
 export type {
   CompiledRoute,
   DynamicRoute,
@@ -131,4 +140,5 @@ export type {
   RestRouteHandlerOptions,
   RouteRegistryOptions,
   ValidationResult,
+  CompressionOptions,
 };

--- a/packages/event-handler/tests/unit/rest/helpers.ts
+++ b/packages/event-handler/tests/unit/rest/helpers.ts
@@ -66,3 +66,14 @@ export const createNoNextMiddleware = (
     // Intentionally doesn't call next()
   };
 };
+
+export const createSettingHeadersMiddleware = (headers: {
+  [key: string]: string;
+}): Middleware => {
+  return async (_params, _options, next) => {
+    await next();
+    Object.entries(headers).map(([key, value]) =>
+      _options.res.headers.set(key, value)
+    );
+  };
+};

--- a/packages/event-handler/tests/unit/rest/helpers.ts
+++ b/packages/event-handler/tests/unit/rest/helpers.ts
@@ -3,11 +3,12 @@ import type { Middleware } from '../../../src/types/rest.js';
 
 export const createTestEvent = (
   path: string,
-  httpMethod: string
+  httpMethod: string,
+  headers: Record<string, string> = {}
 ): APIGatewayProxyEvent => ({
   path,
   httpMethod,
-  headers: {},
+  headers,
   body: null,
   multiValueHeaders: {},
   isBase64Encoded: false,

--- a/packages/event-handler/tests/unit/rest/middleware/compress.test.ts
+++ b/packages/event-handler/tests/unit/rest/middleware/compress.test.ts
@@ -2,7 +2,7 @@ import context from '@aws-lambda-powertools/testing-utils/context';
 import { Router } from 'src/rest/Router.js';
 import type { Middleware } from 'src/types/index.js';
 import { describe, expect, it } from 'vitest';
-import { compress } from '../../../../src/rest/middleware/compress.js';
+import { compress } from '../../../../src/rest/middleware/index.js';
 import { createTestEvent } from '../helpers.js';
 
 describe('Compress Middleware', () => {
@@ -176,30 +176,5 @@ describe('Compress Middleware', () => {
 
     // Assess
     expect(result.headers?.['content-encoding']).toBe('deflate');
-  });
-
-  it('skips compression when no body present', async () => {
-    // Prepare
-    const event = createTestEvent('/test', 'GET');
-    const app = new Router();
-    app.get(
-      '/test',
-      [
-        compress(),
-        (): Middleware => async (_, reqCtx, next) => {
-          await next();
-          reqCtx.res = new Response(null);
-        },
-      ],
-      async () => {
-        return {};
-      }
-    );
-
-    // Act
-    const result = await app.resolve(event, context);
-
-    // Assess
-    expect(result.headers?.['content-encoding']).toBeUndefined();
   });
 });

--- a/packages/event-handler/tests/unit/rest/middleware/compress.test.ts
+++ b/packages/event-handler/tests/unit/rest/middleware/compress.test.ts
@@ -1,0 +1,167 @@
+import context from '@aws-lambda-powertools/testing-utils/context';
+import { Router } from 'src/rest/Router.js';
+import { describe, expect, it } from 'vitest';
+import { compress } from '../../../../src/rest/middleware/compress.js';
+import { createTestEvent } from '../helpers.js';
+
+describe('Compress Middleware', () => {
+  it('compresses response when conditions are met', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET');
+    const app = new Router();
+    app.get('/test', [compress()], async () => {
+      return { test: 'x'.repeat(2000) };
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBe('gzip');
+    expect(result.headers?.['content-length']).toBeUndefined();
+  });
+
+  it('skips compression when content is below threshold', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET');
+    const app = new Router();
+    app.get('/test', [compress({ threshold: 1024 })], async () => {
+      return { test: 'small' };
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBeUndefined();
+  });
+
+  it('skips compression for HEAD requests', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'HEAD');
+    const app = new Router();
+    app.head('/test', [compress()], async () => {
+      return { test: 'x'.repeat(2000) };
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBeUndefined();
+  });
+
+  it('skips compression when already encoded', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'HEAD');
+    const app = new Router();
+    app.get('/test', [compress()], async () => {
+      return { test: 'x'.repeat(2000) };
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBeUndefined();
+  });
+
+  it('skips compression for non-compressible content types', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET', {
+      'Content-Type': 'image/png',
+    });
+    const app = new Router();
+    app.get('/test', [compress()], async () => {
+      return 'x'.repeat(2000);
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBeUndefined();
+  });
+
+  it('skips compression when cache-control no-transform is set', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET');
+    const app = new Router();
+    app.get('/test', [compress()], async (_, reqCtx) => {
+      reqCtx.res.headers.set('Cache-Control', 'no-transform');
+      return 'x'.repeat(2000);
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBeUndefined();
+  });
+
+  it('uses specified encoding when provided', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET', {
+      'Accept-Encoding': 'deflate, gzip',
+    });
+    const app = new Router();
+    app.get('/test', [compress({ encoding: 'deflate' })], async () => {
+      return 'x'.repeat(2000);
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBe('deflate');
+  });
+
+  it('infers encoding from Accept-Encoding header', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET', {
+      'Accept-Encoding': 'deflate',
+    });
+    const app = new Router();
+    app.get('/test', [compress()], async () => {
+      return 'x'.repeat(2000);
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBe('deflate');
+  });
+
+  it('defaults to gzip when no encoding specified', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET', {
+      'Accept-Encoding': 'br',
+    });
+    const app = new Router();
+    app.get('/test', [compress()], async () => {
+      return 'x'.repeat(2000);
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBe('gzip');
+  });
+
+  it('skips compression when no body present', async () => {
+    // Prepare
+    const event = createTestEvent('/test', 'GET');
+    const app = new Router();
+    app.get('/test', [compress()], async () => {
+      return new Response(null);
+    });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.headers?.['content-encoding']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a built in compress middleware which can be used along with the event handler for providing an easy way to compress response bodies to reduce payload size and improve performance.

### Changes

> Please provide a summary of what's being changed

- Added a `middleware` directory in the rest directory to contain the built-in middlewares
- Exported the middleware path to be used
- Created the compress middleware which takes an encoding and a threshold and does the compression if needed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4474 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
