### PR TITLE
chore: drop Node.js 20 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -69,7 +69,6 @@ body:
       options:
         - 24.x
         - 22.x
-        - 20.x
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/quality_check.yml
+++ b/.github/workflows/quality_check.yml
@@ -20,7 +20,7 @@ jobs:
       NODE_ENV: dev
     strategy:
       matrix:
-        version: [20, 22, 24]
+        version: [22, 24]
         workspace: [
           "packages/batch",
           "packages/commons",

--- a/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
@@ -40,7 +40,7 @@ jobs:
       NODE_ENV: dev
     strategy:
       matrix:
-        version: [20, 22, 24]
+        version: [22, 24]
         workspace: [
           "packages/batch",
           "packages/commons",

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -36,7 +36,7 @@ jobs:
             packages/batch,
             layers,
           ]
-        version: [20, 22, 24]
+        version: [22, 24]
         arch: [x86_64, arm64]
       fail-fast: false
     steps:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD013  -->
 # Powertools for AWS Lambda (TypeScript)
 
-![NodeSupport](https://img.shields.io/static/v1?label=node&message=%2020|%2022&style=flat&logo=nodedotjs)
+![NodeSupport](https://img.shields.io/static/v1?label=node&message=%2022|%2024&style=flat&logo=nodedotjs)
 ![GitHub Release](https://img.shields.io/github/v/release/aws-powertools/powertools-lambda-typescript?style=flat)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aws-powertools_powertools-lambda-typescript&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aws-powertools_powertools-lambda-typescript)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=aws-powertools_powertools-lambda-typescript&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=aws-powertools_powertools-lambda-typescript)

--- a/docs/getting-started/lambda-layers.md
+++ b/docs/getting-started/lambda-layers.md
@@ -111,7 +111,6 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
         "CreatedDate": "2025-04-08T07:38:30.424+0000",
         "Version": 24,
         "CompatibleRuntimes": [
-            "nodejs20.x",
             "nodejs22.x",
             "nodejs24.x"
         ],

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -37,8 +37,8 @@ Most AWS SDKs have underlying dependencies, such as language runtimes, AWS Lambd
 
 The following terms are used to classify underlying third party dependencies:
 
-* [**AWS Lambda Runtime**](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html): Examples include `nodejs20.x`, `python3.12`, etc.
-* **Language Runtime**: Examples include Python 3.12, NodeJS 20, Java 17, .NET Core, etc.
+* [**AWS Lambda Runtime**](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html): Examples include `nodejs22.x`, `python3.12`, etc.
+* **Language Runtime**: Examples include Python 3.12, NodeJS 22, Java 17, .NET Core, etc.
 * **Third party Library**: Examples include Pydantic, AWS X-Ray SDK, AWS Encryption SDK, Middy.js, etc.
 
 Powertools for AWS Lambda follows the [AWS Lambda Runtime deprecation policy cycle](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy), when it comes to Language Runtime. This means we will stop supporting their respective deprecated Language Runtime _(e.g., `nodejs20.x`)_ without increasing the major SDK version.

--- a/examples/app/cdk/function-with-logstream-construct.ts
+++ b/examples/app/cdk/function-with-logstream-construct.ts
@@ -43,7 +43,7 @@ type BindTableProps = {
  *
  * The function is created with the following properties:
  * - `handler` set to `handler`
- * - `runtime` set to `Runtime.NODEJS_20_X`
+ * - `runtime` set to `Runtime.NODEJS_22_X`
  * - `tracing` set to `Tracing.ACTIVE`
  * - `architecture` set to `Architecture.ARM_64`
  * - `timeout` set to `Duration.seconds(30)`
@@ -60,7 +60,7 @@ export class FunctionWithLogGroup extends NodejsFunction {
     super(scope, id, {
       ...props,
       handler: 'handler',
-      runtime: Runtime.NODEJS_20_X,
+      runtime: Runtime.NODEJS_22_X,
       tracing: Tracing.ACTIVE,
       architecture: Architecture.ARM_64,
       timeout: Duration.seconds(30),

--- a/examples/snippets/commons/testingMetadata.ts
+++ b/examples/snippets/commons/testingMetadata.ts
@@ -25,7 +25,7 @@ describe('function: getMetadata', async () => {
     vi.stubEnv('AWS_LAMBDA_METADATA_API', '127.0.0.1:1234');
     vi.stubEnv('AWS_LAMBDA_METADATA_TOKEN', 'test-token');
 
-    const payload = { runtime: 'nodejs20.x' };
+    const payload = { runtime: 'nodejs22.x' };
     fetchMock.mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue(payload),

--- a/examples/snippets/idempotency/templates/tableCdk.ts
+++ b/examples/snippets/idempotency/templates/tableCdk.ts
@@ -18,7 +18,7 @@ export class IdempotencyStack extends Stack {
     });
 
     const fnHandler = new NodejsFunction(this, 'helloWorldFunction', {
-      runtime: Runtime.NODEJS_20_X,
+      runtime: Runtime.NODEJS_22_X,
       handler: 'handler',
       entry: 'src/index.ts',
       environment: {

--- a/examples/snippets/idempotency/templates/tableTerraform.tf
+++ b/examples/snippets/idempotency/templates/tableTerraform.tf
@@ -28,7 +28,7 @@ resource "aws_dynamodb_table" "IdempotencyTable" {
 resource "aws_lambda_function" "IdempotencyFunction" {
     function_name = "IdempotencyFunction"
     role          = aws_iam_role.IdempotencyFunctionRole.arn
-    runtime       = "nodejs20.x"
+    runtime       = "nodejs22.x"
     handler       = "index.handler"
     filename      = "lambda.zip"
 }

--- a/layers/package.json
+++ b/layers/package.json
@@ -12,7 +12,6 @@
     "test:unit": "vitest --run tests/unit",
     "test:unit:coverage": "echo 'Not Implemented'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs20x": "echo 'Not Implemented'",
     "test:e2e:nodejs22x": "echo 'Not Implemented'",
     "test:e2e:nodejs24x": "echo 'Not Implemented'",
     "test:e2e": "vitest --run tests/e2e",

--- a/layers/src/canary-stack.ts
+++ b/layers/src/canary-stack.ts
@@ -45,7 +45,7 @@ export class CanaryStack extends Stack {
         '../tests/e2e/layerPublisher.class.test.functionCode.ts'
       ),
       handler: 'handler',
-      runtime: Runtime.NODEJS_20_X,
+      runtime: Runtime.NODEJS_22_X,
       functionName: `canary-${suffix}`,
       timeout: Duration.seconds(30),
       bundling: {

--- a/layers/src/layer-publisher-stack.ts
+++ b/layers/src/layer-publisher-stack.ts
@@ -41,11 +41,7 @@ export class LayerPublisherStack extends Stack {
     this.lambdaLayerVersion = new LayerVersion(this, 'LambdaPowertoolsLayer', {
       layerVersionName: props?.layerName,
       description: `Powertools for AWS Lambda (TypeScript) version ${powertoolsPackageVersion}`,
-      compatibleRuntimes: [
-        Runtime.NODEJS_20_X,
-        Runtime.NODEJS_22_X,
-        Runtime.NODEJS_24_X,
-      ],
+      compatibleRuntimes: [Runtime.NODEJS_22_X, Runtime.NODEJS_24_X],
       license: 'MIT-0',
       compatibleArchitectures: [Architecture.ARM_64, Architecture.X86_64],
       code: Code.fromAsset(resolve(__dirname), {

--- a/layers/tests/unit/layer-publisher.test.ts
+++ b/layers/tests/unit/layer-publisher.test.ts
@@ -20,7 +20,7 @@ describe('Class: LayerPublisherStack', () => {
     // Assess
     template.resourceCountIs('AWS::Lambda::LayerVersion', 1);
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      CompatibleRuntimes: ['nodejs20.x', 'nodejs22.x', 'nodejs24.x'],
+      CompatibleRuntimes: ['nodejs22.x', 'nodejs24.x'],
       LicenseInfo: 'MIT-0',
       /* CompatibleArchitectures: [
         'x86_64',

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "examples/app": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "*.md": "markdownlint-cli2 --fix"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   }
 }

--- a/packages/batch/package.json
+++ b/packages/batch/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/commons/src/awsSdkUtils.ts
+++ b/packages/commons/src/awsSdkUtils.ts
@@ -38,7 +38,7 @@ const isSdkClient = (client: unknown): client is SdkClient =>
  * The middleware will append the provided feature name and the current version of
  * the Powertools for AWS Lambda library to the user agent string.
  *
- * @example "PT/Tracer/2.1.0 PTEnv/nodejs20x"
+ * @example "PT/Tracer/2.1.0 PTEnv/nodejs22x"
  *
  * @param feature The feature name to be added to the user agent
  *

--- a/packages/event-handler/package.json
+++ b/packages/event-handler/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest --run tests/unit",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "vitest --typecheck --run tests/types",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest run tests/e2e",
     "test:e2e": "vitest run tests/e2e",

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/idempotency/tests/e2e/durableIdempotent.test.ts
+++ b/packages/idempotency/tests/e2e/durableIdempotent.test.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import {
-  getRuntimeKey,
   invokeFunction,
   TestStack,
 } from '@aws-lambda-powertools/testing-utils';
@@ -12,85 +11,82 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { IdempotencyTestNodejsFunctionAndDynamoTable } from '../helpers/resources.js';
 import { RESOURCE_NAME_PREFIX } from './constants.js';
 
-describe.skipIf(getRuntimeKey() === 'nodejs20x')(
-  'Idempotency E2E tests, durable functions',
-  () => {
-    const testStack = new TestStack({
-      stackNameProps: {
-        stackNamePrefix: RESOURCE_NAME_PREFIX,
-        testName: 'durable',
-      },
-    });
+describe('Idempotency E2E tests, durable functions', () => {
+  const testStack = new TestStack({
+    stackNameProps: {
+      stackNamePrefix: RESOURCE_NAME_PREFIX,
+      testName: 'durable',
+    },
+  });
 
-    // Location of the lambda function code
-    const lambdaFunctionCodeFilePath = join(
-      __dirname,
-      'durableIdempotent.FunctionCode.ts'
-    );
+  // Location of the lambda function code
+  const lambdaFunctionCodeFilePath = join(
+    __dirname,
+    'durableIdempotent.FunctionCode.ts'
+  );
 
-    let functionNameDurable: string;
-    let tableNameDurable: string;
-    new IdempotencyTestNodejsFunctionAndDynamoTable(
-      testStack,
-      {
-        function: {
-          entry: lambdaFunctionCodeFilePath,
-          handler: 'handlerDurable',
-          durableConfig: {
-            executionTimeout: Duration.minutes(5),
-            retentionPeriod: Duration.days(1),
-          },
+  let functionNameDurable: string;
+  let tableNameDurable: string;
+  new IdempotencyTestNodejsFunctionAndDynamoTable(
+    testStack,
+    {
+      function: {
+        entry: lambdaFunctionCodeFilePath,
+        handler: 'handlerDurable',
+        durableConfig: {
+          executionTimeout: Duration.minutes(5),
+          retentionPeriod: Duration.days(1),
         },
       },
-      {
-        nameSuffix: 'durable',
-      }
+    },
+    {
+      nameSuffix: 'durable',
+    }
+  );
+
+  const ddb = new DynamoDBClient({});
+
+  beforeAll(async () => {
+    // Deploy the stack
+    await testStack.deploy();
+
+    // Get the actual function names from the stack outputs
+    functionNameDurable = testStack.findAndGetStackOutputValue('durableFn');
+    tableNameDurable = testStack.findAndGetStackOutputValue('durableTable');
+  });
+
+  it('calls an idempotent durable function and always returns the same result when called multiple times', async () => {
+    // Prepare
+    const payload = {
+      foo: 'bar',
+    };
+    const payloadHash = createHash('md5')
+      .update(JSON.stringify(payload))
+      .digest('base64');
+
+    // Act
+    await invokeFunction({
+      functionName: `${functionNameDurable}:$LATEST`,
+      times: 2,
+      invocationMode: 'SEQUENTIAL',
+      payload,
+    });
+
+    // Assess
+    const idempotencyRecords = await ddb.send(
+      new ScanCommand({
+        TableName: tableNameDurable,
+      })
     );
+    expect(idempotencyRecords.Items?.length).toEqual(1);
+    expect(idempotencyRecords.Items?.[0].id).toEqual(
+      `${functionNameDurable}#${payloadHash}`
+    );
+  });
 
-    const ddb = new DynamoDBClient({});
-
-    beforeAll(async () => {
-      // Deploy the stack
-      await testStack.deploy();
-
-      // Get the actual function names from the stack outputs
-      functionNameDurable = testStack.findAndGetStackOutputValue('durableFn');
-      tableNameDurable = testStack.findAndGetStackOutputValue('durableTable');
-    });
-
-    it('calls an idempotent durable function and always returns the same result when called multiple times', async () => {
-      // Prepare
-      const payload = {
-        foo: 'bar',
-      };
-      const payloadHash = createHash('md5')
-        .update(JSON.stringify(payload))
-        .digest('base64');
-
-      // Act
-      await invokeFunction({
-        functionName: `${functionNameDurable}:$LATEST`,
-        times: 2,
-        invocationMode: 'SEQUENTIAL',
-        payload,
-      });
-
-      // Assess
-      const idempotencyRecords = await ddb.send(
-        new ScanCommand({
-          TableName: tableNameDurable,
-        })
-      );
-      expect(idempotencyRecords.Items?.length).toEqual(1);
-      expect(idempotencyRecords.Items?.[0].id).toEqual(
-        `${functionNameDurable}#${payloadHash}`
-      );
-    });
-
-    afterAll(async () => {
-      if (!process.env.DISABLE_TEARDOWN) {
-        await testStack.destroy();
-      }
-    });
-  }
-);
+  afterAll(async () => {
+    if (!process.env.DISABLE_TEARDOWN) {
+      await testStack.destroy();
+    }
+  });
+});

--- a/packages/idempotency/tests/helpers/populateEnvironmentVariables.ts
+++ b/packages/idempotency/tests/helpers/populateEnvironmentVariables.ts
@@ -1,7 +1,7 @@
 // Reserved variables
 process.env._X_AMZN_TRACE_ID = '1-abcdef12-3456abcdef123456abcdef12';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
-process.env.AWS_EXECUTION_ENV = 'nodejs20.x';
+process.env.AWS_EXECUTION_ENV = 'nodejs22.x';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
 if (
   process.env.AWS_REGION === undefined &&

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs20x": "echo \"Not implemented\"",
     "test:e2e:nodejs22x": "echo \"Not implemented\"",
     "test:e2e:nodejs24x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/parameters/package.json
+++ b/packages/parameters/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "vitest --run tests/types --typecheck",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "vitest --run tests/types --typecheck",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs20x": "echo 'Not implemented'",
     "test:e2e:nodejs22x": "echo 'Not implemented'",
     "test:e2e:nodejs24x": "echo 'Not implemented'",
     "test:e2e": "echo 'Not implemented'",

--- a/packages/testing/src/constants.ts
+++ b/packages/testing/src/constants.ts
@@ -9,7 +9,6 @@ const defaultRuntime = 'nodejs24x';
  * The AWS Lambda runtimes that are supported by the project.
  */
 const TEST_RUNTIMES = {
-  nodejs20x: Runtime.NODEJS_20_X,
   nodejs22x: Runtime.NODEJS_22_X,
   [defaultRuntime]: Runtime.NODEJS_24_X,
 } as const;

--- a/packages/testing/src/setupEnv.ts
+++ b/packages/testing/src/setupEnv.ts
@@ -366,7 +366,7 @@ declare module 'vitest' {
 // Set up environment variables for testing
 process.env._X_AMZN_TRACE_ID = '1-abcdef12-3456abcdef123456abcdef12';
 process.env.AWS_LAMBDA_FUNCTION_NAME = 'my-lambda-function';
-process.env.AWS_EXECUTION_ENV = 'nodejs20.x';
+process.env.AWS_EXECUTION_ENV = 'nodejs22.x';
 process.env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE = '128';
 if (
   process.env.AWS_REGION === undefined &&

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -15,7 +15,6 @@
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
     "test:unit:watch": "vitest tests/unit",
-    "test:e2e:nodejs20x": "RUNTIME=nodejs20x vitest --run tests/e2e",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",
     "test:e2e": "vitest --run tests/e2e",

--- a/packages/tracer/tests/unit/Tracer.test.ts
+++ b/packages/tracer/tests/unit/Tracer.test.ts
@@ -218,7 +218,7 @@ describe('Class: Tracer', () => {
 
     it('leaves tracing enabled when AWS_EXECUTION_ENV environment variable is set', () => {
       // Prepare
-      process.env.AWS_EXECUTION_ENV = 'nodejs20.x';
+      process.env.AWS_EXECUTION_ENV = 'nodejs22.x';
 
       // Act
       const tracer = new Tracer();

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -11,7 +11,6 @@
     "test:unit": "vitest --run",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
     "test:unit:types": "echo 'Not Implemented'",
-    "test:e2e:nodejs20x": "echo \"Not implemented\"",
     "test:e2e:nodejs22x": "echo \"Not implemented\"",
     "test:e2e:nodejs24x": "echo \"Not implemented\"",
     "test:e2e": "echo \"Not implemented\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "incremental": true,
     "composite": true,
-    "target": "ES2023", // Node.js 20
+    "target": "ES2024", // Node.js 22
     "experimentalDecorators": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary

AWS Lambda marks the `nodejs20.x` runtime as deprecated on 2026-04-30 and will block new-function creation from 2026-06-01. This drops Node.js 20 from the supported runtimes so we stop running integration tests against a runtime we can no longer deploy, 4 weeks ahead of the Lambda cut-off. Supported runtimes going forward: `nodejs22.x` and `nodejs24.x`; minimum `engines.node` is now `>=22`.

### Changes

- Remove `20` from the CI matrix in `quality_check.yml`, `reusable-run-linting-check-and-unit-tests.yml`, and `run-e2e-tests.yml`
- Bump root `package.json` `engines.node` to `>=22` and `tsconfig.json` `target` to `ES2024`
- Remove `Runtime.NODEJS_20_X` from the layer's `compatibleRuntimes`, bump the canary runtime to `NODEJS_22_X`, and update the `layer-publisher` unit test assertion
- Drop the `nodejs20x` entry from `TEST_RUNTIMES` in `packages/testing/src/constants.ts`
- Remove `test:e2e:nodejs20x` scripts from all package `package.json` files (layers + 10 packages)
- Update hardcoded `AWS_EXECUTION_ENV` / runtime strings to `nodejs22.x` in test setup (`setupEnv.ts`, `populateEnvironmentVariables.ts`, `Tracer.test.ts`, `testingMetadata.ts`)
- Remove the 20.x option from the bug report template and bump the `NodeSupport` README badge to `22|24`
- Update docs (`lambda-layers.md`, `versioning.md`) and the `awsSdkUtils.ts` JSDoc example
- Bump `Runtime.NODEJS_20_X` to `NODEJS_22_X` in example CDK constructs and the Terraform snippet
- Remove the now-dead `describe.skipIf(getRuntimeKey() === 'nodejs20x')` guard in `durableIdempotent.test.ts`

**Issue number:** closes #4906

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.