### PR TITLE
fix(metrics): enforce dimension limits per-array

### DIFF
--- a/packages/metrics/src/DimensionsStore.ts
+++ b/packages/metrics/src/DimensionsStore.ts
@@ -92,20 +92,6 @@ class DimensionsStore {
     this.#defaultDimensions = {};
   }
 
-  public getDimensionCount(): number {
-    const dimensions = this.#getDimensions();
-    const dimensionSets = this.#getDimensionSets();
-    const dimensionSetsCount = dimensionSets.reduce(
-      (total, dimensionSet) => total + Object.keys(dimensionSet).length,
-      0
-    );
-    return (
-      Object.keys(dimensions).length +
-      Object.keys(this.#defaultDimensions).length +
-      dimensionSetsCount
-    );
-  }
-
   public setDefaultDimensions(dimensions: Dimensions): void {
     this.#defaultDimensions = { ...dimensions };
   }

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -247,13 +247,18 @@ class Metrics extends Utility implements MetricsInterface {
       );
       return this;
     }
-    if (MAX_DIMENSION_COUNT <= this.#dimensionsStore.getDimensionCount()) {
+    const dimensions = this.#dimensionsStore.getDimensions();
+    const defaultDimensions = this.#dimensionsStore.getDefaultDimensions();
+    const projectedSize = new Set([
+      ...Object.keys(defaultDimensions),
+      ...Object.keys(dimensions),
+      name,
+    ]).size;
+    if (projectedSize > MAX_DIMENSION_COUNT) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );
     }
-    const dimensions = this.#dimensionsStore.getDimensions();
-    const defaultDimensions = this.#dimensionsStore.getDefaultDimensions();
     if (
       Object.hasOwn(dimensions, name) ||
       Object.hasOwn(defaultDimensions, name)
@@ -280,9 +285,12 @@ class Metrics extends Utility implements MetricsInterface {
    */
   public addDimensions(dimensions: Dimensions): this {
     const newDimensions = this.#sanitizeDimensions(dimensions);
-    const currentCount = this.#dimensionsStore.getDimensionCount();
-    const newSetCount = Object.keys(newDimensions).length;
-    if (currentCount + newSetCount >= MAX_DIMENSION_COUNT) {
+    const defaultDimensions = this.#dimensionsStore.getDefaultDimensions();
+    const projectedSize = new Set([
+      ...Object.keys(defaultDimensions),
+      ...Object.keys(newDimensions),
+    ]).size;
+    if (projectedSize > MAX_DIMENSION_COUNT) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );
@@ -798,13 +806,29 @@ class Metrics extends Utility implements MetricsInterface {
     const newDimensions = this.#sanitizeDimensions(dimensions);
     const currentDefaultDimensions =
       this.#dimensionsStore.getDefaultDimensions();
-    const newKeysCount = Object.keys(newDimensions).filter(
-      (key) => !Object.hasOwn(currentDefaultDimensions, key)
-    ).length;
-    if (
-      this.#dimensionsStore.getDimensionCount() + newKeysCount >=
-      MAX_DIMENSION_COUNT
-    ) {
+    const currentDimensions = this.#dimensionsStore.getDimensions();
+    const dimensionSets = this.#dimensionsStore.getDimensionSets();
+
+    const combinedDefaultKeys = [
+      ...Object.keys(currentDefaultDimensions),
+      ...Object.keys(newDimensions),
+    ];
+    let maxProjectedSize = new Set([
+      ...combinedDefaultKeys,
+      ...Object.keys(currentDimensions),
+    ]).size;
+
+    for (const dimensionSet of dimensionSets) {
+      const setSize = new Set([
+        ...combinedDefaultKeys,
+        ...Object.keys(dimensionSet),
+      ]).size;
+      if (setSize > maxProjectedSize) {
+        maxProjectedSize = setSize;
+      }
+    }
+
+    if (maxProjectedSize > MAX_DIMENSION_COUNT) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
       );

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -249,11 +249,15 @@ class Metrics extends Utility implements MetricsInterface {
     }
     const dimensions = this.#dimensionsStore.getDimensions();
     const defaultDimensions = this.#dimensionsStore.getDefaultDimensions();
+    // addDimension only mutates the regular dimensions array, so we don't need to project against dimensionSets
+    // (each set is an independent published array).
     const projectedSize = new Set([
       ...Object.keys(defaultDimensions),
       ...Object.keys(dimensions),
       name,
     ]).size;
+    // MAX_DIMENSION_COUNT is 29 (EMF 30 dimension cap - 1 reserved for service).
+    // Thus exactly 29 custom dimensions are allowed, and we throw only if strictly greater.
     if (projectedSize > MAX_DIMENSION_COUNT) {
       throw new RangeError(
         `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
@@ -286,6 +290,7 @@ class Metrics extends Utility implements MetricsInterface {
   public addDimensions(dimensions: Dimensions): this {
     const newDimensions = this.#sanitizeDimensions(dimensions);
     const defaultDimensions = this.#dimensionsStore.getDefaultDimensions();
+    // addDimensions creates a new independent dimensionSet array, so we only project against defaultDimensions.
     const projectedSize = new Set([
       ...Object.keys(defaultDimensions),
       ...Object.keys(newDimensions),
@@ -813,10 +818,13 @@ class Metrics extends Utility implements MetricsInterface {
       ...Object.keys(currentDefaultDimensions),
       ...Object.keys(newDimensions),
     ];
-    let maxProjectedSize = new Set([
-      ...combinedDefaultKeys,
-      ...Object.keys(currentDimensions),
-    ]).size;
+    const currentDimensionsKeys = Object.keys(currentDimensions);
+    // The main array is only emitted if currentDimensions has keys.
+    // When empty, maxProjectedSize safely defaults to just the combinedDefaultKeys length to guard against phantom arrays.
+    let maxProjectedSize =
+      currentDimensionsKeys.length > 0
+        ? new Set([...combinedDefaultKeys, ...currentDimensionsKeys]).size
+        : new Set(combinedDefaultKeys).size;
 
     for (const dimensionSet of dimensionSets) {
       const setSize = new Set([

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -338,7 +338,7 @@ describe('Working with dimensions', () => {
     }
 
     // Assess
-    expect(() => metrics.addDimension('extra', 'test')).toThrowError(
+    expect(() => metrics.addDimension('extra', 'test')).toThrow(
       `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
     );
   });
@@ -351,12 +351,12 @@ describe('Working with dimensions', () => {
 
     // Act
     // We start with 1 dimension because service name is already added
-    for (let i = 1; i < MAX_DIMENSION_COUNT - 1; i++) {
+    for (let i = 1; i < MAX_DIMENSION_COUNT; i++) {
       metrics.setDefaultDimensions({ [`dimension-${i}`]: 'test' });
     }
 
     // Assess
-    expect(() => metrics.setDefaultDimensions({ extra: 'test' })).toThrowError(
+    expect(() => metrics.setDefaultDimensions({ extra: 'test' })).toThrow(
       'The number of metric dimensions must be lower than 29'
     );
   });
@@ -368,9 +368,30 @@ describe('Working with dimensions', () => {
     });
 
     // Act
-    for (let i = 1; i < MAX_DIMENSION_COUNT - 1; i++) {
+    for (let i = 1; i < MAX_DIMENSION_COUNT; i++) {
       metrics.addDimension(`regular-${i}`, 'test');
     }
+
+    // Assess
+    expect(() =>
+      metrics.setDefaultDimensions({ 'new-default': 'test' })
+    ).toThrow(
+      `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
+    );
+  });
+
+  it('throws when setDefaultDimensions would exceed the limit with existing dimension sets', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
+
+    // Act
+    const newDimensionSet: Record<string, string> = {};
+    for (let i = 0; i < 28; i++) {
+      newDimensionSet[`dimension-extra-${i}`] = 'test';
+    }
+    metrics.addDimensions(newDimensionSet);
 
     // Assess
     expect(() =>
@@ -387,13 +408,48 @@ describe('Working with dimensions', () => {
     });
 
     // Act
-    for (let i = 1; i < MAX_DIMENSION_COUNT - 1; i++) {
+    for (let i = 1; i < MAX_DIMENSION_COUNT; i++) {
       metrics.setDefaultDimensions({ [`dimension-${i}`]: 'test' });
     }
 
     // Assess
     expect(() =>
       metrics.setDefaultDimensions({ 'dimension-1': 'updated' })
+    ).not.toThrow();
+  });
+
+  it('allows overriding existing regular dimensions via addDimension without triggering the limit', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
+
+    // Act
+    for (let i = 1; i < MAX_DIMENSION_COUNT; i++) {
+      metrics.addDimension(`dimension-${i}`, 'test');
+    }
+
+    // Assess
+    expect(() => metrics.addDimension('dimension-1', 'updated')).not.toThrow();
+  });
+
+  it('allows overriding existing default dimensions via addDimensions without triggering the limit', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: true,
+    });
+
+    // Act
+    for (let i = 1; i < MAX_DIMENSION_COUNT; i++) {
+      metrics.setDefaultDimensions({ [`dimension-${i}`]: 'test' });
+    }
+
+    // Assess
+    expect(() =>
+      metrics.addDimensions({
+        'dimension-1': 'updated',
+        'dimension-2': 'updated',
+      })
     ).not.toThrow();
   });
 
@@ -407,20 +463,16 @@ describe('Working with dimensions', () => {
     });
 
     // Act
+    const newDimensionSet: Record<string, string> = {};
     // We start with 2 dimensions because the default dimension & service name are already added
-    for (let i = 2; i < MAX_DIMENSION_COUNT; i++) {
-      metrics.addDimension(`dimension-${i}`, 'test');
+    // We need 28 more to exceed the limit of 29 (2 + 28 = 30 > 29)
+    for (let i = 0; i < 28; i++) {
+      newDimensionSet[`dimension-extra-${i}`] = 'test';
     }
 
     // Assess
-    // Adding a dimension set with 3 dimensions would exceed the limit
-    expect(() =>
-      metrics.addDimensions({
-        'dimension-extra-1': 'test',
-        'dimension-extra-2': 'test',
-        'dimension-extra-3': 'test',
-      })
-    ).toThrowError(
+    // Adding a dimension set that results in > 29 dimensions should exceed the limit
+    expect(() => metrics.addDimensions(newDimensionSet)).toThrow(
       `The number of metric dimensions must be lower than ${MAX_DIMENSION_COUNT}`
     );
   });
@@ -646,5 +698,20 @@ describe('Working with dimensions', () => {
     expect(console.log).toHaveEmittedEMFWith(
       expect.not.objectContaining({ [name]: value })
     );
+  });
+  it('allows adding multiple dimension sets as long as no single set exceeds MAX_DIMENSION_COUNT', () => {
+    // Prepare
+    const metrics = new Metrics({ namespace: 'test' });
+
+    // Act
+    // Add 30 dimension sets, each with 1 dimension
+    for (let i = 0; i < 30; i++) {
+      metrics.addDimensions({ [`dim-${i}`]: 'value' });
+    }
+
+    metrics.addMetric('test', MetricUnit.Count, 1);
+
+    // Assess
+    expect(() => metrics.publishStoredMetrics()).not.toThrow();
   });
 });

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -475,6 +475,22 @@ describe('Working with dimensions', () => {
     );
   });
 
+  it('allows setDefaultDimensions to evaluate maxProjectedSize correctly when dimensionSets are smaller', () => {
+    // Prepare
+    const metrics = new Metrics({ singleMetric: true });
+
+    // Act
+    metrics.addDimension('dim1', 'val1');
+    metrics.addDimension('dim2', 'val2');
+    metrics.addDimensions({ setDim1: 'val3' });
+
+    // Assess
+    // This triggers setDefaultDimensions logic where setSize (3) < maxProjectedSize (4), covering the false branch.
+    expect(() =>
+      metrics.setDefaultDimensions({ newDefault: 'val4' })
+    ).not.toThrow();
+  });
+
   it('handles dimension overrides across multiple dimension sets', () => {
     // Prepare
     const metrics = new Metrics({

--- a/packages/metrics/tests/unit/dimensions.test.ts
+++ b/packages/metrics/tests/unit/dimensions.test.ts
@@ -433,7 +433,7 @@ describe('Working with dimensions', () => {
     expect(() => metrics.addDimension('dimension-1', 'updated')).not.toThrow();
   });
 
-  it('allows overriding existing default dimensions via addDimensions without triggering the limit', () => {
+  it('allows addDimensions to override existing default dimension keys without triggering the limit', () => {
     // Prepare
     const metrics = new Metrics({
       singleMetric: true,
@@ -464,8 +464,6 @@ describe('Working with dimensions', () => {
 
     // Act
     const newDimensionSet: Record<string, string> = {};
-    // We start with 2 dimensions because the default dimension & service name are already added
-    // We need 28 more to exceed the limit of 29 (2 + 28 = 30 > 29)
     for (let i = 0; i < 28; i++) {
       newDimensionSet[`dimension-extra-${i}`] = 'test';
     }


### PR DESCRIPTION
## Summary

### Changes

This PR fundamentally fixes how dimension limits (`MAX_DIMENSION_COUNT`) are enforced across the `Metrics` class. It resolves the issue where valid dimension updates were incorrectly rejected near the limit due to overlapping keys being double-counted.

**What is this PR solving?**
Previously, limit checks relied on `this.#dimensionsStore.getDimensionCount()`, which naively summed the sizes of `dimensions`, `defaultDimensions`, and **all** `dimensionSets`. This approach was flawed for a few reasons:
1. **CloudWatch EMF Constraints:** CloudWatch publishes each `dimensionSet` as a completely separate array of dimensions. The CloudWatch limit of 30 dimensions applies to the maximum size of *any individual array*, not the sum of all dimensions defined across all sets. 
2. **Double Counting:** Using simple arithmetic (`currentCount + newCount`) meant that updating an existing key would incorrectly inflate the dimension count, causing a `RangeError` (issue #5205).
3. **Off-by-one Inconsistencies:** `addDimension` allowed 29 dimensions, whereas `addDimensions` and `setDefaultDimensions` only allowed 28 due to a `>=` vs `>` discrepancy.

**Fix Details:**
- **Replaced naive sums with projected array sizes:** We now use Javascript `Set` to calculate the exact maximum size of the specific dimension arrays that will actually be published to CloudWatch EMF.
- **Natively Handles Updates:** Because `Set` automatically deduplicates overlapping keys, updating existing dimensions inherently evaluates to a size of `0` new dimensions—fixing #5205 automatically.
- **Fixed off-by-one bug:** The limit checks now uniformly use `projectedSize > MAX_DIMENSION_COUNT` so exactly 29 custom dimensions are permitted across all methods (accommodating the 30th reserved `service` dimension).
- **Added comprehensive edge-case tests:** Added tests proving that overlapping keys at the limit threshold behave correctly, and added a regression test proving that adding multiple valid dimension sets no longer incorrectly hits the global dimension limit.

**Issue number:** closes #5205

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
