### PR TITLE
chore(ci): temporarily disable me-central-1 deployments 

### DIFF
--- a/.github/workflows/reusable_deploy_layer_stack.yml
+++ b/.github/workflows/reusable_deploy_layer_stack.yml
@@ -65,7 +65,7 @@ jobs:
             "eu-north-1",
             "sa-east-1",
             "me-south-1",
-            "me-central-1",
+            # "me-central-1", # temporarily disabled due to service disruptions
             "il-central-1",
             "mx-central-1"
           ]

--- a/.github/workflows/update_ssm.yml
+++ b/.github/workflows/update_ssm.yml
@@ -107,8 +107,8 @@ jobs:
           "eu-south-2", 
           "eu-north-1", 
           "sa-east-1", 
-          "me-south-1", 
-          "me-central-1", 
+          "me-south-1",
+          # "me-central-1", # temporarily disabled due to service disruptions
           "il-central-1", 
           "mx-central-1"
         ]

--- a/docs/getting-started/lambda-layers.md
+++ b/docs/getting-started/lambda-layers.md
@@ -48,12 +48,14 @@ We publish the Lambda Layer for Powertools for AWS Lambda in all commercial regi
 | `sa-east-1`      | [arn:aws:lambda:sa-east-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}             |
 | `af-south-1`     | [arn:aws:lambda:af-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}            |
 | `me-south-1`     | [arn:aws:lambda:me-south-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}            |
-| `me-central-1`   | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}          |
+| `me-central-1`*  | [arn:aws:lambda:me-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}          |
 | `il-central-1`   | [arn:aws:lambda:il-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}          |
 | `mx-central-1`   | [arn:aws:lambda:mx-central-1:094274105915:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}          |
 | `us-gov-west-1`  | [arn:aws-us-gov:lambda:us-gov-west-1:165093116878:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}  |
 | `us-gov-east-1`  | [arn:aws-us-gov:lambda:us-gov-east-1:165087284144:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}  |
 | `cn-north-1`     | [arn:aws-cn:lambda:cn-north-1:498634801083:layer:AWSLambdaPowertoolsTypeScriptV2:45](#){: .copyMe}         |
+
+_\* New layer versions for `me-central-1` are temporarily paused due to service disruptions._
 
 ### Lookup Layer ARN via AWS SSM Parameter Store
 


### PR DESCRIPTION
## Summary

### Changes

Temporarily disable `me-central-1` from the layer deployment and SSM update workflow matrices due to service disruptions in the region. A note has been added to the Lambda layers documentation.

- Comment out `me-central-1` in `reusable_deploy_layer_stack.yml` region matrix
- Comment out `me-central-1` in `update_ssm.yml` region matrix
- Add footnote in `docs/getting-started/lambda-layers.md` noting new layer versions are paused

**Issue number:** closes #5110

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.