### PR TITLE
ci: add `--delete` flag to docs publish command

### DIFF
--- a/.github/workflows/reusable_publish_docs.yml
+++ b/.github/workflows/reusable_publish_docs.yml
@@ -109,7 +109,8 @@ jobs:
           set -euo pipefail
           aws s3 sync \
             site/ \
-            "s3://$AWS_DOCS_BUCKET/lambda-typescript/$VERSION/"
+            "s3://$AWS_DOCS_BUCKET/lambda-typescript/$VERSION/" \
+            --delete
       - name: Deploy Docs (Alias)
         env:
           VERSION: ${{ inputs.version }}
@@ -119,7 +120,8 @@ jobs:
           set -euo pipefail
           aws s3 sync \
             site/ \
-            "s3://$AWS_DOCS_BUCKET/lambda-typescript/$ALIAS/"
+            "s3://$AWS_DOCS_BUCKET/lambda-typescript/$ALIAS/" \
+            --delete
       - name: Deploy Docs (Version JSON)
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR adds the `--delete` flag to the AWS CLI command that deploys the documentation site by means of `aws s3 sync`, this way older pages are removed in newer versions, especially `latest`.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4414

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
