### PR TITLE
improv(docs): added a note for customers migrating from `BatchProcessorSync` to `BatchProcessor`

### DIFF
--- a/docs/features/batch.md
+++ b/docs/features/batch.md
@@ -87,7 +87,7 @@ Processing batches from SQS works in three stages:
     By default, the batch processor will process messages in parallel, which does not guarantee the order of processing. If you need to process messages in order, set the [`processInParallel` option to `false`](#sequential-processing), or use [`SqsFifoPartialProcessor` for SQS FIFO queues](#fifo-queues).
 
 !!! note
-    If you're migrating from `BatchProcessorSync` to `BatchProcessor`, note that `processPartialResponse` is async and returns a Promise.
+    If you're migrating from `BatchProcessorSync` to `BatchProcessor`, note that `processPartialResponse` is async and returns a promise.
 
 === "index.ts"
 


### PR DESCRIPTION
## Summary

This PR adds a small note to highlight that the `processPartialResponse` method is async for customers who are migrating from `BatchProcessorSync` to `BatchProcessor`

### Changes

> Please provide a summary of what's being changed

- Added a note about the asynchronous nature of `processPartialResponse`

<img width="1690" height="268" alt="image" src="https://github.com/user-attachments/assets/5b3b58b0-1d09-4d8d-92c3-aa73fd3269ef" />

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #4760 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
