### PR TITLE
fix(event-handler): run global middleware on all requests for REST API

### DIFF
--- a/packages/event-handler/src/rest/converters.ts
+++ b/packages/event-handler/src/rest/converters.ts
@@ -140,7 +140,14 @@ export const handlerResultToWebResponse = (
   resHeaders?: Headers
 ): Response => {
   if (response instanceof Response) {
-    return response;
+    const headers = new Headers(resHeaders);
+    for (const [key, value] of response.headers.entries()) {
+      headers.set(key, value);
+    }
+    return new Response(response.body, {
+      status: response.status,
+      headers,
+    });
   }
 
   const headers = new Headers(resHeaders);

--- a/packages/event-handler/tests/unit/rest/converters.test.ts
+++ b/packages/event-handler/tests/unit/rest/converters.test.ts
@@ -549,17 +549,6 @@ describe('Converters', () => {
   });
 
   describe('handlerResultToResponse', () => {
-    it('returns Response object as-is', () => {
-      // Prepare
-      const response = new Response('Hello', { status: 201 });
-
-      // Act
-      const result = handlerResultToWebResponse(response);
-
-      // Assess
-      expect(result).toBe(response);
-    });
-
     it('converts APIGatewayProxyResult to Response', async () => {
       // Prepare
       const proxyResult = {
@@ -677,6 +666,26 @@ describe('Converters', () => {
 
       // Assess
       expect(result.headers.get('content-type')).toBe('text/plain');
+    });
+
+    it('merges headers from resHeaders with Response object, headers from Response take precedence', () => {
+      // Prepare
+      const response = new Response('Hello', {
+        headers: { 'content-type': 'text/plain' },
+      });
+      const resHeaders = new Headers({
+        'x-custom': 'value',
+        'content-type': 'application/json', // should not override existing
+      });
+
+      // Act
+      const result = handlerResultToWebResponse(response, resHeaders);
+
+      // Assess
+      expect(result.headers.get('content-type')).toBe('text/plain');
+      expect(result.headers.get('x-custom')).toBe('value');
+      expect(result.status).toBe(200);
+      expect(result.text()).resolves.toBe('Hello');
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes bug where global middleware did not run on every request but only if a specific route had been registered. Route handlers are executed as part of a special middleware that is always appended to the end of the middleware stack, if a route handler was not found we would throw a NotFound error and skip the middleware altogether.

In the process of fixing this issue, I also found a bug where if a handler returned a `Response` object we did not merge the headers from the middleware that had run before into the `res.headers` object.

### Changes

- Removed the code that threw a not found error if a route handler was not found
- Moved the logic to handle returning a 404 to the handler middleware. Returned a 404 `Response` object rather than throwing to allow middleware stack to run to completion as throwing stops processing completely.
- Fixed a bug where headers were not merged if handler returned a `Response` object.
- Added tests for new middleware behaviour but did not add a specific test for CORS middleware as this bug is not CORS specific so test lives in main middelware test suite.

Note: if testing the behaviour in a lambda you need to ensure that your `OPTIONS` request has the `Access-Control-Request-Method` header or it will not be treated as a pre-flight request and still return a 404.

**Issue number:** closes #4506

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
