### PR TITLE
test(maintenance): remove unnecessary esbuild banner from e2e tests 

### DIFF
--- a/packages/testing/src/resources/TestNodejsFunction.ts
+++ b/packages/testing/src/resources/TestNodejsFunction.ts
@@ -24,6 +24,7 @@ class TestNodejsFunction extends NodejsFunction {
     extraProps: ExtraTestProps
   ) {
     const isESM = extraProps.outputFormat === 'ESM';
+    const { shouldPolyfillRequire = false } = extraProps;
     const { bundling, ...restProps } = props;
     const functionName = concatenateResourceName({
       testName: stack.testName,
@@ -45,7 +46,7 @@ class TestNodejsFunction extends NodejsFunction {
         mainFields: isESM ? ['module', 'main'] : ['main', 'module'],
         sourceMap: false,
         format: isESM ? OutputFormat.ESM : OutputFormat.CJS,
-        banner: isESM
+        banner: shouldPolyfillRequire
           ? `import { createRequire } from 'module';const require = createRequire(import.meta.url);`
           : '',
       },

--- a/packages/testing/src/types.ts
+++ b/packages/testing/src/types.ts
@@ -20,6 +20,13 @@ interface ExtraTestProps {
    */
   outputFormat?: 'CJS' | 'ESM';
   /**
+   * Determines whether to polyfil the `require` function, this is useful when the bundler
+   * output is ESM and you are using a package that only ships ESM
+   *
+   * @default 'false'
+   */
+  shouldPolyfillRequire?: boolean;
+  /**
    * Whether to create an alias for the function.
    *
    * @default false

--- a/packages/tracer/tests/e2e/decorator.test.ts
+++ b/packages/tracer/tests/e2e/decorator.test.ts
@@ -17,159 +17,171 @@ import {
   RESOURCE_NAME_PREFIX,
 } from './constants.js';
 
-describe('Tracer E2E tests, decorator instrumentation', () => {
-  const testStack = new TestStack({
-    stackNameProps: {
-      stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'Decorator',
-    },
-  });
-
-  // Location of the lambda function code
-  const lambdaFunctionCodeFilePath = join(
-    __dirname,
-    'decorator.test.functionCode.ts'
-  );
-  const startTime = new Date();
-
-  const testTable = new TestDynamodbTable(
-    testStack,
-    {},
-    {
-      nameSuffix: 'TestTable',
-    }
-  );
-
-  const fnDecorator = new TestNodejsFunction(
-    testStack,
-    {
-      entry: lambdaFunctionCodeFilePath,
-      environment: {
-        TEST_TABLE_NAME: testTable.tableName,
-        POWERTOOLS_SERVICE_NAME: 'Decorator',
-      },
-    },
-    {
-      nameSuffix: 'Decorator',
-    }
-  );
-  testTable.grantWriteData(fnDecorator);
-
-  const invocationCount = 2;
-  let traceData: EnrichedXRayTraceDocumentParsed[] = [];
-
-  beforeAll(async () => {
-    // Deploy the stack
-    await testStack.deploy();
-
-    // Get the actual function names from the stack outputs
-    const fnNameDecorator = testStack.findAndGetStackOutputValue('Decorator');
-
-    // Act
-    await invokeAllTestCases(fnNameDecorator, invocationCount);
-    traceData = await getTraces({
-      startTime,
-      resourceName: fnNameDecorator,
-      expectedTracesCount: invocationCount,
-      /**
-       * The trace should have 4 segments:
-       * 1. Lambda Context (AWS::Lambda)
-       * 2. Lambda Function (AWS::Lambda::Function)
-       * 4. DynamoDB (AWS::DynamoDB)
-       * 4. Remote call (docs.aws.amazon.com)
-       */
-      expectedSegmentsCount: 4,
-    });
-  });
-
-  afterAll(async () => {
-    if (!process.env.DISABLE_TEARDOWN) {
-      await testStack.destroy();
-    }
-  });
-
-  it('should generate all trace data correctly', () => {
-    // Assess
-    const mainSubsegment = traceData[0];
-    const { subsegments, annotations, metadata } = mainSubsegment;
-
-    // Check the main segment name
-    expect(mainSubsegment.name).toBe('## index.handler');
-
-    // Check the subsegments of the main segment
-    expect(subsegments.size).toBe(3);
-
-    // Check remote call subsegment
-    expect(subsegments.has('docs.aws.amazon.com')).toBe(true);
-    const httpSubsegment = subsegments.get('docs.aws.amazon.com');
-    expect(httpSubsegment?.namespace).toBe('remote');
-    expect(httpSubsegment?.http?.request?.url).toEqual(
-      'https://docs.aws.amazon.com/powertools/typescript/latest/'
-    );
-    expect(httpSubsegment?.http?.request?.method).toBe('GET');
-    expect(httpSubsegment?.http?.response?.status).toEqual(expect.any(Number));
-    expect(httpSubsegment?.http?.response?.status).toEqual(expect.any(Number));
-
-    // Check the custom subsegment name & metadata
-    expect(subsegments.has(expectedCustomSubSegmentName)).toBe(true);
-    expect(
-      subsegments.get(expectedCustomSubSegmentName)?.metadata
-    ).toStrictEqual({
-      Decorator: {
-        'myMethod response': expectedCustomResponseValue,
+describe.each([
+  { outputFormat: 'CJS' as const },
+  { outputFormat: 'ESM' as const },
+])(
+  'Tracer E2E tests, decorator instrumentation ($outputFormat)',
+  ({ outputFormat }) => {
+    const testStack = new TestStack({
+      stackNameProps: {
+        stackNamePrefix: RESOURCE_NAME_PREFIX,
+        testName: `Decorator${outputFormat}`,
       },
     });
 
-    // Check the other custom subsegment and its subsegments
-    expect(subsegments.has('### methodNoResponse')).toBe(true);
-    expect(subsegments.get('### methodNoResponse')?.metadata).toBeUndefined();
-    expect(subsegments.get('### methodNoResponse')?.subsegments?.length).toBe(
-      1
+    // Location of the lambda function code
+    const lambdaFunctionCodeFilePath = join(
+      __dirname,
+      'decorator.test.functionCode.ts'
     );
-    expect(
-      subsegments.get('### methodNoResponse')?.subsegments?.[0]?.name ===
-        'DynamoDB'
-    ).toBe(true);
+    const startTime = new Date();
 
-    // Check the annotations of the main segment
-    if (!annotations) {
-      throw new Error('No annotations found on the main segment');
-    }
-    expect(annotations.ColdStart).toEqual(true);
-    expect(annotations.Service).toEqual('Decorator');
-    expect(annotations[expectedCustomAnnotationKey]).toEqual(
-      expectedCustomAnnotationValue
+    const testTable = new TestDynamodbTable(
+      testStack,
+      {},
+      {
+        nameSuffix: 'TestTable',
+      }
     );
 
-    // Check the metadata of the main segment
-    if (!metadata) {
-      throw new Error('No metadata found on the main segment');
-    }
-    expect(metadata.Decorator[expectedCustomMetadataKey]).toEqual(
-      expectedCustomMetadataValue
+    const fnDecorator = new TestNodejsFunction(
+      testStack,
+      {
+        entry: lambdaFunctionCodeFilePath,
+        environment: {
+          TEST_TABLE_NAME: testTable.tableName,
+          POWERTOOLS_SERVICE_NAME: 'Decorator',
+        },
+      },
+      {
+        nameSuffix: 'Decorator',
+        outputFormat,
+        shouldPolyfillRequire: outputFormat === 'ESM',
+      }
     );
+    testTable.grantWriteData(fnDecorator);
 
-    // Check the response is present in the metadata
-    expect(metadata.Decorator['index.handler response']).toEqual(
-      expectedCustomResponseValue
-    );
-  });
+    const invocationCount = 2;
+    let traceData: EnrichedXRayTraceDocumentParsed[] = [];
 
-  it('should annotate the trace with error data correctly', () => {
-    const mainSubsegment = traceData[1];
-    const { annotations } = mainSubsegment;
+    beforeAll(async () => {
+      // Deploy the stack
+      await testStack.deploy();
 
-    // Check the annotations of the main segment
-    if (!annotations) {
-      throw new Error('No annotations found on the main segment');
-    }
-    expect(annotations.ColdStart).toEqual(false);
+      // Get the actual function names from the stack outputs
+      const fnNameDecorator = testStack.findAndGetStackOutputValue('Decorator');
 
-    // Check that the main segment has error data
-    expect(mainSubsegment.fault).toBe(true);
-    expect(Object.hasOwn(mainSubsegment, 'cause')).toBe(true);
-    expect(mainSubsegment.cause?.exceptions[0].message).toBe(
-      expectedCustomErrorMessage
-    );
-  });
-});
+      // Act
+      await invokeAllTestCases(fnNameDecorator, invocationCount);
+      traceData = await getTraces({
+        startTime,
+        resourceName: fnNameDecorator,
+        expectedTracesCount: invocationCount,
+        /**
+         * The trace should have 4 segments:
+         * 1. Lambda Context (AWS::Lambda)
+         * 2. Lambda Function (AWS::Lambda::Function)
+         * 4. DynamoDB (AWS::DynamoDB)
+         * 4. Remote call (docs.aws.amazon.com)
+         */
+        expectedSegmentsCount: 4,
+      });
+    });
+
+    afterAll(async () => {
+      if (!process.env.DISABLE_TEARDOWN) {
+        await testStack.destroy();
+      }
+    });
+
+    it('should generate all trace data correctly', () => {
+      // Assess
+      const mainSubsegment = traceData[0];
+      const { subsegments, annotations, metadata } = mainSubsegment;
+
+      // Check the main segment name
+      expect(mainSubsegment.name).toBe('## index.handler');
+
+      // Check the subsegments of the main segment
+      expect(subsegments.size).toBe(3);
+
+      // Check remote call subsegment
+      expect(subsegments.has('docs.aws.amazon.com')).toBe(true);
+      const httpSubsegment = subsegments.get('docs.aws.amazon.com');
+      expect(httpSubsegment?.namespace).toBe('remote');
+      expect(httpSubsegment?.http?.request?.url).toEqual(
+        'https://docs.aws.amazon.com/powertools/typescript/latest/'
+      );
+      expect(httpSubsegment?.http?.request?.method).toBe('GET');
+      expect(httpSubsegment?.http?.response?.status).toEqual(
+        expect.any(Number)
+      );
+      expect(httpSubsegment?.http?.response?.status).toEqual(
+        expect.any(Number)
+      );
+
+      // Check the custom subsegment name & metadata
+      expect(subsegments.has(expectedCustomSubSegmentName)).toBe(true);
+      expect(
+        subsegments.get(expectedCustomSubSegmentName)?.metadata
+      ).toStrictEqual({
+        Decorator: {
+          'myMethod response': expectedCustomResponseValue,
+        },
+      });
+
+      // Check the other custom subsegment and its subsegments
+      expect(subsegments.has('### methodNoResponse')).toBe(true);
+      expect(subsegments.get('### methodNoResponse')?.metadata).toBeUndefined();
+      expect(subsegments.get('### methodNoResponse')?.subsegments?.length).toBe(
+        1
+      );
+      expect(
+        subsegments.get('### methodNoResponse')?.subsegments?.[0]?.name ===
+          'DynamoDB'
+      ).toBe(true);
+
+      // Check the annotations of the main segment
+      if (!annotations) {
+        throw new Error('No annotations found on the main segment');
+      }
+      expect(annotations.ColdStart).toEqual(true);
+      expect(annotations.Service).toEqual('Decorator');
+      expect(annotations[expectedCustomAnnotationKey]).toEqual(
+        expectedCustomAnnotationValue
+      );
+
+      // Check the metadata of the main segment
+      if (!metadata) {
+        throw new Error('No metadata found on the main segment');
+      }
+      expect(metadata.Decorator[expectedCustomMetadataKey]).toEqual(
+        expectedCustomMetadataValue
+      );
+
+      // Check the response is present in the metadata
+      expect(metadata.Decorator['index.handler response']).toEqual(
+        expectedCustomResponseValue
+      );
+    });
+
+    it('should annotate the trace with error data correctly', () => {
+      const mainSubsegment = traceData[1];
+      const { annotations } = mainSubsegment;
+
+      // Check the annotations of the main segment
+      if (!annotations) {
+        throw new Error('No annotations found on the main segment');
+      }
+      expect(annotations.ColdStart).toEqual(false);
+
+      // Check that the main segment has error data
+      expect(mainSubsegment.fault).toBe(true);
+      expect(Object.hasOwn(mainSubsegment, 'cause')).toBe(true);
+      expect(mainSubsegment.cause?.exceptions[0].message).toBe(
+        expectedCustomErrorMessage
+      );
+    });
+  }
+);

--- a/packages/tracer/tests/e2e/manual.test.ts
+++ b/packages/tracer/tests/e2e/manual.test.ts
@@ -16,125 +16,133 @@ import {
   RESOURCE_NAME_PREFIX,
 } from './constants.js';
 
-describe('Tracer E2E tests, manual instantiation', () => {
-  const testStack = new TestStack({
-    stackNameProps: {
-      stackNamePrefix: RESOURCE_NAME_PREFIX,
-      testName: 'Manual',
-    },
-  });
-
-  // Location of the lambda function code
-  const lambdaFunctionCodeFilePath = join(
-    __dirname,
-    'manual.test.functionCode.ts'
-  );
-  const startTime = new Date();
-
-  const testTable = new TestDynamodbTable(
-    testStack,
-    {},
-    {
-      nameSuffix: 'TestTable',
-    }
-  );
-
-  const fnManual = new TestNodejsFunction(
-    testStack,
-    {
-      entry: lambdaFunctionCodeFilePath,
-      environment: {
-        TEST_TABLE_NAME: testTable.tableName,
-        POWERTOOLS_SERVICE_NAME: 'Manual',
+describe.each([
+  { outputFormat: 'CJS' as const },
+  { outputFormat: 'ESM' as const },
+])(
+  'Tracer E2E tests, manual instantiation ($outputFormat)',
+  ({ outputFormat }) => {
+    const testStack = new TestStack({
+      stackNameProps: {
+        stackNamePrefix: RESOURCE_NAME_PREFIX,
+        testName: `Manual${outputFormat}`,
       },
-    },
-    {
-      nameSuffix: 'Manual',
-    }
-  );
-  testTable.grantWriteData(fnManual);
-
-  const invocationCount = 2;
-  let traceData: EnrichedXRayTraceDocumentParsed[] = [];
-
-  beforeAll(async () => {
-    // Deploy the stack
-    await testStack.deploy();
-
-    // Get the actual function names from the stack outputs
-    const fnNameManual = testStack.findAndGetStackOutputValue('Manual');
-
-    // Invoke all test cases
-    await invokeAllTestCases(fnNameManual, invocationCount);
-    traceData = await getTraces({
-      startTime,
-      resourceName: fnNameManual,
-      expectedTracesCount: invocationCount,
-      /**
-       * The trace should have 2 segments:
-       * 1. Lambda Context (AWS::Lambda)
-       * 2. Lambda Function (AWS::Lambda::Function)
-       */
-      expectedSegmentsCount: 2,
     });
-  });
 
-  afterAll(async () => {
-    if (!process.env.DISABLE_TEARDOWN) {
-      await testStack.destroy();
-    }
-  });
+    // Location of the lambda function code
+    const lambdaFunctionCodeFilePath = join(
+      __dirname,
+      'manual.test.functionCode.ts'
+    );
+    const startTime = new Date();
 
-  it('should generate all trace data correctly', () => {
-    // Assess
-    const mainSubsegment = traceData[0];
-    const { subsegments, annotations, metadata } = mainSubsegment;
-
-    // Check the main segment name
-    expect(mainSubsegment.name).toBe('## index.handler');
-
-    // Since CaptureHTTPsRequests is disabled, we should not have any subsegments
-    expect(subsegments.size).toBe(0);
-
-    // Check the annotations of the main segment
-    if (!annotations) {
-      throw new Error('No annotations found on the main segment');
-    }
-    expect(annotations.ColdStart).toEqual(true);
-    expect(annotations.Service).toEqual('Manual');
-    expect(annotations[expectedCustomAnnotationKey]).toEqual(
-      expectedCustomAnnotationValue
+    const testTable = new TestDynamodbTable(
+      testStack,
+      {},
+      {
+        nameSuffix: 'TestTable',
+      }
     );
 
-    // Check the metadata of the main segment
-    if (!metadata) {
-      throw new Error('No metadata found on the main segment');
-    }
-    expect(metadata.Manual?.[expectedCustomMetadataKey]).toEqual(
-      expectedCustomMetadataValue
+    const fnManual = new TestNodejsFunction(
+      testStack,
+      {
+        entry: lambdaFunctionCodeFilePath,
+        environment: {
+          TEST_TABLE_NAME: testTable.tableName,
+          POWERTOOLS_SERVICE_NAME: 'Manual',
+        },
+      },
+      {
+        nameSuffix: 'Manual',
+        outputFormat,
+        shouldPolyfillRequire: outputFormat === 'ESM',
+      }
     );
+    testTable.grantWriteData(fnManual);
 
-    // Check the response is present in the metadata
-    expect(metadata.Manual?.['index.handler response']).toEqual(
-      expectedCustomResponseValue
-    );
-  });
+    const invocationCount = 2;
+    let traceData: EnrichedXRayTraceDocumentParsed[] = [];
 
-  it('should annotate the trace with error data correctly', () => {
-    const mainSubsegment = traceData[1];
-    const { annotations } = mainSubsegment;
+    beforeAll(async () => {
+      // Deploy the stack
+      await testStack.deploy();
 
-    // Check the annotations of the main segment
-    if (!annotations) {
-      throw new Error('No annotations found on the main segment');
-    }
-    expect(annotations.ColdStart).toEqual(false);
+      // Get the actual function names from the stack outputs
+      const fnNameManual = testStack.findAndGetStackOutputValue('Manual');
 
-    // Check that the main segment has error data
-    expect(mainSubsegment.fault).toBe(true);
-    expect(Object.hasOwn(mainSubsegment, 'cause')).toBe(true);
-    expect(mainSubsegment.cause?.exceptions[0].message).toBe(
-      expectedCustomErrorMessage
-    );
-  });
-});
+      // Invoke all test cases
+      await invokeAllTestCases(fnNameManual, invocationCount);
+      traceData = await getTraces({
+        startTime,
+        resourceName: fnNameManual,
+        expectedTracesCount: invocationCount,
+        /**
+         * The trace should have 2 segments:
+         * 1. Lambda Context (AWS::Lambda)
+         * 2. Lambda Function (AWS::Lambda::Function)
+         */
+        expectedSegmentsCount: 2,
+      });
+    });
+
+    afterAll(async () => {
+      if (!process.env.DISABLE_TEARDOWN) {
+        await testStack.destroy();
+      }
+    });
+
+    it('should generate all trace data correctly', () => {
+      // Assess
+      const mainSubsegment = traceData[0];
+      const { subsegments, annotations, metadata } = mainSubsegment;
+
+      // Check the main segment name
+      expect(mainSubsegment.name).toBe('## index.handler');
+
+      // Since CaptureHTTPsRequests is disabled, we should not have any subsegments
+      expect(subsegments.size).toBe(0);
+
+      // Check the annotations of the main segment
+      if (!annotations) {
+        throw new Error('No annotations found on the main segment');
+      }
+      expect(annotations.ColdStart).toEqual(true);
+      expect(annotations.Service).toEqual('Manual');
+      expect(annotations[expectedCustomAnnotationKey]).toEqual(
+        expectedCustomAnnotationValue
+      );
+
+      // Check the metadata of the main segment
+      if (!metadata) {
+        throw new Error('No metadata found on the main segment');
+      }
+      expect(metadata.Manual?.[expectedCustomMetadataKey]).toEqual(
+        expectedCustomMetadataValue
+      );
+
+      // Check the response is present in the metadata
+      expect(metadata.Manual?.['index.handler response']).toEqual(
+        expectedCustomResponseValue
+      );
+    });
+
+    it('should annotate the trace with error data correctly', () => {
+      const mainSubsegment = traceData[1];
+      const { annotations } = mainSubsegment;
+
+      // Check the annotations of the main segment
+      if (!annotations) {
+        throw new Error('No annotations found on the main segment');
+      }
+      expect(annotations.ColdStart).toEqual(false);
+
+      // Check that the main segment has error data
+      expect(mainSubsegment.fault).toBe(true);
+      expect(Object.hasOwn(mainSubsegment, 'cause')).toBe(true);
+      expect(mainSubsegment.cause?.exceptions[0].message).toBe(
+        expectedCustomErrorMessage
+      );
+    });
+  }
+);

--- a/packages/tracer/tests/e2e/middy.test.ts
+++ b/packages/tracer/tests/e2e/middy.test.ts
@@ -50,6 +50,7 @@ describe('Tracer E2E tests, middy instrumentation', () => {
     {
       nameSuffix: 'Middy',
       outputFormat: 'ESM',
+      shouldPolyfillRequire: true,
     }
   );
   testTable.grantWriteData(fnMiddy);


### PR DESCRIPTION
## Summary
This PR changes the end-to-end tests to remove the ESBuild banner that is added by default. This banner is only needed when we are consuming packages that only ship CommonJS arfifacts and bundling to ESM. For utilities that do not consume packaes like this we should not add this banner as it can lead to inadvertent breaking changes being missed such as: https://github.com/aws-powertools/powertools-lambda-typescript/issues/4677.

### Changes
- Make the addition of the banner an explict parameter in CDK rather than being inferred from whether the package is ESM or not.
- Update the only utility that needs this behaviour (`Tracer`) to run all it's tests in both CJS and ESM.
- Note: The diff looks like more has changed that actually has because using `describe.each` to run the Tracer tests in both ESM and CJS format changed the indentation.

### Testing
- Ran E2E tests successfully: https://github.com/aws-powertools/powertools-lambda-typescript/actions/runs/19367840577

**Issue number:** closes #4715 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
