### PR TITLE
improv(event-handler): changed path parameter in middleware and routehandler signature

### DIFF
--- a/packages/event-handler/src/rest/utils.ts
+++ b/packages/event-handler/src/rest/utils.ts
@@ -150,7 +150,7 @@ export const isAPIGatewayProxyResult = (
  * ```
  */
 export const composeMiddleware = (middleware: Middleware[]): Middleware => {
-  return async ({ params, reqCtx, next }): Promise<HandlerResponse | void> => {
+  return async ({ reqCtx, next }): Promise<HandlerResponse | void> => {
     let index = -1;
     let result: HandlerResponse | undefined;
 
@@ -177,7 +177,6 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
       };
 
       const middlewareResult = await middlewareFn({
-        params,
         reqCtx,
         next: nextFn,
       });

--- a/packages/event-handler/src/types/rest.ts
+++ b/packages/event-handler/src/types/rest.ts
@@ -19,6 +19,7 @@ type RequestContext = {
   event: APIGatewayProxyEvent;
   context: Context;
   res: Response;
+  params: Record<string, string>;
 };
 
 type ErrorResolveOptions = RequestContext & ResolveOptions;
@@ -60,10 +61,9 @@ type DynamicRoute = Route & CompiledRoute;
 
 type HandlerResponse = Response | JSONObject;
 
-type RouteHandler<
-  TParams = Record<string, unknown>,
-  TReturn = HandlerResponse,
-> = (args: TParams, reqCtx: RequestContext) => Promise<TReturn>;
+type RouteHandler<TReturn = HandlerResponse> = (
+  reqCtx: RequestContext
+) => Promise<TReturn>;
 
 type HttpMethod = keyof typeof HttpVerbs;
 
@@ -87,7 +87,6 @@ type RestRouteOptions = {
 type NextFunction = () => Promise<HandlerResponse | void>;
 
 type Middleware = (args: {
-  params: Record<string, string>;
   reqCtx: RequestContext;
   next: NextFunction;
 }) => Promise<void | HandlerResponse>;

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -89,7 +89,7 @@ describe('Class: Router - Basic Routing', () => {
     const app = new Router();
     const testEvent = createTestEvent('/test', 'GET');
 
-    app.get('/test', async (_params, reqCtx) => {
+    app.get('/test', async (reqCtx) => {
       return {
         hasRequest: reqCtx.req instanceof Request,
         hasEvent: reqCtx.event === testEvent,
@@ -126,8 +126,8 @@ describe('Class: Router - Basic Routing', () => {
     app.post('/', async () => {
       return { actualPath: '/todos' };
     });
-    app.get('/:todoId', async ({ todoId }) => {
-      return { actualPath: `/todos/${todoId}` };
+    app.get('/:todoId', async (reqCtx) => {
+      return { actualPath: `/todos/${reqCtx.params.todoId}` };
     });
 
     // Act

--- a/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/decorators.test.ts
@@ -398,7 +398,7 @@ describe('Class: Router - Decorators', () => {
 
       class Lambda {
         @app.get('/test')
-        public async getTest(_params: any, reqCtx: any) {
+        public async getTest(reqCtx: any) {
           return {
             hasRequest: reqCtx.req instanceof Request,
             hasEvent: reqCtx.event === testEvent,

--- a/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/middleware.test.ts
@@ -138,8 +138,8 @@ describe('Class: Router - Middleware', () => {
       let middlewareParams: Record<string, string> | undefined;
       let middlewareOptions: RequestContext | undefined;
 
-      app.use(async ({ params, reqCtx, next }) => {
-        middlewareParams = params;
+      app.use(async ({ reqCtx, next }) => {
+        middlewareParams = reqCtx.params;
         middlewareOptions = reqCtx;
         await next();
       });

--- a/packages/event-handler/tests/unit/rest/middleware/compress.test.ts
+++ b/packages/event-handler/tests/unit/rest/middleware/compress.test.ts
@@ -1,8 +1,8 @@
 import { gzipSync } from 'node:zlib';
 import context from '@aws-lambda-powertools/testing-utils/context';
-import { Router } from 'src/rest/Router.js';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { compress } from '../../../../src/rest/middleware/index.js';
+import { Router } from '../../../../src/rest/Router.js';
 import { createSettingHeadersMiddleware, createTestEvent } from '../helpers.js';
 
 describe('Compress Middleware', () => {


### PR DESCRIPTION
## Summary

This PR updates the `Middleware` and the `RouteHandler` types to move the `params` key under the `RequestContext` parameter.

### Changes

> Please provide a summary of what's being changed

- Removed the `params` from the `Middleware` and the `RouteHandler` types and added to the `RequestContext` parameter.
- Updated the occurrences to remove the `params` key and use it through the `reqCtx` property

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4531 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
