### PR TITLE
fix(metrics): account for all dimensions in setDefaultDimensions() li…

### DIFF
--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -798,9 +798,13 @@ class Metrics extends Utility implements MetricsInterface {
     const newDimensions = this.#sanitizeDimensions(dimensions);
     const currentDefaultDimensions =
       this.#dimensionsStore.getDefaultDimensions();
-    const currentCount = Object.keys(currentDefaultDimensions).length;
-    const newSetCount = Object.keys(newDimensions).length;
-    if (currentCount + newSetCount >= MAX_DIMENSION_COUNT) {
+    const newKeysCount = Object.keys(newDimensions).filter(
+      (key) => !Object.hasOwn(currentDefaultDimensions, key)
+    ).length;
+    if (
+      this.#dimensionsStore.getDimensionCount() + newKeysCount >=
+      MAX_DIMENSION_COUNT
+    ) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -361,6 +361,42 @@ describe('Working with dimensions', () => {
     );
   });
 
+  it('throws when setDefaultDimensions would exceed the limit with existing regular dimensions', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
+
+    // Act
+    for (let i = 1; i < MAX_DIMENSION_COUNT - 1; i++) {
+      metrics.addDimension(`regular-${i}`, 'test');
+    }
+
+    // Assess
+    expect(() =>
+      metrics.setDefaultDimensions({ 'new-default': 'test' })
+    ).toThrow(
+      `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
+    );
+  });
+
+  it('allows overriding existing default dimension keys without triggering the limit', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
+
+    // Act
+    for (let i = 1; i < MAX_DIMENSION_COUNT - 1; i++) {
+      metrics.setDefaultDimensions({ [`dimension-${i}`]: 'test' });
+    }
+
+    // Assess
+    expect(() =>
+      metrics.setDefaultDimensions({ 'dimension-1': 'updated' })
+    ).not.toThrow();
+  });
+
   it('throws when adding dimension sets would exceed the limit', () => {
     // Prepare
     const metrics = new Metrics({


### PR DESCRIPTION
## Summary

### Changes

Fixes the dimension limit check in `setDefaultDimensions()` to account for **all** dimension types (default + regular + dimension sets), not just existing defaults.

Previously, `setDefaultDimensions()` only checked `Object.keys(currentDefaultDimensions).length + Object.keys(newDimensions).length`, completely ignoring regular dimensions added via `addDimension()` and dimension sets from `addDimensions()`. This allowed silently exceeding CloudWatch's 29-dimension limit, causing metrics to be dropped.

#### What changed

- **`Metrics.ts`**: Replaced the narrow default-only count with `getDimensionCount()` (which correctly sums all dimension types). Also filters for genuinely new keys to avoid double-counting when overriding existing defaults.
- **`dimensions.test.ts`**: Added two tests:
  - Verifies `setDefaultDimensions()` throws when regular dimensions already fill the limit
  - Verifies overriding existing default keys doesn't trigger a false limit violation

**Issue number:** Closes #5206

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
