### PR TITLE
fix(parser): cognito validationData may be null 

### DIFF
--- a/packages/parser/src/schemas/cognito.ts
+++ b/packages/parser/src/schemas/cognito.ts
@@ -138,7 +138,7 @@ const PreAuthenticationTriggerSchema = CognitoTriggerBaseSchema.extend({
   triggerSource: z.literal('PreAuthentication_Authentication'),
   request: z.object({
     userAttributes: z.record(z.string(), z.string()),
-    validationData: z.record(z.string(), z.string()).optional(),
+    validationData: z.record(z.string(), z.string()).optional().nullable(),
     userNotFound: z.boolean().optional(),
   }),
   response: z.object({}),

--- a/packages/parser/tests/unit/schema/cognito.test.ts
+++ b/packages/parser/tests/unit/schema/cognito.test.ts
@@ -125,6 +125,26 @@ describe('Schemas: Cognito User Pool', () => {
     expect(result).toEqual(event);
   });
 
+  it('parses a valid pre-authentication event with null validationData', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+    event.triggerSource = 'PreAuthentication_Authentication';
+    event.request = {
+      userAttributes: {
+        sub: '42051434-5091-70ec-4b71-7c26db407ea4',
+        'cognito:user_status': 'CONFIRMED',
+      },
+      userNotFound: false,
+      validationData: null,
+    };
+
+    // Act
+    const result = PreAuthenticationTriggerSchema.parse(event);
+
+    // Assess
+    expect(result).toEqual(event);
+  });
+
   it('throws if the pre-authentication event is missing a required field', () => {
     // Prepare
     const event = structuredClone(baseEvent);


### PR DESCRIPTION
## Summary

For the Cognito Trigger pre-authentication event, handle the possibility that the `validationData` may be null instead of absent.

### Changes

As reported in #5249 `validationData` may be null instead of optional. Adjust the Zod schema to handle this as well.
I have included a test.

**Issue number:** closes #5249 

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.