### PR TITLE
fix: ensure state cleanup when throwOnEmptyMetrics throws

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -610,14 +610,16 @@ class Metrics extends Utility implements MetricsInterface {
     }
 
     /* v8 ignore else -- @preserve */
-    if (!this.disabled) {
-      const emfOutput = this.serializeMetrics();
-      hasMetrics && this.console.log(JSON.stringify(emfOutput));
+    try {
+      if (!this.disabled) {
+        const emfOutput = this.serializeMetrics();
+        hasMetrics && this.console.log(JSON.stringify(emfOutput));
+      }
+    } finally {
+      this.clearMetrics();
+      this.clearDimensions();
+      this.clearMetadata();
     }
-
-    this.clearMetrics();
-    this.clearDimensions();
-    this.clearMetadata();
     return this;
   }
 

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -609,8 +609,8 @@ class Metrics extends Utility implements MetricsInterface {
       );
     }
 
-    /* v8 ignore else -- @preserve */
     try {
+      /* v8 ignore else -- @preserve */
       if (!this.disabled) {
         const emfOutput = this.serializeMetrics();
         hasMetrics && this.console.log(JSON.stringify(emfOutput));

--- a/packages/metrics/tests/unit/creatingMetrics.test.ts
+++ b/packages/metrics/tests/unit/creatingMetrics.test.ts
@@ -351,4 +351,43 @@ describe('Creating metrics', () => {
       )
     );
   });
+
+  it('clears dimensions and metadata when serializeMetrics throws', () => {
+    // Prepare
+    const metrics = new Metrics({ singleMetric: false });
+    metrics.addDimension('environment', 'test');
+    metrics.addMetadata('cost-center', '1234');
+    metrics.addMetric('test', MetricUnit.Count, 1);
+
+    // Mock serializeMetrics to throw on first call, then restore original
+    vi.spyOn(metrics, 'serializeMetrics')
+      .mockImplementationOnce(() => {
+        throw new Error('Serialization failed');
+      });
+
+    // Act & Assess: first publish should throw
+    expect(() => metrics.publishStoredMetrics()).toThrowError('Serialization failed');
+
+    // Now add new metrics and publish again — this should succeed
+    // and NOT include the previously added dimension/metadata (proving they were cleared)
+    metrics.addMetric('second', MetricUnit.Count, 2);
+    metrics.publishStoredMetrics();
+
+    // Assess: the second EMF is at index 1 (first call threw before logging)
+    expect(console.log).toHaveEmittedNthEMFWith(
+      1,
+      expect.objectContaining({
+        second: 2,
+        service: 'hello-world',
+      })
+    );
+    expect(console.log).toHaveEmittedNthEMFWith(
+      1,
+      expect.not.objectContaining({
+        test: expect.anything(),
+        environment: expect.anything(),
+        'cost-center': expect.anything(),
+      })
+    );
+  });
 });

--- a/packages/metrics/tests/unit/creatingMetrics.test.ts
+++ b/packages/metrics/tests/unit/creatingMetrics.test.ts
@@ -353,27 +353,23 @@ describe('Creating metrics', () => {
   });
 
   it('clears dimensions and metadata when serializeMetrics throws', () => {
-    // Prepare
-    const metrics = new Metrics({ singleMetric: false });
+    // Prepare: use throwOnEmptyMetrics so serializeMetrics throws naturally
+    // when there are no metrics, without needing to mock
+    const metrics = new Metrics({ singleMetric: false, throwOnEmptyMetrics: true });
     metrics.addDimension('environment', 'test');
     metrics.addMetadata('cost-center', '1234');
-    metrics.addMetric('test', MetricUnit.Count, 1);
 
-    // Mock serializeMetrics to throw on first call, then restore original
-    vi.spyOn(metrics, 'serializeMetrics')
-      .mockImplementationOnce(() => {
-        throw new Error('Serialization failed');
-      });
+    // Act & Assess: publish without metrics throws from serializeMetrics
+    expect(() => metrics.publishStoredMetrics()).toThrowError(
+      'The number of metrics recorded must be higher than zero'
+    );
 
-    // Act & Assess: first publish should throw
-    expect(() => metrics.publishStoredMetrics()).toThrowError('Serialization failed');
-
-    // Now add new metrics and publish again — this should succeed
-    // and NOT include the previously added dimension/metadata (proving they were cleared)
+    // Assess: dimensions and metadata were cleared by the finally block
+    // Add new metrics and publish again — this should succeed
     metrics.addMetric('second', MetricUnit.Count, 2);
     metrics.publishStoredMetrics();
 
-    // Assess: the second EMF is at index 1 (first call threw before logging)
+    // The EMF should contain the new metric but NOT the stale dimension/metadata
     expect(console.log).toHaveEmittedNthEMFWith(
       1,
       expect.objectContaining({
@@ -384,7 +380,6 @@ describe('Creating metrics', () => {
     expect(console.log).toHaveEmittedNthEMFWith(
       1,
       expect.not.objectContaining({
-        test: expect.anything(),
         environment: expect.anything(),
         'cost-center': expect.anything(),
       })


### PR DESCRIPTION
## Summary

### Changes

Wrap the `serializeMetrics()` call in `publishStoredMetrics()` in a `try/finally` block so that state cleanup (`clearMetrics`, `clearDimensions`, `clearMetadata`) always runs, even when serialization throws due to `throwOnEmptyMetrics`.

This fixes a state leak where dimensions and metadata from a failed publish attempt would persist into the next `publishStoredMetrics()` call.

**Issue number:** closes #5207

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change is consistent with the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
