### PR TITLE
test: update domain in e2e tests

### DIFF
--- a/packages/tracer/tests/e2e/decorator.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/decorator.test.functionCode.ts
@@ -44,8 +44,8 @@ export class LambdaFunction {
 
     await this.methodNoResponse(event.invocation);
     await httpRequest({
-      hostname: 'docs.powertools.aws.dev',
-      path: '/lambda/typescript/latest/',
+      hostname: 'docs.aws.amazon.com',
+      path: '/powertools/typescript/latest/',
     });
 
     const res = this.myMethod();

--- a/packages/tracer/tests/e2e/decorator.test.ts
+++ b/packages/tracer/tests/e2e/decorator.test.ts
@@ -4,7 +4,7 @@ import { TestDynamodbTable } from '@aws-lambda-powertools/testing-utils/resource
 import { TestNodejsFunction } from '@aws-lambda-powertools/testing-utils/resources/lambda';
 import type { EnrichedXRayTraceDocumentParsed } from '@aws-lambda-powertools/testing-utils/types';
 import { getTraces } from '@aws-lambda-powertools/testing-utils/utils/xray-traces';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { invokeAllTestCases } from '../helpers/invokeAllTests.js';
 import {
   EXPECTED_ANNOTATION_KEY as expectedCustomAnnotationKey,
@@ -16,6 +16,10 @@ import {
   EXPECTED_SUBSEGMENT_NAME as expectedCustomSubSegmentName,
   RESOURCE_NAME_PREFIX,
 } from './constants.js';
+
+vi.hoisted(() => {
+  process.env.AWS_PROFILE = 'aamorosi-Admin';
+});
 
 describe('Tracer E2E tests, decorator instrumentation', () => {
   const testStack = new TestStack({
@@ -76,7 +80,7 @@ describe('Tracer E2E tests, decorator instrumentation', () => {
        * 1. Lambda Context (AWS::Lambda)
        * 2. Lambda Function (AWS::Lambda::Function)
        * 4. DynamoDB (AWS::DynamoDB)
-       * 4. Remote call (docs.powertools.aws.dev)
+       * 4. Remote call (docs.aws.amazon.com)
        */
       expectedSegmentsCount: 4,
     });
@@ -100,11 +104,11 @@ describe('Tracer E2E tests, decorator instrumentation', () => {
     expect(subsegments.size).toBe(3);
 
     // Check remote call subsegment
-    expect(subsegments.has('docs.powertools.aws.dev')).toBe(true);
-    const httpSubsegment = subsegments.get('docs.powertools.aws.dev');
+    expect(subsegments.has('docs.aws.amazon.com')).toBe(true);
+    const httpSubsegment = subsegments.get('docs.aws.amazon.com');
     expect(httpSubsegment?.namespace).toBe('remote');
     expect(httpSubsegment?.http?.request?.url).toEqual(
-      'https://docs.powertools.aws.dev/lambda/typescript/latest/'
+      'https://docs.aws.amazon.com/powertools/typescript/latest/'
     );
     expect(httpSubsegment?.http?.request?.method).toBe('GET');
     expect(httpSubsegment?.http?.response?.status).toEqual(expect.any(Number));

--- a/packages/tracer/tests/e2e/decorator.test.ts
+++ b/packages/tracer/tests/e2e/decorator.test.ts
@@ -4,7 +4,7 @@ import { TestDynamodbTable } from '@aws-lambda-powertools/testing-utils/resource
 import { TestNodejsFunction } from '@aws-lambda-powertools/testing-utils/resources/lambda';
 import type { EnrichedXRayTraceDocumentParsed } from '@aws-lambda-powertools/testing-utils/types';
 import { getTraces } from '@aws-lambda-powertools/testing-utils/utils/xray-traces';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { invokeAllTestCases } from '../helpers/invokeAllTests.js';
 import {
   EXPECTED_ANNOTATION_KEY as expectedCustomAnnotationKey,
@@ -16,10 +16,6 @@ import {
   EXPECTED_SUBSEGMENT_NAME as expectedCustomSubSegmentName,
   RESOURCE_NAME_PREFIX,
 } from './constants.js';
-
-vi.hoisted(() => {
-  process.env.AWS_PROFILE = 'aamorosi-Admin';
-});
 
 describe('Tracer E2E tests, decorator instrumentation', () => {
   const testStack = new TestStack({

--- a/packages/tracer/tests/e2e/manual.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/manual.test.functionCode.ts
@@ -33,7 +33,7 @@ export const handler = async (
   tracer.putMetadata(customMetadataKey, customMetadataValue);
 
   try {
-    await fetch('https://docs.powertools.aws.dev/lambda/typescript/latest/');
+    await fetch('https://docs.aws.amazon.com/powertools/typescript/latest/');
 
     const res = customResponseValue;
     if (event.throw) {

--- a/packages/tracer/tests/e2e/middy.test.functionCode.ts
+++ b/packages/tracer/tests/e2e/middy.test.functionCode.ts
@@ -34,7 +34,7 @@ export const handler = middy(
         },
       })
     );
-    await fetch('https://docs.powertools.aws.dev/lambda/typescript/latest/');
+    await fetch('https://docs.aws.amazon.com/powertools/typescript/latest/');
 
     if (event.throw) {
       throw new Error(customErrorMessage);

--- a/packages/tracer/tests/e2e/middy.test.ts
+++ b/packages/tracer/tests/e2e/middy.test.ts
@@ -75,7 +75,7 @@ describe('Tracer E2E tests, middy instrumentation', () => {
        * 1. Lambda Context (AWS::Lambda)
        * 2. Lambda Function (AWS::Lambda::Function)
        * 4. DynamoDB (AWS::DynamoDB)
-       * 4. Remote call (docs.powertools.aws.dev)
+       * 4. Remote call (docs.aws.amazon.com)
        */
       expectedSegmentsCount: 4,
     });
@@ -100,11 +100,11 @@ describe('Tracer E2E tests, middy instrumentation', () => {
     expect(subsegments.has('DynamoDB')).toBe(true);
 
     // Check remote call subsegment
-    expect(subsegments.has('docs.powertools.aws.dev')).toBe(true);
-    const httpSubsegment = subsegments.get('docs.powertools.aws.dev');
+    expect(subsegments.has('docs.aws.amazon.com')).toBe(true);
+    const httpSubsegment = subsegments.get('docs.aws.amazon.com');
     expect(httpSubsegment?.namespace).toBe('remote');
     expect(httpSubsegment?.http?.request?.url).toEqual(
-      'https://docs.powertools.aws.dev/lambda/typescript/latest/'
+      'https://docs.aws.amazon.com/powertools/typescript/latest/'
     );
     expect(httpSubsegment?.http?.request?.method).toBe('GET');
     expect(httpSubsegment?.http?.response?.status).toEqual(expect.any(Number));


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

This PR updates the url of the Powertools for AWS docs used in some e2e tests so that the tests can continue working.

As part of the work, I also had to add some user agent & headers to one of the requests so that it's processed correctly - not adding them would result in a 403.

The old domain has now a permanent redirect that caused the tests to fail (see last few runs in the Actions tab).

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4605

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
