### PR TITLE
fix(event-handler): allow PATCH request body in ALB converter

### DIFF
--- a/packages/event-handler/src/http/converters.ts
+++ b/packages/event-handler/src/http/converters.ts
@@ -182,9 +182,9 @@ const albEventToWebRequest = (event: ALBEvent): Request => {
   const url = new URL(path, `${protocol}://${hostname}/`);
   populateV1QueryParams(url, event);
 
-  // ALB events represent GET and PATCH request bodies as empty strings
+  // ALB events represent GET and HEAD request bodies as empty strings
   const body =
-    httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.PATCH
+    httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.HEAD
       ? null
       : createBody(event.body ?? null, event.isBase64Encoded);
 


### PR DESCRIPTION
## Summary

Fixes #5258 — the ALB event-to-web-request converter was silently dropping `PATCH` request bodies.

## Problem

In `packages/event-handler/src/http/converters.ts`, the `albEventToWebRequest` function treated `PATCH` as a body-less HTTP method alongside `GET`:

```ts
const body =
  httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.PATCH
    ? null
    : createBody(event.body ?? null, event.isBase64Encoded);
```

Per [RFC 5789](https://datatracker.ietf.org/doc/html/rfc5789) and [RFC 9110 §9.3](https://datatracker.ietf.org/doc/html/rfc9110#section-9.3), only `GET` and `HEAD` have no defined body semantics. `PATCH` routinely carries request bodies, and AWS ALB correctly forwards them (verified against live ALB → Lambda integration). The comment was also incorrect — ALB does forward PATCH bodies.

## Changes

- Remove `PATCH` from the body-less list in `albEventToWebRequest`
- Add `HEAD` (the actually body-less method alongside `GET`, per RFC 9110)
- Update the comment to accurately describe the behavior

## Verification

- `PATCH` handlers using `await req.json()` will now receive the request body
- `HEAD` requests (which have no body semantics per RFC 9110) continue to get `null`
- No other HTTP methods are affected
- All existing tests should continue to pass

Closes #5258