### PR TITLE
feat(metrics): use async local storage for metrics (#4663)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10817,7 +10817,8 @@
       "version": "2.28.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.28.1"
+        "@aws-lambda-powertools/commons": "2.28.1",
+        "@aws/lambda-invoke-store": "0.1.1"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -10832,6 +10833,15 @@
         "@middy/core": {
           "optional": true
         }
+      }
+    },
+    "packages/metrics/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
+      "integrity": "sha512-RcLam17LdlbSOSp9VxmUu1eI6Mwxp+OwhD2QhiSNmNCzoDb0EeUXTD2n/WbcnrAYMGlmf05th6QYq23VqvJqpA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/parameters": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -88,7 +88,8 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "2.28.1"
+    "@aws-lambda-powertools/commons": "2.28.1",
+    "@aws/lambda-invoke-store": "0.1.1"
   },
   "keywords": [
     "aws",

--- a/packages/metrics/src/DimensionsStore.ts
+++ b/packages/metrics/src/DimensionsStore.ts
@@ -1,0 +1,104 @@
+import { InvokeStore } from '@aws/lambda-invoke-store';
+import type { Dimensions } from './types/Metrics.js';
+
+/**
+ * Manages storage of metrics dimensions with automatic context detection.
+ *
+ * This class abstracts the storage mechanism for metrics, automatically
+ * choosing between AsyncLocalStorage (when in async context) and a fallback
+ * object (when outside async context). The decision is made at runtime on
+ * every method call to support Lambda's transition to async contexts.
+ */
+class DimensionsStore {
+  readonly #dimensionsKey = Symbol('powertools.metrics.dimensions');
+  readonly #dimensionSetsKey = Symbol('powertools.metrics.dimensionSets');
+
+  #fallbackDimensions: Dimensions = {};
+  #fallbackDimensionSets: Dimensions[] = [];
+  #defaultDimensions: Dimensions = {};
+
+  #getDimensions(): Dimensions {
+    if (InvokeStore.getContext() === undefined) {
+      return this.#fallbackDimensions;
+    }
+
+    let stored = InvokeStore.get(this.#dimensionsKey) as Dimensions | undefined;
+    if (stored == null) {
+      stored = {};
+      InvokeStore.set(this.#dimensionsKey, stored);
+    }
+    return stored;
+  }
+
+  #getDimensionSets(): Dimensions[] {
+    if (InvokeStore.getContext() === undefined) {
+      return this.#fallbackDimensionSets;
+    }
+
+    let stored = InvokeStore.get(this.#dimensionSetsKey) as
+      | Dimensions[]
+      | undefined;
+    if (stored == null) {
+      stored = [];
+      InvokeStore.set(this.#dimensionSetsKey, stored);
+    }
+    return stored;
+  }
+
+  public addDimension(name: string, value: string): string {
+    this.#getDimensions()[name] = value;
+    return value;
+  }
+
+  public addDimensionSet(dimensionSet: Dimensions): Dimensions {
+    this.#getDimensionSets().push({ ...dimensionSet });
+    return dimensionSet;
+  }
+
+  public getDimensions(): Dimensions {
+    return { ...this.#getDimensions() };
+  }
+
+  public getDimensionSets(): Dimensions[] {
+    return this.#getDimensionSets().map((set) => ({ ...set }));
+  }
+
+  public clearRequestDimensions(): void {
+    if (InvokeStore.getContext() === undefined) {
+      this.#fallbackDimensions = {};
+      this.#fallbackDimensionSets = [];
+      return;
+    }
+
+    InvokeStore.set(this.#dimensionsKey, {});
+    InvokeStore.set(this.#dimensionSetsKey, []);
+  }
+
+  public clearDefaultDimensions(): void {
+    this.#defaultDimensions = {};
+  }
+
+  public getDimensionCount(): number {
+    const dimensions = this.#getDimensions();
+    const dimensionSets = this.#getDimensionSets();
+    const dimensionSetsCount = dimensionSets.reduce(
+      (total, dimensionSet) => total + Object.keys(dimensionSet).length,
+      0
+    );
+    return (
+      Object.keys(dimensions).length +
+      Object.keys(this.#defaultDimensions).length +
+      dimensionSetsCount
+    );
+  }
+
+  public setDefaultDimensions(dimensions: Dimensions): void {
+    this.#defaultDimensions = { ...dimensions };
+  }
+
+  public getDefaultDimensions(): Dimensions {
+    return { ...this.#defaultDimensions };
+  }
+}
+
+export { DimensionsStore };

--- a/packages/metrics/src/MetadataStore.ts
+++ b/packages/metrics/src/MetadataStore.ts
@@ -1,0 +1,50 @@
+import { InvokeStore } from '@aws/lambda-invoke-store';
+
+/**
+ * Manages storage of metrics #metadata with automatic context detection.
+ *
+ * This class abstracts the storage mechanism for metrics, automatically
+ * choosing between AsyncLocalStorage (when in async context) and a fallback
+ * object (when outside async context). The decision is made at runtime on
+ * every method call to support Lambda's transition to async contexts.
+ */
+class MetadataStore {
+  readonly #metadataKey = Symbol('powertools.metrics.metadata');
+
+  #fallbackStorage: Record<string, string> = {};
+
+  #getStorage(): Record<string, string> {
+    if (InvokeStore.getContext() === undefined) {
+      return this.#fallbackStorage;
+    }
+
+    let stored = InvokeStore.get(this.#metadataKey) as
+      | Record<string, string>
+      | undefined;
+    if (stored == null) {
+      stored = {};
+      InvokeStore.set(this.#metadataKey, stored);
+    }
+    return stored;
+  }
+
+  public set(key: string, value: string): string {
+    this.#getStorage()[key] = value;
+    return value;
+  }
+
+  public getAll(): Record<string, string> {
+    return { ...this.#getStorage() };
+  }
+
+  public clear(): void {
+    if (InvokeStore.getContext() === undefined) {
+      this.#fallbackStorage = {};
+      return;
+    }
+
+    InvokeStore.set(this.#metadataKey, {});
+  }
+}
+
+export { MetadataStore };

--- a/packages/metrics/src/MetricsStore.ts
+++ b/packages/metrics/src/MetricsStore.ts
@@ -1,0 +1,157 @@
+import { InvokeStore } from '@aws/lambda-invoke-store';
+import { isIntegerNumber } from '@aws-lambda-powertools/commons/typeutils';
+import { MetricResolution as MetricResolutions } from './constants.js';
+import type {
+  MetricResolution,
+  MetricUnit,
+  StoredMetric,
+  StoredMetrics,
+} from './types/index.js';
+
+/**
+ * Manages storage of metrics with automatic context detection.
+ *
+ * This class abstracts the storage mechanism for metrics, automatically
+ * choosing between AsyncLocalStorage (when in async context) and a fallback
+ * object (when outside async context). The decision is made at runtime on
+ * every method call to support Lambda's transition to async contexts.
+ */
+class MetricsStore {
+  readonly #storedMetricsKey = Symbol('powertools.metrics.storedMetrics');
+  readonly #timestampKey = Symbol('powertools.metrics.timestamp');
+
+  #fallbackStorage: StoredMetrics = {};
+  #fallbackTimestamp?: number;
+
+  #getStorage(): StoredMetrics {
+    if (InvokeStore.getContext() === undefined) {
+      return this.#fallbackStorage;
+    }
+
+    let stored = InvokeStore.get(this.#storedMetricsKey) as
+      | StoredMetrics
+      | undefined;
+    if (stored == null) {
+      stored = {};
+      InvokeStore.set(this.#storedMetricsKey, stored);
+    }
+    return stored;
+  }
+
+  public getMetric(name: string): StoredMetric | undefined {
+    return this.#getStorage()[name];
+  }
+
+  /**
+   * Adds a metric value to storage. If a metric with the same name already exists,
+   * the value is appended to an array. Validates that the unit matches any existing metric.
+   *
+   * @example
+   * ```typescript
+   * store.setMetric('latency', MetricUnit.Milliseconds, 100);
+   * // Returns: { name: 'latency', unit: 'Milliseconds', value: 100, resolution: 60 }
+   *
+   * store.setMetric('latency', MetricUnit.Milliseconds, 150);
+   * // Returns: { name: 'latency', unit: 'Milliseconds', value: [100, 150], resolution: 60 }
+   * ```
+   *
+   * @param name - The metric name
+   * @param unit - The metric unit (must match existing metric if present)
+   * @param value - The metric value to add
+   * @param resolution - The metric resolution (defaults to Standard)
+   * @returns The stored metric with updated values
+   * @throws Error if unit doesn't match existing metric
+   */
+  public setMetric(
+    name: string,
+    unit: MetricUnit,
+    value: number,
+    resolution: MetricResolution = MetricResolutions.Standard
+  ): StoredMetric {
+    const storage = this.#getStorage();
+    const existingMetric = storage[name];
+
+    if (existingMetric === undefined) {
+      const newMetric: StoredMetric = {
+        name,
+        unit,
+        value,
+        resolution,
+      };
+      storage[name] = newMetric;
+      return { ...newMetric };
+    }
+
+    if (existingMetric.unit !== unit) {
+      const currentUnit = existingMetric.unit;
+      throw new Error(
+        `Metric "${name}" has already been added with unit "${currentUnit}", but we received unit "${unit}". Did you mean to use metric unit "${currentUnit}"?`
+      );
+    }
+
+    if (!Array.isArray(existingMetric.value)) {
+      existingMetric.value = [existingMetric.value];
+    }
+    existingMetric.value.push(value);
+    return { ...existingMetric, value: [...existingMetric.value] };
+  }
+
+  public getMetricNames(): string[] {
+    return Object.keys(this.#getStorage());
+  }
+
+  public getAllMetrics(): StoredMetric[] {
+    return Object.values(this.#getStorage());
+  }
+
+  public clearMetrics(): void {
+    if (InvokeStore.getContext() === undefined) {
+      this.#fallbackStorage = {};
+      this.#fallbackTimestamp = undefined;
+      return;
+    }
+
+    InvokeStore.set(this.#storedMetricsKey, {});
+    InvokeStore.set(this.#timestampKey, undefined);
+  }
+
+  public hasMetrics(): boolean {
+    return this.getMetricNames().length > 0;
+  }
+
+  public getMetricsCount(): number {
+    return this.getMetricNames().length;
+  }
+
+  public getTimestamp(): number | undefined {
+    if (InvokeStore.getContext() === undefined) {
+      return this.#fallbackTimestamp;
+    }
+
+    return InvokeStore.get(this.#timestampKey) as number | undefined;
+  }
+
+  public setTimestamp(timestamp: number | Date): number {
+    const timestampMs = this.#convertTimestampToEmfFormat(timestamp);
+
+    if (InvokeStore.getContext() === undefined) {
+      this.#fallbackTimestamp = timestampMs;
+      return timestampMs;
+    }
+
+    InvokeStore.set(this.#timestampKey, timestampMs);
+    return timestampMs;
+  }
+
+  #convertTimestampToEmfFormat(timestamp: number | Date): number {
+    if (isIntegerNumber(timestamp)) {
+      return timestamp;
+    }
+    if (timestamp instanceof Date) {
+      return timestamp.getTime();
+    }
+    return 0;
+  }
+}
+
+export { MetricsStore };

--- a/packages/metrics/tests/unit/concurrency/dimensionsStore.test.ts
+++ b/packages/metrics/tests/unit/concurrency/dimensionsStore.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DimensionsStore } from '../../../src/DimensionsStore.js';
+import { sequence } from '../helpers.js';
+
+describe('DimensionsStore concurrent invocation isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: { env: 'dev' },
+      expectedResult2: { env: 'dev' },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: { env: 'prod' },
+      expectedResult2: { env: 'dev' },
+    },
+  ])(
+    'handles storing dimensions $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new DimensionsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [() => store.addDimension('env', 'prod')],
+          return: () => store.getDimensions(),
+        },
+        {
+          sideEffects: [() => store.addDimension('env', 'dev')],
+          return: () => store.getDimensions(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: [
+        { service: 'api', version: '1.0' },
+        { service: 'web', version: '2.0' },
+      ],
+      expectedResult2: [
+        { service: 'api', version: '1.0' },
+        { service: 'web', version: '2.0' },
+      ],
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: [{ service: 'api', version: '1.0' }],
+      expectedResult2: [{ service: 'web', version: '2.0' }],
+    },
+  ])(
+    'handles storing dimension sets $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new DimensionsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => store.addDimensionSet({ service: 'api', version: '1.0' }),
+          ],
+          return: () => store.getDimensionSets(),
+        },
+        {
+          sideEffects: [
+            () => store.addDimensionSet({ service: 'web', version: '2.0' }),
+          ],
+          return: () => store.getDimensionSets(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: { dims: {}, sets: [] },
+      expectedResult2: { dims: {}, sets: [] },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: { dims: {}, sets: [] },
+      expectedResult2: {
+        dims: { region: 'us-east-1' },
+        sets: [{ version: '2.0' }],
+      },
+    },
+  ])(
+    'handles clearing the store $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new DimensionsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => {
+              store.addDimension('env', 'prod');
+              store.addDimensionSet({ service: 'api' });
+            },
+            () => {}, // Wait for inv2 to add
+            () => store.clearRequestDimensions(),
+          ],
+          return: () => ({
+            dims: store.getDimensions(),
+            sets: store.getDimensionSets(),
+          }),
+        },
+        {
+          sideEffects: [
+            () => {}, // Wait for inv1 to add
+            () => {
+              store.addDimension('region', 'us-east-1');
+              store.addDimensionSet({ version: '2.0' });
+            },
+            () => {}, // Wait for clear
+          ],
+          return: () => ({
+            dims: store.getDimensions(),
+            sets: store.getDimensionSets(),
+          }),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+});

--- a/packages/metrics/tests/unit/concurrency/metadataStore.test.ts
+++ b/packages/metrics/tests/unit/concurrency/metadataStore.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetadataStore } from '../../../src/MetadataStore.js';
+import { sequence } from '../helpers.js';
+
+describe('MetadataStore concurrent invocation isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: { env: 'dev' },
+      expectedResult2: { env: 'dev' },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: { env: 'prod' },
+      expectedResult2: { env: 'dev' },
+    },
+  ])(
+    'handles storing metadata $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetadataStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [() => store.set('env', 'prod')],
+          return: () => store.getAll(),
+        },
+        {
+          sideEffects: [() => store.set('env', 'dev')],
+          return: () => store.getAll(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: { service: 'web', version: '1.0', region: 'us-east-1' },
+      expectedResult2: { service: 'web', version: '1.0', region: 'us-east-1' },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: { service: 'api', version: '1.0' },
+      expectedResult2: { service: 'web', region: 'us-east-1' },
+    },
+  ])(
+    'handles storing multiple metadata keys $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetadataStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => {
+              store.set('service', 'api');
+              store.set('version', '1.0');
+            },
+          ],
+          return: () => store.getAll(),
+        },
+        {
+          sideEffects: [
+            () => {
+              store.set('service', 'web');
+              store.set('region', 'us-east-1');
+            },
+          ],
+          return: () => store.getAll(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: {},
+      expectedResult2: {},
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: {},
+      expectedResult2: { region: 'us-east-1', env: 'prod' },
+    },
+  ])(
+    'handles clearing the store $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetadataStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => {
+              store.set('service', 'api');
+              store.set('version', '1.0');
+            },
+            () => {}, // Wait for inv2 to add
+            () => store.clear(),
+          ],
+          return: () => store.getAll(),
+        },
+        {
+          sideEffects: [
+            () => {}, // Wait for inv1 to add
+            () => {
+              store.set('region', 'us-east-1');
+              store.set('env', 'prod');
+            },
+            () => {}, // Wait for clear
+          ],
+          return: () => store.getAll(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: { key: 'value3' },
+      expectedResult2: { key: 'value3' },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: { key: 'value3' },
+      expectedResult2: { key: 'value2' },
+    },
+  ])(
+    'handles overwriting same key $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetadataStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => store.set('key', 'value1'),
+            () => {}, // Wait for inv2
+            () => store.set('key', 'value3'),
+          ],
+          return: () => store.getAll(),
+        },
+        {
+          sideEffects: [
+            () => {}, // Wait for inv1
+            () => store.set('key', 'value2'),
+            () => {}, // Wait for inv1's final write
+          ],
+          return: () => store.getAll(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+});

--- a/packages/metrics/tests/unit/concurrency/metrics.test.ts
+++ b/packages/metrics/tests/unit/concurrency/metrics.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Metrics, MetricUnit } from '../../../src/index.js';
+import { sequence } from '../helpers.js';
+
+describe('Metrics concurrent invocation isolation', () => {
+  beforeEach(() => {
+    vi.stubEnv('POWERTOOLS_DEV', 'true');
+    vi.stubEnv('POWERTOOLS_METRICS_DISABLED', 'false');
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedCallCount: 1,
+      expectedOutputs: [
+        {
+          env: 'dev',
+          key: 'value2',
+          count: [1, 2],
+        },
+      ],
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedCallCount: 2,
+      expectedOutputs: [
+        { env: 'prod', key: 'value1', count: 1 },
+        { env: 'dev', key: 'value2', count: 2 },
+      ],
+    },
+  ])(
+    'handles metrics, metadata, and dimensions $description',
+    async ({ useInvokeStore, expectedCallCount, expectedOutputs }) => {
+      const metrics = new Metrics({ singleMetric: false });
+
+      await sequence(
+        {
+          sideEffects: [
+            () => {
+              metrics.addDimension('env', 'prod');
+              metrics.addMetric('count', MetricUnit.Count, 1);
+              metrics.addMetadata('key', 'value1');
+            },
+          ],
+          return: () => metrics.publishStoredMetrics(),
+        },
+        {
+          sideEffects: [
+            () => {
+              metrics.addDimension('env', 'dev');
+              metrics.addMetric('count', MetricUnit.Count, 2);
+              metrics.addMetadata('key', 'value2');
+            },
+          ],
+          return: () => metrics.publishStoredMetrics(),
+        },
+        { useInvokeStore }
+      );
+
+      expect(console.log).toHaveBeenCalledTimes(expectedCallCount);
+      for (const expectedOutput of expectedOutputs) {
+        expect(console.log).toHaveEmittedEMFWith(
+          expect.objectContaining(expectedOutput)
+        );
+      }
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedCallCount: 1,
+      expectedOutputs: [
+        {
+          _aws: expect.objectContaining({ Timestamp: 2000 }),
+          count: [1, 2],
+        },
+      ],
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedCallCount: 2,
+      expectedOutputs: [
+        { _aws: expect.objectContaining({ Timestamp: 1000 }), count: 1 },
+        { _aws: expect.objectContaining({ Timestamp: 2000 }), count: 2 },
+      ],
+    },
+  ])(
+    'handles timestamps $description',
+    async ({ useInvokeStore, expectedCallCount, expectedOutputs }) => {
+      const metrics = new Metrics({ singleMetric: false });
+      const timestamp1 = 1000;
+      const timestamp2 = 2000;
+
+      await sequence(
+        {
+          sideEffects: [
+            () => {
+              metrics.setTimestamp(timestamp1);
+              metrics.addMetric('count', MetricUnit.Count, 1);
+            },
+            () => {},
+            () => metrics.publishStoredMetrics(),
+          ],
+          return: () => {},
+        },
+        {
+          sideEffects: [
+            () => {},
+            () => {
+              metrics.setTimestamp(timestamp2);
+              metrics.addMetric('count', MetricUnit.Count, 2);
+            },
+            () => metrics.publishStoredMetrics(),
+          ],
+          return: () => {},
+        },
+        { useInvokeStore }
+      );
+
+      expect(console.log).toHaveBeenCalledTimes(expectedCallCount);
+      for (const expectedOutput of expectedOutputs) {
+        expect(console.log).toHaveEmittedEMFWith(
+          expect.objectContaining(expectedOutput)
+        );
+      }
+    }
+  );
+});

--- a/packages/metrics/tests/unit/concurrency/metricsStore.test.ts
+++ b/packages/metrics/tests/unit/concurrency/metricsStore.test.ts
@@ -1,0 +1,319 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MetricUnit } from '../../../src/index.js';
+import { MetricsStore } from '../../../src/MetricsStore.js';
+import type { StoredMetric } from '../../../src/types/index.js';
+import { sequence } from '../helpers.js';
+
+describe('MetricsStore concurrent invocation isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: {
+        name: 'count',
+        unit: MetricUnit.Count,
+        value: [1, 2],
+        resolution: 60,
+      },
+      expectedResult2: {
+        name: 'count',
+        unit: MetricUnit.Count,
+        value: [1, 2],
+        resolution: 60,
+      },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: {
+        name: 'count',
+        unit: MetricUnit.Count,
+        value: 1,
+        resolution: 60,
+      },
+      expectedResult2: {
+        name: 'count',
+        unit: MetricUnit.Count,
+        value: 2,
+        resolution: 60,
+      },
+    },
+  ])(
+    'getMetric() $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetricsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => store.setMetric('count', MetricUnit.Count, 1, 60),
+          ],
+          return: () => store.getMetric('count'),
+        },
+        {
+          sideEffects: [
+            () => store.setMetric('count', MetricUnit.Count, 2, 60),
+          ],
+          return: () => store.getMetric('count'),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  const countMetric: StoredMetric = {
+    name: 'count',
+    unit: MetricUnit.Count,
+    value: 1,
+    resolution: 60,
+  };
+  const latencyMetric: StoredMetric = {
+    name: 'latency',
+    unit: MetricUnit.Milliseconds,
+    value: 100,
+    resolution: 60,
+  };
+  const errorMetric: StoredMetric = {
+    name: 'errors',
+    unit: MetricUnit.Count,
+    value: 1,
+    resolution: 60,
+  };
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: [countMetric, latencyMetric, errorMetric],
+      expectedResult2: [countMetric, latencyMetric, errorMetric],
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: [countMetric, latencyMetric],
+      expectedResult2: [errorMetric],
+    },
+  ])(
+    'getAllMetrics() $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetricsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => {
+              store.setMetric('count', MetricUnit.Count, 1, 60);
+              store.setMetric('latency', MetricUnit.Milliseconds, 100, 60);
+            },
+          ],
+          return: () => store.getAllMetrics(),
+        },
+        {
+          sideEffects: [
+            () => {
+              store.setMetric('errors', MetricUnit.Count, 1, 60);
+            },
+          ],
+          return: () => store.getAllMetrics(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: 2000,
+      expectedResult2: 2000,
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: 1000,
+      expectedResult2: 2000,
+    },
+  ])(
+    'timestamp $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetricsStore();
+      const timestamp1 = 1000;
+      const timestamp2 = 2000;
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [() => store.setTimestamp(timestamp1)],
+          return: () => store.getTimestamp(),
+        },
+        {
+          sideEffects: [() => store.setTimestamp(timestamp2)],
+          return: () => store.getTimestamp(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toBe(expectedResult1);
+      expect(result2).toBe(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: { metrics: [], timestamp: undefined },
+      expectedResult2: { metrics: [], timestamp: undefined },
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: { metrics: [], timestamp: undefined },
+      expectedResult2: { metrics: [errorMetric], timestamp: 2000 },
+    },
+  ])(
+    'clearMetrics() $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetricsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => {
+              store.setMetric('count', MetricUnit.Count, 1, 60);
+              store.setTimestamp(1000);
+            },
+            () => {}, // Wait for inv2 to add
+            () => store.clearMetrics(),
+          ],
+          return: () => ({
+            metrics: store.getAllMetrics(),
+            timestamp: store.getTimestamp(),
+          }),
+        },
+        {
+          sideEffects: [
+            () => {}, // Wait for inv1 to add
+            () => {
+              store.setMetric('errors', MetricUnit.Count, 1, 60);
+              store.setTimestamp(2000);
+            },
+            () => {}, // Wait for clear
+          ],
+          return: () => ({
+            metrics: store.getAllMetrics(),
+            timestamp: store.getTimestamp(),
+          }),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toEqual(expectedResult1);
+      expect(result2).toEqual(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: true,
+      expectedResult2: true,
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: true,
+      expectedResult2: false,
+    },
+  ])(
+    'hasMetrics() $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetricsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => store.setMetric('count', MetricUnit.Count, 1, 60),
+          ],
+          return: () => store.hasMetrics(),
+        },
+        {
+          sideEffects: [() => {}], // No-op
+          return: () => store.hasMetrics(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toBe(expectedResult1);
+      expect(result2).toBe(expectedResult2);
+    }
+  );
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedResult1: 2,
+      expectedResult2: 2,
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedResult1: 1,
+      expectedResult2: 1,
+    },
+  ])(
+    'getMetricsCount() $description',
+    async ({ useInvokeStore, expectedResult1, expectedResult2 }) => {
+      // Prepare
+      const store = new MetricsStore();
+
+      // Act
+      const [result1, result2] = await sequence(
+        {
+          sideEffects: [
+            () => store.setMetric('count', MetricUnit.Count, 1, 60),
+          ],
+          return: () => store.getMetricsCount(),
+        },
+        {
+          sideEffects: [
+            () => store.setMetric('errors', MetricUnit.Count, 1, 60),
+          ],
+          return: () => store.getMetricsCount(),
+        },
+        { useInvokeStore }
+      );
+
+      // Assess
+      expect(result1).toBe(expectedResult1);
+      expect(result2).toBe(expectedResult2);
+    }
+  );
+});

--- a/packages/metrics/tests/unit/helpers.ts
+++ b/packages/metrics/tests/unit/helpers.ts
@@ -1,0 +1,134 @@
+import { InvokeStore } from '@aws/lambda-invoke-store';
+
+type Invocation = {
+  sideEffects: (() => void)[];
+  return: () => unknown;
+};
+
+/**
+ * Creates a Promise with externally accessible resolve and reject functions.
+ *
+ * This is a polyfill for the proposed Promise.withResolvers() method that provides
+ * a more convenient way to create promises that can be resolved or rejected from
+ * outside the Promise constructor.
+ *
+ * We need this polyfill because this function is not available in Node 20. When we drop
+ * support for this version of Node, then we should remove this function and use the
+ * inbuilt `Promise.withResolvers` static methods.
+ *
+ * @returns Object containing the promise and its resolve/reject functions
+ *
+ * @example
+ * ```typescript
+ * const { promise, resolve, reject } = withResolvers<string>();
+ *
+ * // Later, from somewhere else:
+ * resolve('success');
+ *
+ * // Or:
+ * reject(new Error('failed'));
+ * ```
+ */
+const withResolvers = <T>() => {
+  let resolve: (value: T) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+/**
+ * Executes two invocations concurrently with synchronized side effects to test isolation behavior.
+ *
+ * This function ensures that side effects are executed in a specific order across both
+ * invocations using barrier synchronization. Each step waits for the corresponding step
+ * in the other invocation to complete before proceeding to the next step.
+ *
+ * @param inv1 - First invocation configuration
+ * @param inv1.sideEffects - Array of functions to execute sequentially, synchronized with inv2
+ * @param inv1.return - Function to call after all side effects, returns the test result
+ * @param inv2 - Second invocation configuration
+ * @param inv2.sideEffects - Array of functions to execute sequentially, synchronized with inv1
+ * @param inv2.return - Function to call after all side effects, returns the test result
+ * @param options - Execution options
+ * @param options.useInvokeStore - Whether to run invocations in separate InvokeStore contexts
+ *   - `true`: Each invocation runs in its own InvokeStore.run() context (isolated)
+ *   - `false`: Both invocations run in shared context (no isolation)
+ *
+ * @returns Promise that resolves to tuple of [inv1Result, inv2Result]
+ *
+ * @example
+ * ```typescript
+ * // Basic 2-step sequencing: inv1 acts, then inv2 acts
+ * const [result1, result2] = await sequence({
+ *   sideEffects: [() => doSomething('A')],
+ *   return: () => getResult()
+ * }, {
+ *   sideEffects: [() => doSomething('B')],
+ *   return: () => getResult()
+ * }, { useInvokeStore: true });
+ *
+ * // Execution order: inv1 doSomething('A') → inv2 doSomething('B') → both return
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Complex 3-step sequencing with barriers
+ * const [result1, result2] = await sequence({
+ *   sideEffects: [
+ *     () => action1(),     // Step 1: inv1 acts first
+ *     () => {},            // Step 2: inv1 waits for inv2
+ *     () => action3()      // Step 3: inv1 acts after inv2
+ *   ],
+ *   return: () => getResult()
+ * }, {
+ *   sideEffects: [
+ *     () => {},            // Step 1: inv2 waits for inv1
+ *     () => action2(),     // Step 2: inv2 acts after inv1
+ *     () => {}             // Step 3: inv2 waits for inv1
+ *   ],
+ *   return: () => getResult()
+ * }, { useInvokeStore: false });
+ *
+ * // Execution order: action1() → action2() → action3() → both return
+ * ```
+ */
+function sequence(
+  inv1: Invocation,
+  inv2: Invocation,
+  options: { useInvokeStore?: boolean }
+) {
+  const executionEnv = options?.useInvokeStore
+    ? (f: () => unknown) => InvokeStore.run({}, f)
+    : (f: () => unknown) => f();
+
+  const inv1Barriers = inv1.sideEffects.map(() => withResolvers<void>());
+  const inv2Barriers = inv2.sideEffects.map(() => withResolvers<void>());
+
+  const invocation1 = executionEnv(async () => {
+    for (let i = 0; i < inv1Barriers.length; i++) {
+      const sideEffect = inv1.sideEffects[i] ?? (() => {});
+      sideEffect();
+      inv1Barriers[i].resolve();
+      await inv2Barriers[i].promise;
+    }
+    return inv1.return();
+  });
+
+  const invocation2 = executionEnv(async () => {
+    for (let i = 0; i < inv2Barriers.length; i++) {
+      await inv1Barriers[i].promise;
+      const sideEffect = inv2.sideEffects[i] ?? (() => {});
+      sideEffect();
+      inv2Barriers[i].resolve();
+    }
+    return inv2.return();
+  });
+
+  return Promise.all([invocation1, invocation2]);
+}
+
+export { withResolvers, sequence };
+export type { Invocation };


### PR DESCRIPTION
## Summary

Last week we had to revert several PRs due to an issue with the InvokeStore [module](https://www.npmjs.com/package/@aws/lambda-invoke-store). This module has now been patched.

This PR re-introduces support for using an async context in the Metrics utility. This allows users to emit metrics that are isolated specifically to the current lambda invocation, isolated from any other executions.

### Changes

- Added specific storage classes for metrics, metadata and dimensions:
  - `MetricsStore`
  - `MetadataStore`
  - `DimensionStore`
- The `Metrics` class only accesses the data in these stores through this interface and never touches the stored objects directly.
- These storage classes check whether they are running in the `InvokeStore` context: if they are then the metrics are stored in the current async context, otherwise we fallback to a plain instance wide object as per the current implementation.
- The storage class handle converting the data into the correct format now rather than the `Metrics` class, e.g., `setMetric` will check if the metric already exists and handle converting values into an array if the metric is already there. Likewise with setting timestamps.
- Added specific concurrency tests to ensure isolation is working as intended for all three stores and the `Metrics` class as a whole.

**Issue number:** closes #4662

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
