### PR TITLE
fix(metrics): align addDimensions boundary check

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -282,7 +282,7 @@ class Metrics extends Utility implements MetricsInterface {
     const newDimensions = this.#sanitizeDimensions(dimensions);
     const currentCount = this.#dimensionsStore.getDimensionCount();
     const newSetCount = Object.keys(newDimensions).length;
-    if (currentCount + newSetCount >= MAX_DIMENSION_COUNT) {
+    if (currentCount + newSetCount > MAX_DIMENSION_COUNT) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -389,6 +389,35 @@ describe('Working with dimensions', () => {
     );
   });
 
+  it('allows adding a dimension set when it reaches the limit exactly', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
+
+    // Act
+    // We start with 1 dimension because service name is already added
+    for (let i = 1; i < MAX_DIMENSION_COUNT - 1; i++) {
+      metrics.addDimension(`dimension-${i}`, 'test');
+    }
+
+    metrics.addDimensions({
+      final: 'test',
+    });
+
+    // Assess
+    metrics.addMetric('foo', MetricUnit.Count, 1);
+    metrics.publishStoredMetrics();
+
+    expect(console.log).toHaveEmittedEMFWith(
+      expect.objectContaining({
+        service: 'hello-world',
+        final: 'test',
+        foo: 1,
+      })
+    );
+  });
+
   it('handles dimension overrides across multiple dimension sets', () => {
     // Prepare
     const metrics = new Metrics({


### PR DESCRIPTION
## Summary

### Changes

- allow `addDimensions()` to accept a dimension set when the final total reaches `MAX_DIMENSION_COUNT`, matching the existing `addDimension()` boundary behavior
- add a regression test for the exact `28 + 1` case from the issue so the two APIs stay aligned

**Issue number:** closes #5204

### Validation

- `npx @biomejs/biome check packages/metrics/src/Metrics.ts packages/metrics/tests/unit/dimensions.test.ts`
- `npx vitest --run packages/metrics/tests/unit/dimensions.test.ts -t "allows adding a dimension set when it reaches the limit exactly"`
- `npm run build --workspace @aws-lambda-powertools/commons --workspace @aws-lambda-powertools/testing-utils --workspace @aws-lambda-powertools/metrics`
- `npm test --workspace @aws-lambda-powertools/metrics`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
