### PR TITLE
fix(event-handler): restrict v1/alb comma header splitting to an allowlist

### DIFF
--- a/packages/event-handler/src/http/constants.ts
+++ b/packages/event-handler/src/http/constants.ts
@@ -116,6 +116,26 @@ const COMPRESSION_ENCODING_TYPES = {
   ANY: '*',
 } as const;
 
+/**
+ * Known headers that are defined as a comma-separated list of values (1#element).
+ * These headers can be safely split by commas to populate multiValueHeaders.
+ */
+const MULTI_VALUE_HEADERS_ALLOWLIST = new Set([
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'cache-control',
+  'vary',
+  'connection',
+  'allow',
+  'x-forwarded-for',
+  'te',
+  'expect',
+  'transfer-encoding',
+  'content-encoding',
+  'content-language',
+]);
+
 const HttpStatusText: Record<number, string> = {
   // 2xx Success
   200: 'OK',
@@ -192,6 +212,7 @@ export {
   HttpStatusCodes,
   HttpStatusText,
   HttpVerbs,
+  MULTI_VALUE_HEADERS_ALLOWLIST,
   PARAM_PATTERN,
   SAFE_CHARS,
   UNSAFE_CHARS,

--- a/packages/event-handler/src/http/converters.ts
+++ b/packages/event-handler/src/http/converters.ts
@@ -218,6 +218,26 @@ const proxyEventToWebRequest = (
 };
 
 /**
+ * Known headers that are defined as a comma-separated list of values (1#element).
+ * These headers can be safely split by commas to populate multiValueHeaders.
+ */
+const MULTI_VALUE_HEADERS_ALLOWLIST = new Set([
+  'accept',
+  'accept-encoding',
+  'accept-language',
+  'cache-control',
+  'vary',
+  'connection',
+  'allow',
+  'x-forwarded-for',
+  'te',
+  'expect',
+  'transfer-encoding',
+  'content-encoding',
+  'content-language',
+]);
+
+/**
  * Converts Web API Headers to API Gateway V1 headers format.
  * Splits multi-value headers by comma or semicolon and organizes them into separate objects.
  *
@@ -245,10 +265,20 @@ const webHeadersToApiGatewayV1Headers = (webHeaders: Headers) => {
       continue;
     }
 
-    const values = value.split(',').map((v) => v.trimStart());
+    const lowerKey = key.toLowerCase();
 
-    if (values.length > 1) {
-      multiValueHeaders[key] = values;
+    // Only split on comma if the header is an allowed multi-value header or starts with access-control-
+    if (
+      MULTI_VALUE_HEADERS_ALLOWLIST.has(lowerKey) ||
+      lowerKey.startsWith('access-control-')
+    ) {
+      const values = value.split(',').map((v) => v.trimStart());
+
+      if (values.length > 1) {
+        multiValueHeaders[key] = values;
+      } else {
+        headers[key] = value;
+      }
     } else {
       headers[key] = value;
     }

--- a/packages/event-handler/src/http/converters.ts
+++ b/packages/event-handler/src/http/converters.ts
@@ -18,7 +18,12 @@ import type {
   V1Headers,
   WebResponseToProxyResultOptions,
 } from '../types/http.js';
-import { HttpStatusCodes, HttpStatusText, HttpVerbs } from './constants.js';
+import {
+  HttpStatusCodes,
+  HttpStatusText,
+  HttpVerbs,
+  MULTI_VALUE_HEADERS_ALLOWLIST,
+} from './constants.js';
 import { InvalidHttpMethodError } from './errors.js';
 import {
   isALBEvent,
@@ -216,26 +221,6 @@ const proxyEventToWebRequest = (
   }
   return proxyEventV1ToWebRequest(event);
 };
-
-/**
- * Known headers that are defined as a comma-separated list of values (1#element).
- * These headers can be safely split by commas to populate multiValueHeaders.
- */
-const MULTI_VALUE_HEADERS_ALLOWLIST = new Set([
-  'accept',
-  'accept-encoding',
-  'accept-language',
-  'cache-control',
-  'vary',
-  'connection',
-  'allow',
-  'x-forwarded-for',
-  'te',
-  'expect',
-  'transfer-encoding',
-  'content-encoding',
-  'content-language',
-]);
 
 /**
  * Converts Web API Headers to API Gateway V1 headers format.

--- a/packages/event-handler/tests/unit/http/converters.test.ts
+++ b/packages/event-handler/tests/unit/http/converters.test.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
+import { MULTI_VALUE_HEADERS_ALLOWLIST } from '../../../src/http/constants.js';
 import {
   bodyToNodeStream,
   webHeadersToApiGatewayHeaders,
@@ -1460,6 +1461,25 @@ describe('Converters', () => {
           'x-custom-string': 'foo, bar, baz',
         },
         multiValueHeaders: {},
+      });
+    });
+
+    it.each(
+      Array.from(MULTI_VALUE_HEADERS_ALLOWLIST)
+    )('splits allowed comma-separated header: %s', (headerName) => {
+      // Prepare
+      const headers = new Headers();
+      headers.set(headerName, 'value1, value2, value3');
+
+      // Act
+      const result = webHeadersToApiGatewayHeaders(headers, 'ApiGatewayV1');
+
+      // Assess
+      expect(result).toEqual({
+        headers: {},
+        multiValueHeaders: {
+          [headerName]: ['value1', 'value2', 'value3'],
+        },
       });
     });
 

--- a/packages/event-handler/tests/unit/http/converters.test.ts
+++ b/packages/event-handler/tests/unit/http/converters.test.ts
@@ -1390,8 +1390,8 @@ describe('Converters', () => {
     it('handles duplicate header keys by accumulating values', () => {
       // Prepare
       const headers = new Headers();
-      headers.append('x-custom', 'value1');
-      headers.append('x-custom', 'value2');
+      headers.append('x-forwarded-for', 'value1');
+      headers.append('x-forwarded-for', 'value2');
 
       // Act
       const result = webHeadersToApiGatewayHeaders(headers, 'ApiGatewayV1');
@@ -1400,7 +1400,7 @@ describe('Converters', () => {
       expect(result).toEqual({
         headers: {},
         multiValueHeaders: {
-          'x-custom': ['value1', 'value2'],
+          'x-forwarded-for': ['value1', 'value2'],
         },
       });
     });
@@ -1408,8 +1408,8 @@ describe('Converters', () => {
     it('moves header from headers to multiValueHeaders when duplicate appears', () => {
       // Prepare
       const headers = new Headers();
-      headers.set('x-custom', 'value1');
-      headers.append('x-custom', 'value2');
+      headers.set('x-forwarded-for', 'value1');
+      headers.append('x-forwarded-for', 'value2');
 
       // Act
       const result = webHeadersToApiGatewayHeaders(headers, 'ApiGatewayV1');
@@ -1418,7 +1418,7 @@ describe('Converters', () => {
       expect(result).toEqual({
         headers: {},
         multiValueHeaders: {
-          'x-custom': ['value1', 'value2'],
+          'x-forwarded-for': ['value1', 'value2'],
         },
       });
     });
@@ -1439,6 +1439,27 @@ describe('Converters', () => {
         multiValueHeaders: {
           accept: ['application/json', 'text/html', 'text/plain'],
         },
+      });
+    });
+
+    it('does not split single-value headers containing commas', () => {
+      // Prepare
+      const headers = new Headers();
+      headers.set('date', 'Sun, 06 Nov 1994 08:49:37 GMT');
+      headers.set('last-modified', 'Sunday, 06-Nov-94 08:49:37 GMT');
+      headers.set('x-custom-string', 'foo, bar, baz');
+
+      // Act
+      const result = webHeadersToApiGatewayHeaders(headers, 'ApiGatewayV1');
+
+      // Assess
+      expect(result).toEqual({
+        headers: {
+          date: 'Sun, 06 Nov 1994 08:49:37 GMT',
+          'last-modified': 'Sunday, 06-Nov-94 08:49:37 GMT',
+          'x-custom-string': 'foo, bar, baz',
+        },
+        multiValueHeaders: {},
       });
     });
 


### PR DESCRIPTION
## Summary

### Changes

The HTTP `webHeadersToApiGatewayV1Headers` converter previously split all headers indiscriminately by comma `,` to construct the `multiValueHeaders` object. This corrupted several standard single-value HTTP headers that naturally contain commas as part of their syntax, most notably `Date`, `Last-Modified`, and `Expires`.

This PR introduces an allowlist mechanism (`MULTI_VALUE_HEADERS_ALLOWLIST`) based on the HTTP `1#element` specification. Only known multi-value headers are split by commas to populate the `multiValueHeaders` object.

The allowlist includes:
* `accept`
* `accept-encoding`
* `accept-language`
* `cache-control`
* `vary`
* `connection`
* `allow`
* `x-forwarded-for`
* `te`
* `expect`
* `transfer-encoding`
* `content-encoding`
* `content-language`
* Any header starting with `access-control-`

All other headers are assigned exactly as they were passed into the standard `headers` object.

- Added `MULTI_VALUE_HEADERS_ALLOWLIST` to `constants.ts`.
- Updated `webHeadersToApiGatewayV1Headers` to condition the comma-split operation on the allowlist.
- Added tests asserting that `Date` and `Last-Modified` headers are not split.
- Updated existing `converters.test.ts` test cases to use allowed headers when testing the `multiValueHeaders` accumulation logic.

**Issue number:** closes #5256

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
