### PR TITLE
docs(event-handler): update custom middleware example to use Store API

### DIFF
--- a/docs/features/event-handler/http.md
+++ b/docs/features/event-handler/http.md
@@ -530,13 +530,14 @@ accepts configuration options and returns a middleware function.
 
 === "index.ts"
 
-    ```ts hl_lines="20-21 36 41"
-    --8<-- "examples/snippets/event-handler/http/advanced_mw_custom_middleware.ts:8"
+    ```ts hl_lines="23"
+    --8<-- "examples/snippets/event-handler/http/advanced_mw_custom_middleware.ts:7"
     ```
 
-In this example we have a middleware that acts only in the post-processing stage as all
-the logic occurs after the `next` function has been called. This is so as to ensure that
-the handler has run and we have access to request body.
+In this example we have a middleware that extracts a correlation ID from a request header
+or generates a new one if absent. It stores the ID in the request context using
+`reqCtx.set()` so that route handlers can retrieve it with `reqCtx.get()`. This ensures
+each invocation has its own isolated state without relying on module-level variables.
 
 #### Avoiding destructuring pitfalls
 

--- a/examples/snippets/event-handler/http/advanced_mw_custom_middleware.ts
+++ b/examples/snippets/event-handler/http/advanced_mw_custom_middleware.ts
@@ -1,56 +1,42 @@
-declare const getUserTodos: (
-  userId: string
-) => Promise<Record<string, string>[]>;
-declare const jwt: {
-  verify(token: string, secret: string): { sub: string; roles: string[] };
-};
+declare const processOrder: (
+  orderId: string,
+  correlationId: string
+) => Promise<{ status: string }>;
 
-import { getStringFromEnv } from '@aws-lambda-powertools/commons/utils/env';
-import {
-  Router,
-  UnauthorizedError,
-} from '@aws-lambda-powertools/event-handler/http';
+import { randomUUID } from 'node:crypto';
+import { Router } from '@aws-lambda-powertools/event-handler/http';
 import type { Middleware } from '@aws-lambda-powertools/event-handler/types';
 import { Logger } from '@aws-lambda-powertools/logger';
 import type { Context } from 'aws-lambda';
 
-const jwtSecret = getStringFromEnv({
-  key: 'JWT_SECRET',
-  errorMessage: 'JWT_SECRET is not set',
-});
+type AppEnv = {
+  store: {
+    request: { correlationId: string };
+  };
+};
 
 const logger = new Logger({});
-const app = new Router();
-const store: { userId: string; roles: string[] } = { userId: '', roles: [] };
+const app = new Router<AppEnv>();
 
 // Factory function that returns middleware
-const verifyToken = (options: { jwtSecret: string }): Middleware => {
-  return async ({ reqCtx: { req }, next }) => {
-    const auth = req.headers.get('Authorization');
-    if (!auth || !auth.startsWith('Bearer '))
-      throw new UnauthorizedError('Missing or invalid Authorization header');
+const correlationId = (options: { header: string }): Middleware<AppEnv> => {
+  return async ({ reqCtx, next }) => {
+    const id = reqCtx.req.headers.get(options.header) ?? randomUUID();
 
-    const token = auth.slice(7);
-    try {
-      const payload = jwt.verify(token, options.jwtSecret);
-      store.userId = payload.sub;
-      store.roles = payload.roles;
-    } catch (error) {
-      logger.error('Token verification failed', { error });
-      throw new UnauthorizedError('Invalid token');
-    }
+    reqCtx.set('correlationId', id);
+    logger.appendKeys({ correlationId: id });
 
     await next();
   };
 };
 
 // Use custom middleware globally
-app.use(verifyToken({ jwtSecret }));
+app.use(correlationId({ header: 'X-Correlation-Id' }));
 
-app.post('/todos', async () => {
-  const { userId } = store;
-  const todos = await getUserTodos(userId);
-  return { todos };
+app.post('/orders', async (reqCtx) => {
+  const id = reqCtx.get('correlationId') ?? randomUUID();
+  const result = await processOrder('order-123', id);
+  return { correlationId: id, ...result };
 });
 
 export const handler = async (event: unknown, context: Context) =>


### PR DESCRIPTION
## Summary

### Changes

Replace the custom middleware example that used module-level mutable state with a correlation ID
middleware that uses the Store API (`reqCtx.set`/`reqCtx.get`). This demonstrates the recommended
pattern for managing per-request state in Lambda and avoids state leaking across warm invocations.

**Issue number:** closes #5103

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.