### PR TITLE
fix(commons): keep AWS_SDK_UA_APP_ID idempotent and <=50 chars

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,11 +1,20 @@
 import { PT_VERSION } from './version.js';
 
 const env = process.env.AWS_EXECUTION_ENV || 'NA';
-if (process.env.AWS_SDK_UA_APP_ID) {
-  process.env.AWS_SDK_UA_APP_ID = `${process.env.AWS_SDK_UA_APP_ID}/PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
-} else {
-  process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
-}
+const POWETOOLS_NOOP_UA = `PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
+const AWS_SDK_UA_APP_ID_MAX_LENGTH = 50;
+
+const currentUserAgentAppId = process.env.AWS_SDK_UA_APP_ID?.trim();
+const nextUserAgentAppId = currentUserAgentAppId?.includes('PT/NO-OP')
+  ? currentUserAgentAppId
+  : currentUserAgentAppId
+    ? `${currentUserAgentAppId}/${POWETOOLS_NOOP_UA}`
+    : POWETOOLS_NOOP_UA;
+
+process.env.AWS_SDK_UA_APP_ID = nextUserAgentAppId.slice(
+  0,
+  AWS_SDK_UA_APP_ID_MAX_LENGTH
+);
 
 export { addUserAgentMiddleware, isSdkClient } from './awsSdkUtils.js';
 export { deepMerge } from './deepMerge.js';

--- a/packages/commons/tests/unit/awsSdkUtils.test.ts
+++ b/packages/commons/tests/unit/awsSdkUtils.test.ts
@@ -89,6 +89,32 @@ describe('Helpers: awsSdk', () => {
     );
   });
 
+  it('does not append PT no-op marker more than once', async () => {
+    // Prepare
+    process.env.AWS_SDK_UA_APP_ID = `test/PT/NO-OP/${version}/PTEnv/NA`;
+
+    // Act
+    vi.resetModules();
+    await import('../../src/index.js');
+
+    // Assess
+    expect(process.env.AWS_SDK_UA_APP_ID).toEqual(
+      `test/PT/NO-OP/${version}/PTEnv/NA`
+    );
+  });
+
+  it('keeps AWS_SDK_UA_APP_ID within the 50-char SDK limit', async () => {
+    // Prepare
+    process.env.AWS_SDK_UA_APP_ID = 'MyCompany-ECommerce-Ordering-Service';
+
+    // Act
+    vi.resetModules();
+    await import('../../src/index.js');
+
+    // Assess
+    expect(process.env.AWS_SDK_UA_APP_ID?.length).toBeLessThanOrEqual(50);
+  });
+
   describe('Function: customUserAgentMiddleware', () => {
     it('returns a middleware function', () => {
       // Prepare


### PR DESCRIPTION
Fixes #5082

This patch makes commons user-agent app-id initialization safe for repeated module loads and compliant with the AWS SDK 50-char limit:
- avoid appending the PT/NO-OP marker when it already exists
- cap the final AWS_SDK_UA_APP_ID value to 50 chars
- add regression tests for idempotency and max-length behavior

Greetings, saschabuehrle