### PR TITLE
feat(event-handler): implemented route prefixes in HTTP event handler

### DIFF
--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -56,6 +56,10 @@ class Router {
    * Whether the router is running in development mode.
    */
   protected readonly isDev: boolean = false;
+  /**
+   * The base prefix to be used for all routes registered using this Router.
+   */
+  protected readonly prefix?: Path;
 
   public constructor(options?: RestRouterOptions) {
     this.context = {};
@@ -73,6 +77,7 @@ class Router {
       logger: this.logger,
     });
     this.isDev = isDevMode();
+    this.prefix = options?.prefix;
   }
 
   /**
@@ -281,9 +286,17 @@ class Router {
   public route(handler: RouteHandler, options: RestRouteOptions): void {
     const { method, path, middleware = [] } = options;
     const methods = Array.isArray(method) ? method : [method];
+    const resolvedPath: Path =
+      this.prefix === undefined
+        ? path
+        : path === '/'
+          ? this.prefix
+          : `${this.prefix}${path}`;
 
     for (const method of methods) {
-      this.routeRegistry.register(new Route(method, path, handler, middleware));
+      this.routeRegistry.register(
+        new Route(method, resolvedPath, handler, middleware)
+      );
     }
   }
 

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -43,6 +43,10 @@ type RestRouterOptions = {
    * When no logger is provided, we'll only log warnings and errors using the global `console` object.
    */
   logger?: GenericLogger;
+  /**
+   * The base prefix to be used for all routes registered using this Router.
+   */
+  prefix?: Path;
 };
 
 interface CompiledRoute {

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -117,4 +117,31 @@ describe('Class: Router - Basic Routing', () => {
       InternalServerError
     );
   });
+
+  it('routes to the prefixed path when having a shared prefix defined', async () => {
+    // Prepare
+    const app = new Router({
+      prefix: '/todos',
+    });
+    app.post('/', async () => {
+      return { actualPath: '/todos' };
+    });
+    app.get('/:todoId', async ({ todoId }) => {
+      return { actualPath: `/todos/${todoId}` };
+    });
+
+    // Act
+    const createResult = await app.resolve(
+      createTestEvent('/todos', 'POST'),
+      context
+    );
+    const getResult = await app.resolve(
+      createTestEvent('/todos/1', 'GET'),
+      context
+    );
+
+    // Assess
+    expect(JSON.parse(createResult.body).actualPath).toBe('/todos');
+    expect(JSON.parse(getResult.body).actualPath).toBe('/todos/1');
+  });
 });


### PR DESCRIPTION
## Summary

This PR implements the feature to allow the use of `prefix` so that we don't need to keep repeating the same shared prefix for every route path. 

### Changes

> Please provide a summary of what's being changed

- Added `prefix` option to the `RestRouterOptions` in the constructor
- Added the logic to append the prefix if present

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4513 
<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
