### PR TITLE
feat(event-handler): expose response streaming in public API

### DIFF
--- a/packages/event-handler/src/rest/index.ts
+++ b/packages/event-handler/src/rest/index.ts
@@ -25,4 +25,5 @@ export {
   isAPIGatewayProxyEventV2,
   isExtendedAPIGatewayProxyResult,
   isHttpMethod,
+  streamify,
 } from './utils.js';

--- a/packages/event-handler/tests/unit/rest/helpers.ts
+++ b/packages/event-handler/tests/unit/rest/helpers.ts
@@ -149,25 +149,6 @@ export class MockResponseStream extends HttpResponseStream {
   }
 }
 
-// Helper to parse streaming response format
-export function parseStreamOutput(chunks: Buffer[]) {
-  const output = Buffer.concat(chunks);
-  const nullBytes = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
-  const separatorIndex = output.indexOf(nullBytes);
-
-  if (separatorIndex === -1) {
-    return { prelude: null, body: output.toString() };
-  }
-
-  const preludeBuffer = output.subarray(0, separatorIndex);
-  const bodyBuffer = output.subarray(separatorIndex + 8);
-
-  return {
-    prelude: JSON.parse(preludeBuffer.toString()),
-    body: bodyBuffer.toString(),
-  };
-}
-
 // Create a handler function from the Router instance
 export const createHandler = (app: Router) => {
   function handler(
@@ -207,12 +188,6 @@ export const createHandlerWithScope = (app: Router, scope: unknown) => {
   }
   return handler;
 };
-
-// Create a stream handler function from the Router instance with a custom scope
-export const createStreamHandler =
-  (app: Router, scope: unknown) =>
-  (event: unknown, _context: Context, responseStream: MockResponseStream) =>
-    app.resolveStream(event, _context, { scope, responseStream });
 
 // Create a test Lambda class with all HTTP method decorators
 export const createTestLambdaClass = (


### PR DESCRIPTION
## Summary
This PR adds streaming functionality to the public API. Streaming is now used like so:

```ts
import {Router, streamify} from '@aws-lambda-powertools/event-handler/experimental-rest';

const app = new Router();

app.get('/event', async ({event}) => {
  return Readable.from(Buffer.from(JSON.stringify(event)))
});

export const handler = streamify(app)
```

### Changes

- Created `streamify` function that turns a `Router` instance into a handler that can return streaming responses.
- Create a fallback `streamifyHandler` function that is used when `streamify` is used in non-lambda environments, which is useful for unit tests.

#### Testing
- Moved the logic from `parseStreamOutput` used by the tests to the fallback `streamifyHandler` function.
- Updated all the unit tests to use the `streamify` function rather than `app.resolveStream`.
- Tested in a ambda with a streaming function URL set up.

**Issue number:** closes #4726 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
