### PR TITLE
improv(parser): export InferOutput from public types entry point

### DIFF
--- a/packages/parser/src/types/index.ts
+++ b/packages/parser/src/types/index.ts
@@ -1,4 +1,5 @@
 export type {
+  InferOutput,
   ParsedResult,
   ParsedResultError,
   ParsedResultSuccess,


### PR DESCRIPTION
## Summary
Exports `InferOutput` from the public `@aws-lambda-powertools/parser/types` entry point.

### Changes

TypeScript enforces that all types appearing in a function's inferred return type must be nameable via public package exports (see [TS2742](https://github.com/microsoft/TypeScript/issues/47663) / TS2883 — the latter is a variant that also reports the source module path). This check becomes harder to avoid in TypeScript 6 because the compiler is stricter about declaration emit portability.

When using the `parser` middleware with `safeParse: true`, the return type of the wrapping function includes `InferOutput<TSchema>`. Because `InferOutput` was only exported from the internal path `lib/esm/types/parser.js` and not from any public entry point, TypeScript 6 could not generate a valid declaration file and raised:

```
error TS2883: The inferred type of 'X' cannot be named without a reference to
'InferOutput' from '...node_modules/@aws-lambda-powertools/parser/lib/esm/types/parser.js'.
This is likely not portable. A type annotation is necessary.
```

Consumers hitting this error were forced to add explicit type casts or annotations as a workaround.

### Fix

Add `InferOutput` to the existing re-exports in `packages/parser/src/types/index.ts`. This is a one-line, type-only change with no runtime impact. Once `InferOutput` is available at `@aws-lambda-powertools/parser/types`, TypeScript can reference it in generated `.d.ts` files automatically and the error is resolved without any changes required on the consumer side.

### Testing

Verified locally by:
1. Manually adding `InferOutput` to the built `lib/esm/types/index.d.ts`
2. Confirming that TS2883 is resolved without any type annotations or casts in consumer code
3. Confirming that removing the manual edit brings the error back

**Issue number:** closes #5174

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.