### PR TITLE
feat(event-handler): added `includeRouter` method to split routes

### DIFF
--- a/packages/event-handler/src/rest/ErrorHandlerRegistry.ts
+++ b/packages/event-handler/src/rest/ErrorHandlerRegistry.ts
@@ -76,6 +76,8 @@ export class ErrorHandlerRegistry {
    * Merges another {@link ErrorHandlerRegistry | `ErrorHandlerRegistry`} instance into the current instance.
    * It takes the handlers from the provided registry and adds them to the current registry.
    *
+   * Error handlers from the included router are merged with existing handlers. If handlers for the same error type exist in both routers, the included router's handler takes precedence.
+   *
    * @param errorHandlerRegistry - The registry instance to merge with the current instance
    */
   public merge(errorHandlerRegistry: ErrorHandlerRegistry): void {

--- a/packages/event-handler/src/rest/ErrorHandlerRegistry.ts
+++ b/packages/event-handler/src/rest/ErrorHandlerRegistry.ts
@@ -71,4 +71,19 @@ export class ErrorHandlerRegistry {
 
     return null;
   }
+
+  /**
+   * Merges another {@link ErrorHandlerRegistry | `ErrorHandlerRegistry`} instance into the current instance.
+   * It takes the handlers from the provided registry and adds them to the current registry.
+   *
+   * @param errorHandlerRegistry - The registry instance to merge with the current instance
+   */
+  public merge(errorHandlerRegistry: ErrorHandlerRegistry): void {
+    for (const [
+      errorConstructor,
+      errorHandler,
+    ] of errorHandlerRegistry.#handlers) {
+      this.register(errorConstructor, errorHandler);
+    }
+  }
 }

--- a/packages/event-handler/src/rest/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/rest/RouteHandlerRegistry.ts
@@ -8,7 +8,7 @@ import type {
   ValidationResult,
 } from '../types/rest.js';
 import { ParameterValidationError } from './errors.js';
-import type { Route } from './Route.js';
+import { Route } from './Route.js';
 import { compilePath, validatePathPattern } from './utils.js';
 
 class RouteHandlerRegistry {
@@ -192,6 +192,43 @@ class RouteHandlerRegistry {
     }
 
     return null;
+  }
+
+  /**
+   * Merges another {@link RouteHandlerRegistry | `RouteHandlerRegistry`} instance into the current instance.
+   * It takes the static and dynamic routes from the provided registry and adds them to the current registry.
+   *
+   * @param routeHandlerRegistry - The registry instance to merge with the current instance
+   * @param options.prefix - An optional prefix to be added to the paths defined in the router
+   */
+  public merge(
+    routeHandlerRegistry: RouteHandlerRegistry,
+    options?: { prefix: Path }
+  ): void {
+    for (const route of routeHandlerRegistry.#staticRoutes.values()) {
+      this.register(
+        new Route(
+          route.method as HttpMethod,
+          options?.prefix
+            ? route.path === '/'
+              ? options.prefix
+              : `${options.prefix}${route.path}`
+            : route.path,
+          route.handler,
+          route.middleware
+        )
+      );
+    }
+    for (const route of routeHandlerRegistry.#dynamicRoutes) {
+      this.register(
+        new Route(
+          route.method as HttpMethod,
+          options?.prefix ? `${options.prefix}${route.path}` : route.path,
+          route.handler,
+          route.middleware
+        )
+      );
+    }
   }
 }
 

--- a/packages/event-handler/src/rest/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/rest/RouteHandlerRegistry.ts
@@ -9,7 +9,11 @@ import type {
 } from '../types/rest.js';
 import { ParameterValidationError } from './errors.js';
 import { Route } from './Route.js';
-import { compilePath, validatePathPattern } from './utils.js';
+import {
+  compilePath,
+  resolvePrefixedPath,
+  validatePathPattern,
+} from './utils.js';
 
 class RouteHandlerRegistry {
   readonly #staticRoutes: Map<string, Route> = new Map();
@@ -199,6 +203,7 @@ class RouteHandlerRegistry {
    * It takes the static and dynamic routes from the provided registry and adds them to the current registry.
    *
    * @param routeHandlerRegistry - The registry instance to merge with the current instance
+   * @param options - Configuration options for merging the router
    * @param options.prefix - An optional prefix to be added to the paths defined in the router
    */
   public merge(
@@ -210,17 +215,10 @@ class RouteHandlerRegistry {
       ...routeHandlerRegistry.#dynamicRoutes,
     ];
     for (const route of routes) {
-      let path = route.path;
-      if (options?.prefix) {
-        path =
-          route.path === '/'
-            ? options.prefix
-            : `${options.prefix}${route.path}`;
-      }
       this.register(
         new Route(
           route.method as HttpMethod,
-          path,
+          resolvePrefixedPath(route.path, options?.prefix),
           route.handler,
           route.middleware
         )

--- a/packages/event-handler/src/rest/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/rest/RouteHandlerRegistry.ts
@@ -202,6 +202,8 @@ class RouteHandlerRegistry {
    * Merges another {@link RouteHandlerRegistry | `RouteHandlerRegistry`} instance into the current instance.
    * It takes the static and dynamic routes from the provided registry and adds them to the current registry.
    *
+   * Routes from the included router are added to the current router's registry. If a route with the same method and path already exists, the included router's route takes precedence.
+   *
    * @param routeHandlerRegistry - The registry instance to merge with the current instance
    * @param options - Configuration options for merging the router
    * @param options.prefix - An optional prefix to be added to the paths defined in the router

--- a/packages/event-handler/src/rest/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/rest/RouteHandlerRegistry.ts
@@ -205,25 +205,22 @@ class RouteHandlerRegistry {
     routeHandlerRegistry: RouteHandlerRegistry,
     options?: { prefix: Path }
   ): void {
-    for (const route of routeHandlerRegistry.#staticRoutes.values()) {
+    const routes = [
+      ...routeHandlerRegistry.#staticRoutes.values(),
+      ...routeHandlerRegistry.#dynamicRoutes,
+    ];
+    for (const route of routes) {
+      let path = route.path;
+      if (options?.prefix) {
+        path =
+          route.path === '/'
+            ? options.prefix
+            : `${options.prefix}${route.path}`;
+      }
       this.register(
         new Route(
           route.method as HttpMethod,
-          options?.prefix
-            ? route.path === '/'
-              ? options.prefix
-              : `${options.prefix}${route.path}`
-            : route.path,
-          route.handler,
-          route.middleware
-        )
-      );
-    }
-    for (const route of routeHandlerRegistry.#dynamicRoutes) {
-      this.register(
-        new Route(
-          route.method as HttpMethod,
-          options?.prefix ? `${options.prefix}${route.path}` : route.path,
+          path,
           route.handler,
           route.middleware
         )

--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -562,11 +562,11 @@ class Router {
    * const todosRouter = new Router();
    *
    * todosRouter.get('/todos', async () => {
-   *   // List Todos
+   *   // List API
    * });
    *
    * todosRouter.get('/todos/{todoId}', async () => {
-   *   // Get Todo
+   *   // Get API
    * });
    *
    * const app = new Router();

--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -551,6 +551,43 @@ class Router {
       handler
     );
   }
+
+  /**
+   * Merges the routes, context and middleware from the passed router instance into this router instance
+   *
+   * @example
+   * ```typescript
+   * import { Router } from '@aws-lambda-powertools/event-handler/experimental-rest';
+   *
+   * const todosRouter = new Router();
+   *
+   * todosRouter.get('/todos', async () => {
+   *   // List Todos
+   * });
+   *
+   * todosRouter.get('/todos/{todoId}', async () => {
+   *   // Get Todo
+   * });
+   *
+   * const app = new Router();
+   * app.includeRouter(todosRouter);
+   *
+   * export const handler = async (event: unknown, context: Context) => {
+   *   return app.resolve(event, context);
+   * };
+   * ```
+   * @param router - The Router from which to merge the routes, context and middleware
+   * @param options.prefix - An optional prefix to be added to the paths defined in the router
+   */
+  public includeRouter(router: Router, options?: { prefix: Path }): void {
+    this.context = {
+      ...this.context,
+      ...router.context,
+    };
+    this.routeRegistry.merge(router.routeRegistry, options);
+    this.errorHandlerRegistry.merge(router.errorHandlerRegistry);
+    this.middleware.push(...router.middleware);
+  }
 }
 
 export { Router };

--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -41,6 +41,7 @@ import {
   isAPIGatewayProxyEvent,
   isAPIGatewayProxyResult,
   isHttpMethod,
+  resolvePrefixedPath,
 } from './utils.js';
 
 class Router {
@@ -293,10 +294,7 @@ class Router {
   public route(handler: RouteHandler, options: RestRouteOptions): void {
     const { method, path, middleware = [] } = options;
     const methods = Array.isArray(method) ? method : [method];
-    let resolvedPath = path;
-    if (this.prefix) {
-      resolvedPath = path === '/' ? this.prefix : `${this.prefix}${path}`;
-    }
+    const resolvedPath = resolvePrefixedPath(path, this.prefix);
 
     for (const method of methods) {
       this.routeRegistry.register(
@@ -553,7 +551,13 @@ class Router {
   }
 
   /**
-   * Merges the routes, context and middleware from the passed router instance into this router instance
+   * Merges the routes, context and middleware from the passed router instance into this router instance.
+   *
+   * **Override Behaviors:**
+   * - **Context**: Properties from the included router override existing properties with the same key in the current router. A warning is logged when conflicts occur.
+   * - **Routes**: Routes from the included router are added to the current router's registry. If a route with the same method and path already exists, the included router's route takes precedence.
+   * - **Error Handlers**: Error handlers from the included router are merged with existing handlers. If handlers for the same error type exist in both routers, the included router's handler takes precedence.
+   * - **Middleware**: Middleware from the included router is appended to the current router's middleware array. All middleware executes in registration order (current router's middleware first, then included router's middleware).
    *
    * @example
    * ```typescript
@@ -576,7 +580,8 @@ class Router {
    *   return app.resolve(event, context);
    * };
    * ```
-   * @param router - The Router from which to merge the routes, context and middleware
+   * @param router - The `Router` from which to merge the routes, context and middleware
+   * @param options - Configuration options for merging the router
    * @param options.prefix - An optional prefix to be added to the paths defined in the router
    */
   public includeRouter(router: Router, options?: { prefix: Path }): void {

--- a/packages/event-handler/src/rest/utils.ts
+++ b/packages/event-handler/src/rest/utils.ts
@@ -196,3 +196,16 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
     return result;
   };
 };
+
+/**
+ * Resolves a prefixed path by combining the provided path and prefix.
+ *
+ * @param path - The path to resolve
+ * @param prefix - The prefix to prepend to the path
+ */
+export const resolvePrefixedPath = (path: Path, prefix?: Path): Path => {
+  if (prefix) {
+    return path === '/' ? prefix : `${prefix}${path}`;
+  }
+  return path;
+};

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -144,4 +144,47 @@ describe('Class: Router - Basic Routing', () => {
     expect(JSON.parse(createResult.body).actualPath).toBe('/todos');
     expect(JSON.parse(getResult.body).actualPath).toBe('/todos/1');
   });
+
+  it('routes to the included router when using split routers', async () => {
+    // Prepare
+    const baseRouter = new Router();
+    baseRouter.get('/', async () => ({ api: 'root' }));
+    baseRouter.get('/version', async () => ({ api: 'listVersions' }));
+    baseRouter.get('/version/:id', async () => ({ api: 'getVersion' }));
+    baseRouter.notFound(async () => ({ error: 'NotFound' }));
+
+    const todoRouter = new Router();
+    todoRouter.get('/', async () => ({ api: 'listTodos' }));
+    todoRouter.post('/create', async () => ({ api: 'createTodo' }));
+    todoRouter.get('/:id', async () => ({ api: 'getTodo' }));
+
+    const taskRouter = new Router();
+    taskRouter.get('/', async () => ({ api: 'listTasks' }));
+    taskRouter.post('/create', async () => ({ api: 'createTask' }));
+    taskRouter.get('/:taskId', async () => ({ api: 'getTask' }));
+
+    const app = new Router();
+    app.includeRouter(baseRouter);
+    app.includeRouter(todoRouter, { prefix: '/todos' });
+    app.includeRouter(taskRouter, { prefix: '/todos/:id/tasks' });
+
+    // Act & Assess
+    const testCases = [
+      ['/', 'GET', 'api', 'root'],
+      ['/version', 'GET', 'api', 'listVersions'],
+      ['/version/1', 'GET', 'api', 'getVersion'],
+      ['/todos', 'GET', 'api', 'listTodos'],
+      ['/todos/create', 'POST', 'api', 'createTodo'],
+      ['/todos/1', 'GET', 'api', 'getTodo'],
+      ['/todos/1/tasks', 'GET', 'api', 'listTasks'],
+      ['/todos/1/tasks/create', 'POST', 'api', 'createTask'],
+      ['/todos/1/tasks/1', 'GET', 'api', 'getTask'],
+      ['/non-existent', 'GET', 'error', 'NotFound'],
+    ] as const;
+
+    for (const [path, method, key, expected] of testCases) {
+      const result = await app.resolve(createTestEvent(path, method), context);
+      expect(JSON.parse(result.body)[key]).toBe(expected);
+    }
+  });
 });

--- a/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/basic-routing.test.ts
@@ -181,6 +181,7 @@ describe('Class: Router - Basic Routing', () => {
       context
     );
 
+    // Assert
     expect(JSON.parse(rootResult.body).api).toEqual('root');
     expect(JSON.parse(listTodosResult.body).api).toEqual('listTodos');
     expect(JSON.parse(notFoundResult.body).error).toEqual('Route not found');

--- a/packages/event-handler/tests/unit/rest/utils.test.ts
+++ b/packages/event-handler/tests/unit/rest/utils.test.ts
@@ -9,7 +9,11 @@ import {
   isAPIGatewayProxyEvent,
   isAPIGatewayProxyResult,
 } from '../../../src/rest/index.js';
-import { compilePath, validatePathPattern } from '../../../src/rest/utils.js';
+import {
+  compilePath,
+  resolvePrefixedPath,
+  validatePathPattern,
+} from '../../../src/rest/utils.js';
 import type {
   Middleware,
   Path,
@@ -565,6 +569,20 @@ describe('Path Utilities', () => {
       });
 
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('resolvePrefixedPath', () => {
+    it.each([
+      { path: '/test', prefix: '/prefix', expected: '/prefix/test' },
+      { path: '/', prefix: '/prefix', expected: '/prefix' },
+      { path: '/test', expected: '/test' },
+    ])('resolves prefixed path', ({ path, prefix, expected }) => {
+      // Prepare & Act
+      const resolvedPath = resolvePrefixedPath(path as Path, prefix as Path);
+
+      // Assert
+      expect(resolvedPath).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds an `includeRouter` method to allows merging routes, context, and middleware from one router instance into another. 

### Changes

> Please provide a summary of what's being changed

- Added `merge` methods on the Route Handler and Error Handler registries to merge error handlers and routes
- Added `includeRouter` method on the Router to merge context, registries and middlewares

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4481 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
