### PR TITLE
improv(event-handler): changed the Middleware and RequestContext signatures

### DIFF
--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -164,7 +164,7 @@ class Router {
    *
    * @example
    * ```typescript
-   * const authMiddleware: Middleware = async (params, reqCtx, next) => {
+   * const authMiddleware: Middleware = async ({params, reqCtx, next}) => {
    *   // Authentication logic
    *   if (!isAuthenticated(reqCtx.request)) {
    *     return new Response('Unauthorized', { status: 401 });
@@ -231,7 +231,11 @@ class Router {
 
       const route = this.routeRegistry.resolve(method, path);
 
-      const handlerMiddleware: Middleware = async (params, reqCtx, next) => {
+      const handlerMiddleware: Middleware = async ({
+        params,
+        reqCtx,
+        next,
+      }) => {
         if (route === null) {
           const notFoundRes = await this.handleError(
             new NotFoundError(`Route ${path} for method ${method} not found`),
@@ -263,11 +267,11 @@ class Router {
         handlerMiddleware,
       ]);
 
-      const middlewareResult = await middleware(
-        route?.params ?? {},
-        requestContext,
-        () => Promise.resolve()
-      );
+      const middlewareResult = await middleware({
+        params: route?.params ?? {},
+        reqCtx: requestContext,
+        next: () => Promise.resolve(),
+      });
 
       // middleware result takes precedence to allow short-circuiting
       const result = middlewareResult ?? requestContext.res;

--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -166,7 +166,7 @@ class Router {
    * ```typescript
    * const authMiddleware: Middleware = async ({params, reqCtx, next}) => {
    *   // Authentication logic
-   *   if (!isAuthenticated(reqCtx.request)) {
+   *   if (!isAuthenticated(reqCtx.req)) {
    *     return new Response('Unauthorized', { status: 401 });
    *   }
    *   await next();
@@ -215,19 +215,19 @@ class Router {
       };
     }
 
-    const request = proxyEventToWebRequest(event);
+    const req = proxyEventToWebRequest(event);
 
     const requestContext: RequestContext = {
       event,
       context,
-      request,
+      req,
       // this response should be overwritten by the handler, if it isn't
       // it means something went wrong with the middleware chain
       res: new Response('', { status: 500 }),
     };
 
     try {
-      const path = new URL(request.url).pathname as Path;
+      const path = new URL(req.url).pathname as Path;
 
       const route = this.routeRegistry.resolve(method, path);
 

--- a/packages/event-handler/src/rest/middleware/compress.ts
+++ b/packages/event-handler/src/rest/middleware/compress.ts
@@ -70,9 +70,7 @@ const compress = (options?: CompressionOptions): Middleware => {
   return async ({ reqCtx, next }) => {
     await next();
 
-    if (
-      !shouldCompress(reqCtx.request, reqCtx.res, preferredEncoding, threshold)
-    ) {
+    if (!shouldCompress(reqCtx.req, reqCtx.res, preferredEncoding, threshold)) {
       return;
     }
 

--- a/packages/event-handler/src/rest/middleware/compress.ts
+++ b/packages/event-handler/src/rest/middleware/compress.ts
@@ -67,7 +67,7 @@ const compress = (options?: CompressionOptions): Middleware => {
   const threshold =
     options?.threshold ?? DEFAULT_COMPRESSION_RESPONSE_THRESHOLD;
 
-  return async (_, reqCtx, next) => {
+  return async ({ reqCtx, next }) => {
     await next();
 
     if (

--- a/packages/event-handler/src/rest/middleware/cors.ts
+++ b/packages/event-handler/src/rest/middleware/cors.ts
@@ -96,7 +96,7 @@ export const cors = (options?: CorsOptions): Middleware => {
     }
   };
 
-  return async (_params, reqCtx, next) => {
+  return async ({ reqCtx, next }) => {
     const requestOrigin = reqCtx.request.headers.get('Origin');
     if (!isOriginAllowed(requestOrigin)) {
       await next();

--- a/packages/event-handler/src/rest/middleware/cors.ts
+++ b/packages/event-handler/src/rest/middleware/cors.ts
@@ -97,15 +97,15 @@ export const cors = (options?: CorsOptions): Middleware => {
   };
 
   return async ({ reqCtx, next }) => {
-    const requestOrigin = reqCtx.request.headers.get('Origin');
+    const requestOrigin = reqCtx.req.headers.get('Origin');
     if (!isOriginAllowed(requestOrigin)) {
       await next();
       return;
     }
 
     // Handle preflight OPTIONS request
-    if (reqCtx.request.method === HttpVerbs.OPTIONS) {
-      if (!isValidPreflightRequest(reqCtx.request.headers)) {
+    if (reqCtx.req.method === HttpVerbs.OPTIONS) {
+      if (!isValidPreflightRequest(reqCtx.req.headers)) {
         await next();
         return;
       }

--- a/packages/event-handler/src/rest/utils.ts
+++ b/packages/event-handler/src/rest/utils.ts
@@ -129,13 +129,13 @@ export const isAPIGatewayProxyResult = (
  *
  * @example
  * ```typescript
- * const middleware1: Middleware = async (params, options, next) => {
+ * const middleware1: Middleware = async ({params, options, next}) => {
  *   console.log('middleware1 start');
  *   await next();
  *   console.log('middleware1 end');
  * };
  *
- * const middleware2: Middleware = async (params, options, next) => {
+ * const middleware2: Middleware = async ({params, options, next}) => {
  *   console.log('middleware2 start');
  *   await next();
  *   console.log('middleware2 end');
@@ -151,11 +151,7 @@ export const isAPIGatewayProxyResult = (
  * ```
  */
 export const composeMiddleware = (middleware: Middleware[]): Middleware => {
-  return async (
-    params: Record<string, string>,
-    reqCtx: RequestContext,
-    next: () => Promise<HandlerResponse | void>
-  ): Promise<HandlerResponse | void> => {
+  return async ({ params, reqCtx, next }): Promise<HandlerResponse | void> => {
     let index = -1;
     let result: HandlerResponse | undefined;
 
@@ -181,7 +177,11 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
         return result;
       };
 
-      const middlewareResult = await middlewareFn(params, reqCtx, nextFn);
+      const middlewareResult = await middlewareFn({
+        params,
+        reqCtx,
+        next: nextFn,
+      });
 
       if (nextPromise && !nextAwaited && i < middleware.length - 1) {
         throw new Error(

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -86,11 +86,11 @@ type RestRouteOptions = {
 
 type NextFunction = () => Promise<HandlerResponse | void>;
 
-type Middleware = (
-  params: Record<string, string>,
-  reqCtx: RequestContext,
-  next: NextFunction
-) => Promise<void | HandlerResponse>;
+type Middleware = (args: {
+  params: Record<string, string>;
+  reqCtx: RequestContext;
+  next: NextFunction;
+}) => Promise<void | HandlerResponse>;
 
 type RouteRegistryOptions = {
   /**

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -15,7 +15,7 @@ type ErrorResponse = {
 };
 
 type RequestContext = {
-  request: Request;
+  req: Request;
   event: APIGatewayProxyEvent;
   context: Context;
   res: Response;

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -91,7 +91,7 @@ describe('Class: Router - Basic Routing', () => {
 
     app.get('/test', async (_params, reqCtx) => {
       return {
-        hasRequest: reqCtx.request instanceof Request,
+        hasRequest: reqCtx.req instanceof Request,
         hasEvent: reqCtx.event === testEvent,
         hasContext: reqCtx.context === context,
       };

--- a/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
@@ -400,7 +400,7 @@ describe('Class: Router - Decorators', () => {
         @app.get('/test')
         public async getTest(_params: any, reqCtx: any) {
           return {
-            hasRequest: reqCtx.request instanceof Request,
+            hasRequest: reqCtx.req instanceof Request,
             hasEvent: reqCtx.event === testEvent,
             hasContext: reqCtx.context === context,
           };
@@ -435,7 +435,7 @@ describe('Class: Router - Decorators', () => {
             statusCode: HttpErrorCodes.BAD_REQUEST,
             error: 'Bad Request',
             message: error.message,
-            hasRequest: reqCtx.request instanceof Request,
+            hasRequest: reqCtx.req instanceof Request,
             hasEvent: reqCtx.event === testEvent,
             hasContext: reqCtx.context === context,
           };

--- a/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
@@ -375,7 +375,7 @@ describe('Class: Router - Error Handling', () => {
       statusCode: HttpErrorCodes.BAD_REQUEST,
       error: 'Bad Request',
       message: error.message,
-      hasRequest: reqCtx.request instanceof Request,
+      hasRequest: reqCtx.req instanceof Request,
       hasEvent: reqCtx.event === testEvent,
       hasContext: reqCtx.context === context,
     }));

--- a/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
@@ -154,7 +154,7 @@ describe('Class: Router - Middleware', () => {
       expect(middlewareParams).toEqual({ id: '123' });
       expect(middlewareOptions?.event).toBe(testEvent);
       expect(middlewareOptions?.context).toBe(context);
-      expect(middlewareOptions?.request).toBeInstanceOf(Request);
+      expect(middlewareOptions?.req).toBeInstanceOf(Request);
     });
 
     it('returns error response when next() is called multiple times', async () => {

--- a/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
@@ -44,16 +44,17 @@ describe('Class: Router - Middleware', () => {
       const app = new Router();
       const executionOrder: string[] = [];
 
-      app.use(async (_params, _reqCtx, next) => {
+      app.use(async ({ next }) => {
         executionOrder.push('global-middleware');
         await next();
       });
 
       const middleware: Middleware[] = middlewareNames.map(
-        (name) => async (_params, _reqCtx, next) => {
-          executionOrder.push(name);
-          await next();
-        }
+        (name) =>
+          async ({ next }) => {
+            executionOrder.push(name);
+            await next();
+          }
       );
 
       app.get(path as Path, middleware, async () => {
@@ -137,7 +138,7 @@ describe('Class: Router - Middleware', () => {
       let middlewareParams: Record<string, string> | undefined;
       let middlewareOptions: RequestContext | undefined;
 
-      app.use(async (params, reqCtx, next) => {
+      app.use(async ({ params, reqCtx, next }) => {
         middlewareParams = params;
         middlewareOptions = reqCtx;
         await next();
@@ -161,7 +162,7 @@ describe('Class: Router - Middleware', () => {
       vi.stubEnv('POWERTOOLS_DEV', 'true');
       const app = new Router();
 
-      app.use(async (_params, _reqCtx, next) => {
+      app.use(async ({ next }) => {
         await next();
         await next();
       });
@@ -185,11 +186,11 @@ describe('Class: Router - Middleware', () => {
       vi.stubEnv('POWERTOOLS_DEV', 'true');
       const app = new Router();
 
-      app.use(async (_params, _reqCtx, next) => {
+      app.use(async ({ next }) => {
         await next();
       });
 
-      app.use(async (_params, _reqCtx, next) => {
+      app.use(async ({ next }) => {
         next();
       });
 
@@ -241,7 +242,7 @@ describe('Class: Router - Middleware', () => {
       const app = new Router();
       const executionOrder: string[] = [];
 
-      app.use(async (_params, _reqCtx, next) => {
+      app.use(async ({ next }) => {
         executionOrder.push('middleware1-start');
         await next();
         executionOrder.push('middleware1-end');
@@ -362,7 +363,7 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, reqCtx, next) => {
+      app.use(async ({ reqCtx, next }) => {
         await next();
         reqCtx.res.headers.set('x-custom-header', 'middleware-value');
         reqCtx.res.headers.set('x-request-id', '12345');
@@ -393,7 +394,7 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, reqCtx, next) => {
+      app.use(async ({ reqCtx, next }) => {
         await next();
         const originalBody = await reqCtx.res.text();
         reqCtx.res = new Response(`Modified: ${originalBody}`, {
@@ -422,7 +423,7 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, reqCtx, next) => {
+      app.use(async ({ reqCtx, next }) => {
         reqCtx.res.headers.set('x-before-handler', 'middleware-value');
         await next();
       });
@@ -451,7 +452,7 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, reqCtx, next) => {
+      app.use(async ({ reqCtx, next }) => {
         reqCtx.res.headers.set('x-before-handler', 'middleware-value');
         await next();
       });
@@ -478,12 +479,12 @@ describe('Class: Router - Middleware', () => {
       // Prepare
       const app = new Router();
 
-      app.use(async (_params, reqCtx, next) => {
+      app.use(async ({ reqCtx, next }) => {
         reqCtx.res.headers.set('x-test-header', 'before-next');
         await next();
       });
 
-      app.use(async (_params, reqCtx, next) => {
+      app.use(async ({ reqCtx, next }) => {
         await next();
         reqCtx.res.headers.set('x-test-header', 'after-next');
       });
@@ -531,7 +532,7 @@ describe('Class: Router - Middleware', () => {
       const app = new Router();
       const executionOrder: string[] = [];
 
-      app.use(async (_params, _reqCtx, next) => {
+      app.use(async ({ next }) => {
         executionOrder.push('middleware-start');
         await next();
         executionOrder.push('middleware-end');

--- a/packages/event-handler/tests/unit/rest/helpers.ts
+++ b/packages/event-handler/tests/unit/rest/helpers.ts
@@ -28,7 +28,7 @@ export const createTrackingMiddleware = (
   name: string,
   executionOrder: string[]
 ): Middleware => {
-  return async (_params, _options, next) => {
+  return async ({ next }) => {
     executionOrder.push(`${name}-start`);
     await next();
     executionOrder.push(`${name}-end`);
@@ -40,7 +40,7 @@ export const createThrowingMiddleware = (
   executionOrder: string[],
   errorMessage: string
 ): Middleware => {
-  return async (_params, _options, _next) => {
+  return async () => {
     executionOrder.push(name);
     throw new Error(errorMessage);
   };
@@ -51,7 +51,7 @@ export const createReturningMiddleware = (
   executionOrder: string[],
   response: any
 ): Middleware => {
-  return async (_params, _options, _next) => {
+  return async () => {
     executionOrder.push(name);
     return response;
   };
@@ -61,7 +61,7 @@ export const createNoNextMiddleware = (
   name: string,
   executionOrder: string[]
 ): Middleware => {
-  return async (_params, _options, _next) => {
+  return async () => {
     executionOrder.push(name);
     // Intentionally doesn't call next()
   };
@@ -70,10 +70,10 @@ export const createNoNextMiddleware = (
 export const createSettingHeadersMiddleware = (headers: {
   [key: string]: string;
 }): Middleware => {
-  return async (_params, options, next) => {
+  return async ({ reqCtx, next }) => {
     await next();
     Object.entries(headers).forEach(([key, value]) => {
-      options.res.headers.set(key, value);
+      reqCtx.res.headers.set(key, value);
     });
   };
 };
@@ -81,8 +81,8 @@ export const createSettingHeadersMiddleware = (headers: {
 export const createHeaderCheckMiddleware = (headers: {
   [key: string]: string;
 }): Middleware => {
-  return async (_params, options, next) => {
-    options.res.headers.forEach((value, key) => {
+  return async ({ reqCtx, next }) => {
+    reqCtx.res.headers.forEach((value, key) => {
       headers[key] = value;
     });
     await next();


### PR DESCRIPTION
## Summary

This PR updates the signatures of the Middleware function to use a single parameter object instead of multiple parameters. It also updates the `request` property of the `RequestContext` type to use the shortened version `req` to make it consistent with the response `res` 

### Changes

> Please provide a summary of what's being changed

- Updated the middleware signatures
- Changed all occurence of `reqCtx.request` to `reqCtx.req`

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4480 and #4518 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
