### PR TITLE
fix(deps): revert @aws/lambda-invoke-store to dependency

### DIFF
--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -65,7 +65,6 @@
   "types": "./lib/cjs/index.d.ts",
   "main": "./lib/cjs/index.js",
   "devDependencies": {
-    "@aws/lambda-invoke-store": "0.2.1",
     "@aws-lambda-powertools/testing-utils": "file:../testing",
     "@aws-sdk/client-cloudwatch": "^3.939.0",
     "@types/promise-retry": "^1.1.3",
@@ -90,6 +89,7 @@
     "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues"
   },
   "dependencies": {
+    "@aws/lambda-invoke-store": "0.2.1",
     "@aws-lambda-powertools/commons": "2.29.0"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

### Changes

I am receiving the following error when running tests in a project that depends on the metrics package.

```
Error: Cannot find package '@aws/lambda-invoke-store' imported from /workspace/node_modules/.pnpm/@aws-lambda-powertools+metrics@2.29.0_@middy+core@6.4.5/node_modules/@aws-lambda-powertools/metrics/lib/esm/DimensionsStore.js
```

@aws/lambda-invoke-store was changed from a dependency to a devDependency of the metrics package in  #4794 . Multiple packages had the version of this package updated, however the metrics package was the only one that changed it to a devDependency. 

**Issue number:** closes #4787 

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
