### PR TITLE
fix(event-handler): normalize trailing slashes in HTTP Router prefix joining

### DIFF
--- a/packages/event-handler/src/http/Router.ts
+++ b/packages/event-handler/src/http/Router.ts
@@ -81,6 +81,7 @@ import {
   isBinaryResult,
   isExtendedAPIGatewayProxyResult,
   resolvePrefixedPath,
+  stripTrailingSlashes,
 } from './utils.js';
 
 class Router<TEnv extends Env = Env> {
@@ -344,7 +345,7 @@ class Router<TEnv extends Env = Env> {
       const method = req.method as HttpMethod;
       const rawPath = new URL(req.url).pathname;
       const path = (
-        rawPath === '/' ? rawPath : rawPath.replace(/\/+$/, '')
+        rawPath === '/' ? rawPath : stripTrailingSlashes(rawPath)
       ) as Path;
 
       const route = this.routeRegistry.resolve(method, path);

--- a/packages/event-handler/src/http/Router.ts
+++ b/packages/event-handler/src/http/Router.ts
@@ -342,7 +342,10 @@ class Router<TEnv extends Env = Env> {
 
     try {
       const method = req.method as HttpMethod;
-      const path = new URL(req.url).pathname as Path;
+      const rawPath = new URL(req.url).pathname;
+      const path = (
+        rawPath === '/' ? rawPath : rawPath.replace(/\/+$/, '')
+      ) as Path;
 
       const route = this.routeRegistry.resolve(method, path);
 

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -339,15 +339,24 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
  * @param path - The path to resolve
  * @param prefix - The prefix to prepend to the path; trailing slashes are ignored
  */
+// Linear-time trailing-slash strip. Avoids `replace(/\/+$/, '')` to keep
+// behavior linear on attacker-controlled request paths.
+export const stripTrailingSlashes = (input: string): string => {
+  let end = input.length;
+  while (end > 0 && input[end - 1] === '/') end--;
+  return end === input.length ? input : input.slice(0, end);
+};
+
 export const resolvePrefixedPath = (path: Path, prefix?: Path): Path => {
   if (!prefix) return path;
-  const prefixStr = getPathString(prefix).replace(/\/+$/, '');
+  const prefixStr = stripTrailingSlashes(getPathString(prefix));
   if (isRegExp(prefix) || isRegExp(path)) {
     const pathStr = getPathString(path);
     const sep = pathStr.startsWith('/') ? '' : '/';
     return new RegExp(`${prefixStr}${sep}${pathStr}`);
   }
-  return `${prefixStr}${path}`.replace(/\/$/, '') as Path;
+  const joined = `${prefixStr}${path}`;
+  return (joined.endsWith('/') ? joined.slice(0, -1) : joined) as Path;
 };
 
 export const HttpResponseStream =

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -322,6 +322,14 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
   };
 };
 
+// Linear-time trailing-slash strip. Avoids `replace(/\/+$/, '')` to keep
+// behavior linear on attacker-controlled request paths.
+export const stripTrailingSlashes = (input: string): string => {
+  let end = input.length;
+  while (end > 0 && input[end - 1] === '/') end--;
+  return end === input.length ? input : input.slice(0, end);
+};
+
 /**
  * Resolves a prefixed path by combining the provided path and prefix.
  *
@@ -339,14 +347,6 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
  * @param path - The path to resolve
  * @param prefix - The prefix to prepend to the path; trailing slashes are ignored
  */
-// Linear-time trailing-slash strip. Avoids `replace(/\/+$/, '')` to keep
-// behavior linear on attacker-controlled request paths.
-export const stripTrailingSlashes = (input: string): string => {
-  let end = input.length;
-  while (end > 0 && input[end - 1] === '/') end--;
-  return end === input.length ? input : input.slice(0, end);
-};
-
 export const resolvePrefixedPath = (path: Path, prefix?: Path): Path => {
   if (!prefix) return path;
   const prefixStr = stripTrailingSlashes(getPathString(prefix));

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -325,24 +325,29 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
 /**
  * Resolves a prefixed path by combining the provided path and prefix.
  *
- * The function returns a RegExp if any of the path or prefix is a RegExp.
- * Otherwise, it returns a `/${string}` type value.
+ * Trailing slashes on the prefix are stripped before joining, so a prefix of
+ * `/api` and `/api/` produce the same result. When the resulting path would
+ * end with a redundant `/` (e.g. path `/` under any prefix), the trailing
+ * slash is collapsed so the route id is canonical (`/api`, not `/api/`).
+ * Incoming request paths are normalized the same way at lookup time, so a
+ * route registered with path `/` under prefix `/api` matches both `/api` and
+ * `/api/`.
+ *
+ * Returns a `RegExp` if either argument is a `RegExp`; otherwise a
+ * `/${string}` typed value.
  *
  * @param path - The path to resolve
- * @param prefix - The prefix to prepend to the path
+ * @param prefix - The prefix to prepend to the path; trailing slashes are ignored
  */
 export const resolvePrefixedPath = (path: Path, prefix?: Path): Path => {
   if (!prefix) return path;
-  if (isRegExp(prefix)) {
-    if (isRegExp(path)) {
-      return new RegExp(`${getPathString(prefix)}/${getPathString(path)}`);
-    }
-    return new RegExp(`${getPathString(prefix)}${path}`);
+  const prefixStr = getPathString(prefix).replace(/\/+$/, '');
+  if (isRegExp(prefix) || isRegExp(path)) {
+    const pathStr = getPathString(path);
+    const sep = pathStr.startsWith('/') ? '' : '/';
+    return new RegExp(`${prefixStr}${sep}${pathStr}`);
   }
-  if (isRegExp(path)) {
-    return new RegExp(`${prefix}/${getPathString(path)}`);
-  }
-  return `${prefix}${path}`.replace(/\/$/, '') as Path;
+  return `${prefixStr}${path}`.replace(/\/$/, '') as Path;
 };
 
 export const HttpResponseStream =

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -322,8 +322,17 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
   };
 };
 
-// Linear-time trailing-slash strip. Avoids `replace(/\/+$/, '')` to keep
-// behavior linear on attacker-controlled request paths.
+/**
+ * Strips trailing forward slashes from a path string in linear time.
+ *
+ * Implemented as a manual scan from the right rather than `replace(/\/+$/, '')`
+ * to keep the cost linear on attacker-controlled request paths — a regex
+ * approach can be coerced into pathological backtracking on inputs with long
+ * runs of slashes.
+ *
+ * @param input - The path string to normalize
+ * @returns The input with any trailing `/` characters removed; the original string is returned unchanged when no trailing slashes are present
+ */
 export const stripTrailingSlashes = (input: string): string => {
   let end = input.length;
   while (end > 0 && input[end - 1] === '/') end--;

--- a/packages/event-handler/tests/unit/http/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/http/Router/basic-routing.test.ts
@@ -218,6 +218,39 @@ describe.each([
     expect(JSON.parse(getResult.body ?? '{}').actualPath).toBe('/todos/1');
   });
 
+  it('matches a root route registered under a prefix for both /prefix and /prefix/', async () => {
+    // Prepare
+    const app = new Router({ prefix: '/api' });
+    app.get('/', () => ({ root: true }));
+
+    // Act
+    const noSlash = await app.resolve(createEvent('/api', 'GET'), context);
+    const trailingSlash = await app.resolve(
+      createEvent('/api/', 'GET'),
+      context
+    );
+
+    // Assess
+    expect(noSlash.statusCode).toBe(200);
+    expect(JSON.parse(noSlash.body ?? '{}')).toEqual({ root: true });
+    expect(trailingSlash.statusCode).toBe(200);
+    expect(JSON.parse(trailingSlash.body ?? '{}')).toEqual({ root: true });
+  });
+
+  it('routes correctly when prefix accidentally ends with a slash', async () => {
+    // Prepare: prefix ends with `/` — the registered route id should not
+    // contain `//` and incoming requests should still match.
+    const app = new Router({ prefix: '/api/' });
+    app.get('/users', () => ({ users: [] }));
+
+    // Act
+    const result = await app.resolve(createEvent('/api/users', 'GET'), context);
+
+    // Assess
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body ?? '{}')).toEqual({ users: [] });
+  });
+
   it('routes to the included router when using split routers', async () => {
     // Prepare
     const todoRouter = new Router({ logger: console });

--- a/packages/event-handler/tests/unit/http/utils.test.ts
+++ b/packages/event-handler/tests/unit/http/utils.test.ts
@@ -855,6 +855,8 @@ describe('Path Utilities', () => {
     it.each([
       { path: '/test', prefix: '/prefix', expected: '/prefix/test' },
       { path: '/', prefix: '/prefix', expected: '/prefix' },
+      { path: '/users', prefix: '/api/', expected: '/api/users' },
+      { path: '/', prefix: '/api/', expected: '/api' },
       { path: '/test', expected: '/test' },
       { path: /.+/, prefix: '/prefix', expected: /\/prefix\/.+/ },
       { path: '/test', prefix: /\/prefix/, expected: /\/prefix\/test/ },


### PR DESCRIPTION
## Summary

`Router` registered route ids did not handle trailing slashes consistently: a root route under a prefix (e.g. `app.get('/', …)` with `prefix: '/api'`) was unreachable from `/api/`, and a prefix that accidentally ended with `/` produced double slashes in the route id (e.g. `'/api//users'`), breaking matches.

### Changes

- `resolvePrefixedPath` now strips trailing slashes from the prefix before joining, so `'/api'` and `'/api/'` produce the same result and no `//` appears in the route id.
- `Router.resolve` normalizes incoming request paths the same way (preserving `/` itself), so a route registered as `/` under prefix `/api` matches both `/api` and `/api/`.
- Added unit cases for `resolvePrefixedPath` covering prefix-with-trailing-slash inputs, and integration tests in `basic-routing.test.ts` for both bug scenarios from the issue.
- Updated the `resolvePrefixedPath` JSDoc to document the normalization preconditions.

**Issue number:** closes #5252

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.