### PR TITLE
chore: always append `PTEnv` to UA string

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,9 +1,10 @@
 import { PT_VERSION } from './version.js';
 
+const env = process.env.AWS_EXECUTION_ENV || 'NA';
 if (!process.env.AWS_SDK_UA_APP_ID) {
-  process.env.AWS_SDK_UA_APP_ID = `PT/TEST/${PT_VERSION}`;
+  process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
 } else {
-  process.env.AWS_SDK_UA_APP_ID = `${process.env.AWS_SDK_UA_APP_ID}/PT/TEST/${PT_VERSION}`;
+  process.env.AWS_SDK_UA_APP_ID = `${process.env.AWS_SDK_UA_APP_ID}/PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
 }
 
 export { addUserAgentMiddleware, isSdkClient } from './awsSdkUtils.js';

--- a/packages/commons/tests/unit/awsSdkUtils.test.ts
+++ b/packages/commons/tests/unit/awsSdkUtils.test.ts
@@ -84,7 +84,9 @@ describe('Helpers: awsSdk', () => {
 
   it('concatenates the PT AWS_SDK_UA_APP_ID when one is already set', () => {
     // Assess
-    expect(process.env.AWS_SDK_UA_APP_ID).toEqual(`test/PT/TEST/${version}`);
+    expect(process.env.AWS_SDK_UA_APP_ID).toEqual(
+      `test/PT/NO-OP/${version}/PTEnv/NA`
+    );
   });
 
   describe('Function: customUserAgentMiddleware', () => {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the logic that detects the presence of the `AWS_SDK_UA_APP_ID` environment variables, and optionally concatenates Powertools for AWS-specific user agent strings to it by making sure the `PTEnv` part is always included.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4521

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
