### PR TITLE
fix: fix China region arn typo

### DIFF
--- a/docs/getting-started/lambda-layers.md
+++ b/docs/getting-started/lambda-layers.md
@@ -53,7 +53,7 @@ We publish the Lambda Layer for Powertools for AWS Lambda in all commercial regi
 | `mx-central-1`   | [arn:aws:lambda:mx-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:41](#){: .copyMe}          |
 | `us-gov-west-1`  | [arn:aws-us-gov:lambda:us-gov-west-1:165093116878:layer:AWSLambdaPowertoolsTypeScriptV2:41](#){: .copyMe}  |
 | `us-gov-east-1`  | [arn:aws-us-gov:lambda:us-gov-east-1:165087284144:layer:AWSLambdaPowertoolsTypeScriptV2:41](#){: .copyMe}  |
-| `cn-north-1`     | [arn:aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:41](#){: .copyMe}     |
+| `cn-north-1`     | [arn:aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:41](#){: .copyMe}         |
 
 ### Lookup Layer ARN via AWS SSM Parameter Store
 


### PR DESCRIPTION
## Summary

### Changes

Change the ARN of China cn-north-1 region, this typo makes our users too confusing, and we want to change it to correct one.

**Current**: arn:aws-aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:41

**Correct**: arn:aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:41

The partition should be **aws-cn** rather than **aws-aws-cn**

**Issue number:**  fix  #4819

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
