### PR TITLE
fix(logger): flush log buffer on critical() when flushOnErrorLog is e…

### DIFF
--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -408,9 +408,6 @@ class Logger extends Utility implements LoggerInterface {
    * @param extraInput - The extra input to log.
    */
   public error(input: LogItemMessage, ...extraInput: LogItemExtraInput): void {
-    if (this.#bufferConfig.enabled && this.#bufferConfig.flushOnErrorLog) {
-      this.flushBuffer();
-    }
     this.processLogItem(LogLevelThreshold.ERROR, input, extraInput);
   }
 
@@ -1063,6 +1060,15 @@ class Logger extends Utility implements LoggerInterface {
     input: LogItemMessage,
     extraInput: LogItemExtraInput
   ): void {
+    if (
+      this.#bufferConfig.enabled &&
+      this.#bufferConfig.flushOnErrorLog &&
+      logLevel >= LogLevelThreshold.ERROR &&
+      logLevel < LogLevelThreshold.SILENT
+    ) {
+      this.flushBuffer();
+    }
+
     const traceId = getXRayTraceIdFromEnv();
     if (traceId !== undefined && this.shouldBufferLog(traceId, logLevel)) {
       try {

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -271,8 +271,8 @@ describe('Buffer logs', () => {
     logger.critical('This is a critical message');
 
     // Assess
-    expect(console.debug).toBeCalledTimes(1);
-    expect(console.error).toBeCalledTimes(1); // critical uses console.error
+    expect(console.debug).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(1); // critical uses console.error
   });
 
   it('does not flush on critical logs when flushOnErrorLog is disabled', () => {
@@ -287,8 +287,8 @@ describe('Buffer logs', () => {
     logger.critical('This is a critical message');
 
     // Assess
-    expect(console.debug).toBeCalledTimes(0);
-    expect(console.error).toBeCalledTimes(1); // critical uses console.error
+    expect(console.debug).toHaveBeenCalledTimes(0);
+    expect(console.error).toHaveBeenCalledTimes(1); // critical uses console.error
   });
 
   it('passes down the same buffer config to child loggers', () => {

--- a/packages/logger/tests/unit/logBuffer.test.ts
+++ b/packages/logger/tests/unit/logBuffer.test.ts
@@ -259,6 +259,38 @@ describe('Buffer logs', () => {
     expect(console.error).toBeCalledTimes(1);
   });
 
+  it('it flushes the buffer when a critical log is logged', () => {
+    // Prepare
+    const logger = new Logger({
+      logLevel: LogLevel.ERROR,
+      logBufferOptions: { enabled: true },
+    });
+
+    // Act
+    logger.debug('This is a log message');
+    logger.critical('This is a critical message');
+
+    // Assess
+    expect(console.debug).toBeCalledTimes(1);
+    expect(console.error).toBeCalledTimes(1); // critical uses console.error
+  });
+
+  it('does not flush on critical logs when flushOnErrorLog is disabled', () => {
+    // Prepare
+    const logger = new Logger({
+      logLevel: LogLevel.ERROR,
+      logBufferOptions: { enabled: true, flushOnErrorLog: false },
+    });
+
+    // Act
+    logger.debug('This is a log message');
+    logger.critical('This is a critical message');
+
+    // Assess
+    expect(console.debug).toBeCalledTimes(0);
+    expect(console.error).toBeCalledTimes(1); // critical uses console.error
+  });
+
   it('passes down the same buffer config to child loggers', () => {
     // Prepare
     const logger = new Logger({


### PR DESCRIPTION
## Summary

### Changes

Centralizes the flush-on-error logic from `error()` into `processLogItem()` so that any log level `>= ERROR` (including `CRITICAL`) will automatically flush the buffer when `flushOnErrorLog` is enabled.

Previously, only `error()` checked `flushOnErrorLog` and flushed the buffer. `critical()`, despite being more severe, did not flush — causing buffered diagnostic logs to be silently discarded.

#### What changed

- **`Logger.ts`**: Removed the buffer flush check from `error()` and moved it into `processLogItem()`, which all log level methods funnel through. The condition checks `logLevel >= LogLevelThreshold.ERROR && logLevel < LogLevelThreshold.SILENT` to cover both `ERROR` and `CRITICAL` while excluding `SILENT`.
- **`logBuffer.test.ts`**: Added two unit tests:
  - Verifies `critical()` flushes the buffer when `flushOnErrorLog` is enabled (default)
  - Verifies `critical()` does **not** flush the buffer when `flushOnErrorLog` is explicitly disabled

**Issue number:** Closes #5210

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
