### PR TITLE
improv(ci): Added environment suffix to prevent artefact name conflict

### DIFF
--- a/.github/workflows/layers_partitions_deploy.yml
+++ b/.github/workflows/layers_partitions_deploy.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Store Metadata - ${{ matrix.region }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}.json
+          name: AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}-${{ inputs.environment }}.json
           path: AWSLambdaPowertoolsTypeScriptV2-${{ matrix.region }}.json
           retention-days: 1
           if-no-files-found: error


### PR DESCRIPTION
## Summary

This PR fixes the Layer deployment (Partition) workflow which was failing due to a recent change in the process which caused a naming conflict on the generated artefact.

### Changes

> Please provide a summary of what's being changed

- Adds an environment suffix (eg: -Gamma, -Prod) to the artefact name

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4919 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
