### PR TITLE
docs(idempotency): fix dataKeywordArgument reference and remove unused test code

### DIFF
--- a/packages/idempotency/src/makeIdempotent.ts
+++ b/packages/idempotency/src/makeIdempotent.ts
@@ -44,38 +44,73 @@ const isOptionsWithDataIndexArgument = (
 };
 
 /**
- * Use function wrapper to make your function idempotent.
+ * Function wrapper to make any function idempotent.
+ *
+ * The `makeIdempotent` function is a higher-order function that takes another function and returns a new version of that function with idempotency behavior.
+ * This means that if the function is called multiple times with the same input, it will return the same result without re-executing the original function logic.
+ *
+ * By default, the entire first argument is hashed to create the idempotency key. You can customize this behavior:
+ * - Use {@link IdempotencyConfig.eventKeyJmesPath | `eventKeyJmesPath`} to hash only a subset of the payload
+ * - Use {@link ItempotentFunctionOptions.dataIndexArgument | `dataIndexArgument`} to hash a different function argument
+ *
+ *
+ * **Using a subset of the payload**
+ *
  * @example
- * ```ts
- * // this is your processing function with an example record { transactionId: '123', foo: 'bar' }
- * const processRecord = (record: Record<string, unknown>): any => {
- *   // you custom processing logic
+ * ```typescript
+ * import { makeIdempotent, IdempotencyConfig } from '@aws-lambda-powertools/idempotency';
+ * import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
+ *
+ * const processRecord = (record: Record<string, unknown>): unknown => {
+ *   // your processing logic
  *   return result;
  * };
  *
- * // we use wrapper to make processing function idempotent with DynamoDBPersistenceLayer
  * const processIdempotently = makeIdempotent(processRecord, {
- *   persistenceStore: new DynamoDBPersistenceLayer()
+ *   persistenceStore: new DynamoDBPersistenceLayer({ tableName: 'idempotency-table' }),
  *   config: new IdempotencyConfig({
- *     eventKeyJmesPath: 'transactionId', // this will use `transactionId` argument as idempotency payload
+ *     eventKeyJmesPath: 'transactionId', // hash only this field as idempotency key
  *   }),
  * });
  *
- * export const handler = async (
- *   _event: EventRecords,
- *   _context: Context
- * ): Promise<void> => {
- *   for (const record of _event.records) {
- *     const result = await processIdempotently(record);
- *     // do something with the result
+ * export const handler = async (event: { records: Record<string, unknown>[] }) => {
+ *  for (const record of event.records) {
+ *    // use the idempotent function
+ *    const result = await processIdempotently(record);
+ *    // ... do something with the result
  *   }
- *
- *   return Promise.resolve();
  * };
+ *```
+ *
+ * **Using a different function argument (useful for multi-parameter functions)**
+ *
+ * @example
+ * ```typescript
+ * import { makeIdempotent } from '@aws-lambda-powertools/idempotency';
+ * import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
+ *
+ * const processRecord = (record: Record<string, unknown>, userId: string): unknown => {
+ *   // your processing logic
+ *   return result;
+ * };
+ *
+ * const processIdempotently = makeIdempotent(processRecord, {
+ *   persistenceStore: new DynamoDBPersistenceLayer({ tableName: 'idempotency-table' }),
+ *   dataIndexArgument: 1, // hash the userId (second argument) instead of first (record)
+ * });
+ *
+ * export const handler = async (event: { records: Record<string,unknown>[]; userId: string }) => {
+ *  for (const record of event.records) {
+ *    const userId = event.userId;
+ *    // use the idempotent function
+ *    const result = await processIdempotently(record, userId);
+ *    // ... do something with the result
+ *   }
+ * };
+ * ```
  *
  * @param fn - the function to make idempotent
  * @param options - the options to configure the idempotency behavior
- * ```
  */
 function makeIdempotent<Func extends AnyFunction>(
   fn: Func,

--- a/packages/idempotency/src/makeIdempotent.ts
+++ b/packages/idempotency/src/makeIdempotent.ts
@@ -56,7 +56,9 @@ const isOptionsWithDataIndexArgument = (
  * // we use wrapper to make processing function idempotent with DynamoDBPersistenceLayer
  * const processIdempotently = makeIdempotent(processRecord, {
  *   persistenceStore: new DynamoDBPersistenceLayer()
- *   dataKeywordArgument: 'transactionId', // keyword argument to hash the payload and the result
+ *   config: new IdempotencyConfig({
+ *     eventKeyJmesPath: 'transactionId', // this will use `transactionId` argument as idempotency payload
+ *   }),
  * });
  *
  * export const handler = async (

--- a/packages/idempotency/tests/unit/IdempotencyHandler.test.ts
+++ b/packages/idempotency/tests/unit/IdempotencyHandler.test.ts
@@ -20,7 +20,6 @@ const mockFunctionPayloadToBeHashed = {};
 const persistenceStore = new PersistenceLayerTestClass();
 const mockIdempotencyOptions = {
   persistenceStore,
-  dataKeywordArgument: 'testKeywordArgument',
   config: new IdempotencyConfig({}),
 };
 


### PR DESCRIPTION
## Summary
Fixes documentation error where `dataKeywordArgument` is referenced but doesn't exist in the type definitions. 

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

- Replaced `dataKeywordArgument` references with `config.eventKeyJmesPath` in documentation

- Removed unused `dataKeywordArgument` reference from test file

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4533

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
