### PR TITLE
fix(logger): correct persistentLogAttributes warning behavior

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -1291,7 +1291,12 @@ class Logger extends Utility implements LoggerInterface {
       correlationIdSearchFn,
     } = options;
 
-    if (persistentLogAttributes && persistentKeys) {
+    if (
+      persistentLogAttributes &&
+      Object.keys(persistentLogAttributes).length > 0 &&
+      persistentKeys &&
+      Object.keys(persistentKeys).length > 0
+    ) {
       this.warn(
         'Both persistentLogAttributes and persistentKeys options were provided. Using persistentKeys as persistentLogAttributes is deprecated and will be removed in future releases'
       );

--- a/packages/logger/tests/unit/workingWithkeys.test.ts
+++ b/packages/logger/tests/unit/workingWithkeys.test.ts
@@ -622,6 +622,15 @@ describe('Working with keys', () => {
     );
   });
 
+  it('should pass persistentKeys to child with no warning', () => {
+    // Prepare
+    const logger = new Logger();
+    logger.createChild({ persistentKeys: { abc: 'xyz' } });
+
+    // Assess
+    expect(console.warn).toHaveBeenCalledTimes(0);
+  });
+
   it("doesn't overwrite standard keys when appending keys", () => {
     // Prepare
     const logger = new Logger();


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Stricter condition for `persistentLogAttributes` and `persistentKeys` usage warning.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4624

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
