### PR TITLE
fix(logger): infinite loop on log buffer when item size is max bytes

### DIFF
--- a/packages/logger/src/logBuffer.ts
+++ b/packages/logger/src/logBuffer.ts
@@ -110,8 +110,12 @@ export class CircularMap<V> extends Map<string, SizedSet<V>> {
 
     const buffer = this.get(key) || new SizedSet<V>();
 
-    if (buffer.currentBytesSize + item.byteSize >= this.#maxBytesSize) {
+    if (
+      buffer.currentBytesSize !== 0 &&
+      buffer.currentBytesSize + item.byteSize >= this.#maxBytesSize
+    ) {
       this.#deleteFromBufferUntilSizeIsLessThanMax(buffer, item);
+
       if (this.#onBufferOverflow) {
         this.#onBufferOverflow();
       }
@@ -132,7 +136,10 @@ export class CircularMap<V> extends Map<string, SizedSet<V>> {
     buffer: SizedSet<V>,
     item: SizedItem<V>
   ) {
-    while (buffer.currentBytesSize + item.byteSize >= this.#maxBytesSize) {
+    while (
+      buffer.size !== 0 &&
+      buffer.currentBytesSize + item.byteSize >= this.#maxBytesSize
+    ) {
       buffer.shift();
       buffer.hasEvictedLog = true;
     }


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

This PR fixes a bug where an infinite loop occurs when a new buffered log's byte size is equal to the maxBytes size (`logBufferOptions.maxBytes`) specified while log buffering is enabled (`logBufferOptions.enabled = true`).

See issue for more details.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4737

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
