### PR TITLE
improv(event-handler): rename ServiceError class to HttpError

### DIFF
--- a/packages/event-handler/src/rest/Router.ts
+++ b/packages/event-handler/src/rest/Router.ts
@@ -31,10 +31,10 @@ import {
 } from './converters.js';
 import { ErrorHandlerRegistry } from './ErrorHandlerRegistry.js';
 import {
+  HttpError,
   InternalServerError,
   MethodNotAllowedError,
   NotFoundError,
-  ServiceError,
 } from './errors.js';
 import { Route } from './Route.js';
 import { RouteHandlerRegistry } from './RouteHandlerRegistry.js';
@@ -399,14 +399,14 @@ class Router {
           headers: { 'Content-Type': 'application/json' },
         });
       } catch (handlerError) {
-        if (handlerError instanceof ServiceError) {
+        if (handlerError instanceof HttpError) {
           return await this.handleError(handlerError, options);
         }
         return this.#defaultErrorHandler(handlerError as Error);
       }
     }
 
-    if (error instanceof ServiceError) {
+    if (error instanceof HttpError) {
       return new Response(JSON.stringify(error.toJSON()), {
         status: error.statusCode,
         headers: { 'Content-Type': 'application/json' },

--- a/packages/event-handler/src/rest/errors.ts
+++ b/packages/event-handler/src/rest/errors.ts
@@ -20,7 +20,7 @@ class ParameterValidationError extends RouteMatchingError {
   }
 }
 
-abstract class ServiceError extends Error {
+abstract class HttpError extends Error {
   abstract readonly statusCode: HttpStatusCode;
   abstract readonly errorType: string;
   public readonly details?: Record<string, unknown>;
@@ -31,7 +31,7 @@ abstract class ServiceError extends Error {
     details?: Record<string, unknown>
   ) {
     super(message, options);
-    this.name = 'ServiceError';
+    this.name = 'HttpError';
     this.details = details;
   }
 
@@ -47,7 +47,7 @@ abstract class ServiceError extends Error {
   }
 }
 
-class BadRequestError extends ServiceError {
+class BadRequestError extends HttpError {
   readonly statusCode = HttpStatusCodes.BAD_REQUEST;
   readonly errorType = 'BadRequestError';
 
@@ -61,7 +61,7 @@ class BadRequestError extends ServiceError {
   }
 }
 
-class UnauthorizedError extends ServiceError {
+class UnauthorizedError extends HttpError {
   readonly statusCode = HttpStatusCodes.UNAUTHORIZED;
   readonly errorType = 'UnauthorizedError';
 
@@ -75,7 +75,7 @@ class UnauthorizedError extends ServiceError {
   }
 }
 
-class ForbiddenError extends ServiceError {
+class ForbiddenError extends HttpError {
   readonly statusCode = HttpStatusCodes.FORBIDDEN;
   readonly errorType = 'ForbiddenError';
 
@@ -89,7 +89,7 @@ class ForbiddenError extends ServiceError {
   }
 }
 
-class NotFoundError extends ServiceError {
+class NotFoundError extends HttpError {
   readonly statusCode = HttpStatusCodes.NOT_FOUND;
   readonly errorType = 'NotFoundError';
 
@@ -103,7 +103,7 @@ class NotFoundError extends ServiceError {
   }
 }
 
-class MethodNotAllowedError extends ServiceError {
+class MethodNotAllowedError extends HttpError {
   readonly statusCode = HttpStatusCodes.METHOD_NOT_ALLOWED;
   readonly errorType = 'MethodNotAllowedError';
 
@@ -117,7 +117,7 @@ class MethodNotAllowedError extends ServiceError {
   }
 }
 
-class RequestTimeoutError extends ServiceError {
+class RequestTimeoutError extends HttpError {
   readonly statusCode = HttpStatusCodes.REQUEST_TIMEOUT;
   readonly errorType = 'RequestTimeoutError';
 
@@ -131,7 +131,7 @@ class RequestTimeoutError extends ServiceError {
   }
 }
 
-class RequestEntityTooLargeError extends ServiceError {
+class RequestEntityTooLargeError extends HttpError {
   readonly statusCode = HttpStatusCodes.REQUEST_ENTITY_TOO_LARGE;
   readonly errorType = 'RequestEntityTooLargeError';
 
@@ -145,7 +145,7 @@ class RequestEntityTooLargeError extends ServiceError {
   }
 }
 
-class InternalServerError extends ServiceError {
+class InternalServerError extends HttpError {
   readonly statusCode = HttpStatusCodes.INTERNAL_SERVER_ERROR;
   readonly errorType = 'InternalServerError';
 
@@ -159,7 +159,7 @@ class InternalServerError extends ServiceError {
   }
 }
 
-class ServiceUnavailableError extends ServiceError {
+class ServiceUnavailableError extends HttpError {
   readonly statusCode = HttpStatusCodes.SERVICE_UNAVAILABLE;
   readonly errorType = 'ServiceUnavailableError';
 
@@ -183,7 +183,7 @@ export {
   RequestEntityTooLargeError,
   RequestTimeoutError,
   RouteMatchingError,
-  ServiceError,
+  HttpError,
   ServiceUnavailableError,
   UnauthorizedError,
 };

--- a/packages/event-handler/src/rest/index.ts
+++ b/packages/event-handler/src/rest/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   BadRequestError,
   ForbiddenError,
+  HttpError,
   InternalServerError,
   MethodNotAllowedError,
   NotFoundError,
@@ -15,7 +16,6 @@ export {
   RequestEntityTooLargeError,
   RequestTimeoutError,
   RouteMatchingError,
-  ServiceError,
   ServiceUnavailableError,
   UnauthorizedError,
 } from './errors.js';

--- a/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
+++ b/packages/event-handler/tests/unit/rest/Router/error-handling.test.ts
@@ -182,7 +182,7 @@ describe('Class: Router - Error Handling', () => {
     });
   });
 
-  it('uses ServiceError toJSON method when no custom handler is registered', async () => {
+  it('uses HttpError toJSON method when no custom handler is registered', async () => {
     // Prepare
     const app = new Router();
 


### PR DESCRIPTION
## Summary
This PR renames the base abstract class for errors from `ServiceError` to `HttpError`

### Changes

Renames the base class and updates all references in the code.

**Issue number:** #4609

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
