### PR TITLE
fix(event-handler): preserve ALB PATCH bodies

### DIFF
--- a/packages/event-handler/src/http/converters.ts
+++ b/packages/event-handler/src/http/converters.ts
@@ -182,9 +182,9 @@ const albEventToWebRequest = (event: ALBEvent): Request => {
   const url = new URL(path, `${protocol}://${hostname}/`);
   populateV1QueryParams(url, event);
 
-  // ALB events represent GET and PATCH request bodies as empty strings
+  // ALB events represent GET and HEAD request bodies as empty strings
   const body =
-    httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.PATCH
+    httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.HEAD
       ? null
       : createBody(event.body ?? null, event.isBase64Encoded);
 

--- a/packages/event-handler/tests/unit/http/converters.test.ts
+++ b/packages/event-handler/tests/unit/http/converters.test.ts
@@ -1,6 +1,9 @@
 import { Readable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
-import { MULTI_VALUE_HEADERS_ALLOWLIST } from '../../../src/http/constants.js';
+import {
+  HttpVerbs,
+  MULTI_VALUE_HEADERS_ALLOWLIST,
+} from '../../../src/http/constants.js';
 import {
   bodyToNodeStream,
   webHeadersToApiGatewayHeaders,
@@ -468,6 +471,45 @@ describe('Converters', () => {
       expect(request.method).toBe('POST');
       expect(request.text()).resolves.toBe('{"key":"value"}');
       expect(request.headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('handles PATCH request with string body', async () => {
+      // Prepare
+      const event = createTestALBEvent(
+        '/test',
+        HttpVerbs.PATCH,
+        { 'Content-Type': 'application/json' },
+        { key: 'value' }
+      );
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('PATCH');
+      expect(await request.text()).toBe('{"key":"value"}');
+      expect(request.headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('handles HEAD request without a body', () => {
+      // Prepare
+      const event = createTestALBEvent(
+        '/test',
+        HttpVerbs.HEAD,
+        {},
+        {
+          key: 'value',
+        }
+      );
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('HEAD');
+      expect(request.body).toBe(null);
     });
 
     it('decodes base64 encoded body', () => {

--- a/packages/event-handler/tests/unit/http/helpers.ts
+++ b/packages/event-handler/tests/unit/http/helpers.ts
@@ -48,8 +48,8 @@ export const createTestEvent = (
 });
 
 const createAlbBody = (httpMethod: string, body: JSONValue): string | null => {
-  // ALB events represent GET and PATCH request bodies as empty strings
-  if (httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.PATCH) {
+  // ALB events represent GET and HEAD request bodies as empty strings
+  if (httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.HEAD) {
     return '';
   }
   if (body === null) {


### PR DESCRIPTION
## Summary

### Changes

Fixes the ALB event converter so `PATCH` requests keep their event body when converted to a Web API `Request`.

The converter previously treated `PATCH` like a bodyless method and set the body to `null`, so handlers using `await req.json()` could not read non-empty ALB patch payloads. This keeps `GET` bodyless behavior and switches the other bodyless ALB method to `HEAD`.

**Issue number:** closes #5258

## Testing

- `npm --workspace @aws-lambda-powertools/commons run build`
- `npm --workspace @aws-lambda-powertools/event-handler test -- tests/unit/http/converters.test.ts`
- `npm --workspace @aws-lambda-powertools/event-handler run lint:ci`
- `git diff --check`

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
