### PR TITLE
fix(event-handler): default error handler returns a web Response correctly

### DIFF
--- a/packages/kafka/src/consumer.ts
+++ b/packages/kafka/src/consumer.ts
@@ -196,7 +196,11 @@ const deserializeRecord = async (
     },
     originalKey: key,
     get value() {
+      if (value === undefined) {
+        return undefined;
+      }
       if (isNull(value)) return null;
+
       const deserializedValue = deserialize({
         value: value,
         deserializer: deserializerValue,

--- a/packages/kafka/src/types/types.ts
+++ b/packages/kafka/src/types/types.ts
@@ -201,7 +201,7 @@ type Record = {
   /**
    * Base64-encoded value of the record
    */
-  value: string | null;
+  value?: string | null;
   /**
    * Array of record headers
    */

--- a/packages/kafka/tests/unit/consumer.test.ts
+++ b/packages/kafka/tests/unit/consumer.test.ts
@@ -609,4 +609,32 @@ describe('Kafka consumer', () => {
     // Assess
     expect(result).toBeNull();
   });
+
+  it('handles tombstone events without a message value', async () => {
+    // Prepare
+    const event = structuredClone(jsonTestEvent);
+    delete event.records['mytopic-0'][0].value;
+
+    const handler = kafkaConsumer<string, unknown>(
+      async (event) => {
+        await setTimeout(1); // simulate some processing time
+        const firstRecord = event.records[0];
+        if (firstRecord) {
+          return firstRecord.value;
+        }
+        return undefined;
+      },
+      {
+        value: {
+          type: SchemaType.JSON,
+        },
+      }
+    );
+
+    // Act
+    const result = await handler(event, context);
+
+    // Assess
+    expect(result).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary
The default router error handling was not handling a `Response` object correctly when returned from the `toJSON` method.

### Changes
The base `HttpError` now has a correct `toJSON` response type and an added `toWebResponse` method which is responsible for constructing a web `Response` for the default error handler.  Errors that extend the `HttpError` can easily modify the `Response` (ex: adding additional headers, etc).

**Issue number:** closes #5013

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
