### PR TITLE
fix(metrics): clear state in publishStoredMetrics even when throwOnEmptyMetrics throws

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -609,15 +609,16 @@ class Metrics extends Utility implements MetricsInterface {
       );
     }
 
-    /* v8 ignore else -- @preserve */
-    if (!this.disabled) {
-      const emfOutput = this.serializeMetrics();
-      hasMetrics && this.console.log(JSON.stringify(emfOutput));
+    try {
+      if (!this.disabled) {
+        const emfOutput = this.serializeMetrics();
+        hasMetrics && this.console.log(JSON.stringify(emfOutput));
+      }
+    } finally {
+      this.clearMetrics();
+      this.clearDimensions();
+      this.clearMetadata();
     }
-
-    this.clearMetrics();
-    this.clearDimensions();
-    this.clearMetadata();
     return this;
   }
 

--- a/packages/metrics/tests/unit/creatingMetrics.test.ts
+++ b/packages/metrics/tests/unit/creatingMetrics.test.ts
@@ -219,17 +219,15 @@ describe('Creating metrics', () => {
     metrics.addDimension('request_id', 'abc-123');
     metrics.addMetadata('trace_id', 'xyz-789');
 
-    // Act - first publish throws because no metrics were added
+    // Act
     expect(() => metrics.publishStoredMetrics()).toThrowError(
       'The number of metrics recorded must be higher than zero'
     );
-
-    // Publish again with a metric - dimensions and metadata should be clean
     metrics.setThrowOnEmptyMetrics(false);
     metrics.addMetric('test', MetricUnit.Count, 1);
     metrics.publishStoredMetrics();
 
-    // Assess - leaked state should not appear in the output
+    // Assess
     expect(console.log).toHaveEmittedNthEMFWith(
       1,
       expect.not.objectContaining({

--- a/packages/metrics/tests/unit/creatingMetrics.test.ts
+++ b/packages/metrics/tests/unit/creatingMetrics.test.ts
@@ -209,6 +209,61 @@ describe('Creating metrics', () => {
     );
   });
 
+  it('clears dimensions and metadata even when throwOnEmptyMetrics throws', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: false,
+      namespace: DEFAULT_NAMESPACE,
+    });
+    metrics.setThrowOnEmptyMetrics(true);
+    metrics.addDimension('request_id', 'abc-123');
+    metrics.addMetadata('trace_id', 'xyz-789');
+
+    // Act - first publish throws because no metrics were added
+    expect(() => metrics.publishStoredMetrics()).toThrowError(
+      'The number of metrics recorded must be higher than zero'
+    );
+
+    // Publish again with a metric - dimensions and metadata should be clean
+    metrics.setThrowOnEmptyMetrics(false);
+    metrics.addMetric('test', MetricUnit.Count, 1);
+    metrics.publishStoredMetrics();
+
+    // Assess - leaked state should not appear in the output
+    expect(console.log).toHaveEmittedNthEMFWith(
+      1,
+      expect.not.objectContaining({
+        request_id: 'abc-123',
+      })
+    );
+    expect(console.log).toHaveEmittedNthEMFWith(
+      1,
+      expect.not.objectContaining({
+        trace_id: 'xyz-789',
+      })
+    );
+  });
+
+  it('does not emit metrics when disabled but still clears state', () => {
+    // Prepare
+    process.env.POWERTOOLS_DEV = undefined;
+    process.env.POWERTOOLS_METRICS_DISABLED = 'true';
+    const metrics = new Metrics({
+      singleMetric: false,
+      namespace: DEFAULT_NAMESPACE,
+    });
+    metrics.addMetric('test', MetricUnit.Count, 1);
+    metrics.addDimension('env', 'prod');
+    metrics.addMetadata('trace', '123');
+
+    // Act
+    metrics.publishStoredMetrics();
+
+    // Assess
+    expect(console.log).not.toHaveBeenCalled();
+    expect(metrics.hasStoredMetrics()).toBe(false);
+  });
+
   it('flushes the buffer automatically when the buffer is full', () => {
     // Prepare
     const metrics = new Metrics({


### PR DESCRIPTION
## Summary

### Changes

When `serializeMetrics()` throws due to `throwOnEmptyMetrics`, the cleanup calls (`clearMetrics`, `clearDimensions`, `clearMetadata`) in `publishStoredMetrics()` are never reached. This causes dimensions and metadata to leak into subsequent publish calls.

- Wrap the serialize/emit block in `try/finally` to guarantee state cleanup even when an exception is thrown
- Add test verifying dimensions and metadata don't leak after a failed publish
- Add test for the `disabled=true` code path in `publishStoredMetrics`, removing the `/* v8 ignore else */` coverage pragma

**Issue number:** closes #5207

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.