### PR TITLE
improv(docs): fixed the docs to mention middy support for v7.x

### DIFF
--- a/docs/features/validation.md
+++ b/docs/features/validation.md
@@ -66,7 +66,7 @@ It's not mandatory to validate both the inbound and outbound payloads. You can e
 If you are using Middy.js, you can use the `validator` middleware to validate the incoming event and response payload.
 
 ??? note "A note on Middy.js"
-    We officially support versions of Middy.js `v4.x` through `v6.x`
+    We officially support versions of Middy.js `v4.x` through `v7.x`
 
     Check their docs to learn more about [Middy.js and its middleware stack](https://middy.js.org/docs/intro/getting-started){target="_blank"} as well as [best practices when working with Powertools for AWS](https://middy.js.org/docs/integrations/lambda-powertools#best-practices){target="_blank"}.
 

--- a/docs/getting-started/usage-patterns.md
+++ b/docs/getting-started/usage-patterns.md
@@ -33,7 +33,7 @@ All our decorators assume that the method they are decorating is asynchronous. T
 If your existing codebase relies on the [Middy.js](https://middy.js.org/docs/) middleware engine, you can use the Powertools for AWS Lambda (TypeScript) middleware to integrate with your existing code. This approach is similar to the Class Method decorator pattern but uses the Middy.js middleware engine to apply Powertools utilities.
 
 !!! note
-    We guarantee support for Middy.js `v5.x` and `v6.x`.
+    We guarantee support for Middy.js `v4.x` through `v7.x`.
     Check Middy.js docs to learn more about [best practices](https://middy.js.org/docs/integrations/lambda-powertools#best-practices){target="_blank"} when working with Powertools for AWS middlewares.
 
 ```ts


### PR DESCRIPTION
## Summary

This PR changes the doc to mention that Powertools supports Middy v7.x

### Changes

> Please provide a summary of what's being changed

- Updated the docs to mention support for middy v7.x

<!-- What is this PR solving? Write a clear description or reference the issue(s) it addresses. -->

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #5237 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
