### PR TITLE
improv(ci): automated the Gamma/Prod deployment to China/GovCloud regions

### DIFF
--- a/.github/workflows/layers_partitions.yml
+++ b/.github/workflows/layers_partitions.yml
@@ -2,7 +2,7 @@
 # ---
 # This workflow publishes a specific layer version in an AWS account based on the partition input.
 #
-# We pull the version of the layer and store them as artifacts, the we upload them to each of the Partitioned AWS accounts.
+# We pull the version of the layer and store them as artifacts, then we upload them to each of the Partitioned AWS accounts.
 #
 # A number of safety checks are performed to ensure safety.
 #
@@ -112,10 +112,11 @@ jobs:
     with:
       environment: Gamma
       partition: ${{ inputs.partition }}
+      arn_partition: ${{ needs.setup.outputs.partition }}
       regions: ${{ needs.setup.outputs.regions }}
       aud: ${{ needs.setup.outputs.aud }}
     secrets: inherit
-  # Copies the Layer to the Gamma Environment in the selected partition
+  # Copies the Layer to the Prod Environment in the selected partition
   deploy-prod:
     name: Deploy Prod Layer
     needs: [setup, download, deploy-gamma]
@@ -123,6 +124,7 @@ jobs:
     with:
       environment: Prod
       partition: ${{ inputs.partition }}
+      arn_partition: ${{ needs.setup.outputs.partition }}
       regions: ${{ needs.setup.outputs.regions }}
       aud: ${{ needs.setup.outputs.aud }}
     secrets: inherit

--- a/.github/workflows/layers_partitions_deploy.yml
+++ b/.github/workflows/layers_partitions_deploy.yml
@@ -9,6 +9,9 @@ on:
       partition:
         required: true
         type: string
+      arn_partition:
+        required: true
+        type: string
       regions:
         required: true
         type: string
@@ -30,12 +33,12 @@ jobs:
         region: ${{ fromJson(inputs.regions) }}
     steps:
       - name: Download Zip
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: AWSLambdaPowertoolsTypeScriptV2.zip
       
       - name: Download Metadata
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: AWSLambdaPowertoolsTypeScriptV2.json
       
@@ -45,10 +48,11 @@ jobs:
           test "$(openssl dgst -sha256 -binary AWSLambdaPowertoolsTypeScriptV2.zip | openssl enc -base64)" == "$SHA" && echo "SHA OK: ${SHA}" || exit 1
       
       - id: transform
-        run: echo "CONVERTED_REGION=$(echo '${{ matrix.region }}' | tr 'a-z\-' 'A-Z_')" >> "$GITHUB_OUTPUT"
+        run: |
+          echo 'CONVERTED_REGION=${{ matrix.region }}' | tr 'a-z\-' 'A-Z_' >> "$GITHUB_OUTPUT"
       
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708
+        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           role-to-assume: ${{ secrets[format('IAM_ROLE_{0}', steps.transform.outputs.CONVERTED_REGION)] }}
           aws-region: ${{ matrix.region }}
@@ -59,12 +63,13 @@ jobs:
         id: create-layer
         run: |
           set -euo pipefail
-          jq '{"LayerName": "AWSLambdaPowertoolsTypeScriptV2", "Description": .Description, "CompatibleRuntimes": .CompatibleRuntimes, "LicenseInfo": .LicenseInfo}' AWSLambdaPowertoolsTypeScriptV2.json > input.json
+          cat AWSLambdaPowertoolsTypeScriptV2.json | jq '{"LayerName": "AWSLambdaPowertoolsTypeScriptV2", "Description": .Description, "CompatibleRuntimes": .CompatibleRuntimes, "LicenseInfo": .LicenseInfo}' > input.json
           
           LAYER_VERSION=$(aws --region "${{ matrix.region }}" lambda publish-layer-version \
             --zip-file fileb://./AWSLambdaPowertoolsTypeScriptV2.zip \
             --cli-input-json file://./input.json \
-            --query 'Version' --output text)
+            --query 'Version' \
+            --output text)
           
           echo "LAYER_VERSION=$LAYER_VERSION" >> "$GITHUB_OUTPUT"
           
@@ -75,18 +80,21 @@ jobs:
             --principal '*' \
             --version-number "$LAYER_VERSION"
       
+      # This step retrieves the newly deployed layer metadata and compares it against the original source layer:
+      # 1. SHA256 hash verification - ensures the layer content is identical to the source
+      # 2. Description validation - confirms the version number in the description matches the source
+      # 3. Layer Version number verification - validates that the layer version numbers match between source and target
+      # 4. Tabular comparison output - displays side-by-side comparison of key layer properties
       - name: Verify Layer
         env:
           LAYER_VERSION: ${{ steps.create-layer.outputs.LAYER_VERSION }}
           ENVIRONMENT: ${{ inputs.environment }}
-          PARTITION: ${{ inputs.partition }}
+          PARTITION: ${{ inputs.arn_partition }}
         run: |
           set -euo pipefail
-          layer_output="AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}.json"
-          
-          aws --region "${{ matrix.region }}" lambda get-layer-version-by-arn \
-            --arn "arn:${PARTITION}:lambda:${{ matrix.region }}:${{ secrets[format('AWS_ACCOUNT_{0}', steps.transform.outputs.CONVERTED_REGION)] }}:layer:AWSLambdaPowertoolsTypeScriptV2:${LAYER_VERSION}" \
-            > "$layer_output"
+          export layer_output="AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}.json"
+          # Dynamic secret access is safe here - secrets are scoped per environment
+          aws --region "${{ matrix.region }}" lambda get-layer-version-by-arn --arn "arn:${PARTITION}:lambda:${{ matrix.region }}:${{ secrets[format('AWS_ACCOUNT_{0}', steps.transform.outputs.CONVERTED_REGION)] }}:layer:AWSLambdaPowertoolsTypeScriptV2:${LAYER_VERSION}" > "$layer_output"
           
           REMOTE_SHA=$(jq -r '.Content.CodeSha256' "$layer_output")
           LOCAL_SHA=$(jq -r '.Content.CodeSha256' AWSLambdaPowertoolsTypeScriptV2.json)
@@ -94,7 +102,7 @@ jobs:
           
           REMOTE_DESCRIPTION=$(jq -r '.Description' "$layer_output")
           LOCAL_DESCRIPTION=$(jq -r '.Description' AWSLambdaPowertoolsTypeScriptV2.json)
-          test "$REMOTE_DESCRIPTION" == "$LOCAL_DESCRIPTION" && echo "Version number OK: ${LOCAL_DESCRIPTION}" || exit 1
+          test "$REMOTE_DESCRIPTION" == "$LOCAL_DESCRIPTION" && echo "Description OK: ${LOCAL_DESCRIPTION}" || exit 1
           
           if [ "$ENVIRONMENT" == "Prod" ]; then
             REMOTE_LAYER_VERSION=$(jq -r '.LayerVersionArn' "$layer_output" | sed 's/.*://')
@@ -102,13 +110,12 @@ jobs:
             test "$REMOTE_LAYER_VERSION" == "$LOCAL_LAYER_VERSION" && echo "Layer Version number OK: ${LOCAL_LAYER_VERSION}" || exit 1
           fi
           
-          jq -s -r '["Layer Arn", "Runtimes", "Version", "Description", "SHA256"], ([.[0], .[1]] | .[] | [.LayerArn, (.CompatibleRuntimes | join("/")), .Version, .Description, .Content.CodeSha256]) |@tsv' \
-            AWSLambdaPowertoolsTypeScriptV2.json "$layer_output" | column -t -s $'\t'
+          jq -s -r '["Layer Arn", "Runtimes", "Version", "Description", "SHA256"], ([.[0], .[1]] | .[] | [.LayerArn, (.CompatibleRuntimes | join("/")), .Version, .Description, .Content.CodeSha256]) |@tsv' AWSLambdaPowertoolsTypeScriptV2.json "$layer_output" | column -t -s $'\t'
 
-      - name: Store Metadata
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+      - name: Store Metadata - ${{ matrix.region }}
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: AWSLambdaPowertoolsTypeScriptV2-${{ inputs.environment }}-${{ matrix.region }}.json
+          name: AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}.json
           path: AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}.json
           retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
## Summary

This PR updates the Layer Deployment (Partitions) workflow to automate the step of first deploying the layer to gamma and then to prod. It also removes the need to input the layer version number manually in the workflow 

### Changes

- Removed the environment and version number input from the workflow
- Added a step to get the latest layer version number from us-east-1
- Created a reusable workflow to deploy the layer
- Updated the workflow to deploy to gamma and then to prod automatically

**Issue number:** closes #4858 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
