### PR TITLE
fix(event-handler): allow cors preflight without request headers

### DIFF
--- a/packages/event-handler/src/http/middleware/cors.ts
+++ b/packages/event-handler/src/http/middleware/cors.ts
@@ -75,11 +75,12 @@ export const cors = (options?: CorsOptions): Middleware => {
       .get('Access-Control-Request-Headers')
       ?.toLowerCase();
     return (
-      accessControlRequestMethod &&
+      accessControlRequestMethod !== undefined &&
       allowedMethods.includes(accessControlRequestMethod) &&
-      accessControlRequestHeaders
-        ?.split(',')
-        .every((header) => allowedHeaders.includes(header.trim()))
+      (!accessControlRequestHeaders ||
+        accessControlRequestHeaders
+          .split(',')
+          .every((header) => allowedHeaders.includes(header.trim())))
     );
   };
 

--- a/packages/event-handler/tests/unit/http/middleware/cors.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/cors.test.ts
@@ -203,4 +203,40 @@ describe('CORS Middleware', () => {
       corsConfig.maxAge.toString()
     );
   });
+
+  it('handles OPTIONS preflight requests without Access-Control-Request-Headers', async () => {
+    // Prepare
+    const app = new Router();
+    const corsConfig = {
+      origin,
+      allowMethods: ['GET', 'POST'],
+      allowHeaders: ['Authorization', 'Content-Type'],
+      maxAge: 3600,
+    };
+    app.use(cors(corsConfig));
+
+    // Act
+    const result = await app.resolve(
+      createTestEvent('/test', 'OPTIONS', {
+        Origin: origin,
+        'Access-Control-Request-Method': 'GET',
+      }),
+      context
+    );
+
+    // Assess
+    expect(result.statusCode).toBe(204);
+    expect(result.headers?.['access-control-allow-origin']).toEqual(
+      corsConfig.origin
+    );
+    expect(result.multiValueHeaders?.['access-control-allow-methods']).toEqual(
+      corsConfig.allowMethods
+    );
+    expect(result.multiValueHeaders?.['access-control-allow-headers']).toEqual(
+      corsConfig.allowHeaders.map((header) => header.toLowerCase())
+    );
+    expect(result.headers?.['access-control-max-age']).toEqual(
+      corsConfig.maxAge.toString()
+    );
+  });
 });

--- a/packages/event-handler/tests/unit/http/middleware/cors.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/cors.test.ts
@@ -167,7 +167,16 @@ describe('CORS Middleware', () => {
     expect(result.headers?.['access-control-allow-origin']).toBeUndefined();
   });
 
-  it('handles OPTIONS preflight requests', async () => {
+  it.each([
+    [
+      'handles OPTIONS preflight requests',
+      { 'Access-Control-Request-Headers': 'Authorization' },
+    ],
+    [
+      'handles OPTIONS preflight requests without Access-Control-Request-Headers',
+      {} as Record<string, string>,
+    ],
+  ])('%s', async (_, additionalHeaders) => {
     // Prepare
     const app = new Router();
     const corsConfig = {
@@ -183,43 +192,7 @@ describe('CORS Middleware', () => {
       createTestEvent('/test', 'OPTIONS', {
         Origin: origin,
         'Access-Control-Request-Method': 'GET',
-        'Access-Control-Request-Headers': 'Authorization',
-      }),
-      context
-    );
-
-    // Assess
-    expect(result.statusCode).toBe(204);
-    expect(result.headers?.['access-control-allow-origin']).toEqual(
-      corsConfig.origin
-    );
-    expect(result.multiValueHeaders?.['access-control-allow-methods']).toEqual(
-      corsConfig.allowMethods
-    );
-    expect(result.multiValueHeaders?.['access-control-allow-headers']).toEqual(
-      corsConfig.allowHeaders.map((header) => header.toLowerCase())
-    );
-    expect(result.headers?.['access-control-max-age']).toEqual(
-      corsConfig.maxAge.toString()
-    );
-  });
-
-  it('handles OPTIONS preflight requests without Access-Control-Request-Headers', async () => {
-    // Prepare
-    const app = new Router();
-    const corsConfig = {
-      origin,
-      allowMethods: ['GET', 'POST'],
-      allowHeaders: ['Authorization', 'Content-Type'],
-      maxAge: 3600,
-    };
-    app.use(cors(corsConfig));
-
-    // Act
-    const result = await app.resolve(
-      createTestEvent('/test', 'OPTIONS', {
-        Origin: origin,
-        'Access-Control-Request-Method': 'GET',
+        ...additionalHeaders,
       }),
       context
     );


### PR DESCRIPTION
## Summary

### Changes

The `cors` middleware incorrectly rejects valid CORS `OPTIONS` preflight requests if the `Access-Control-Request-Headers` header is missing. Per the Fetch Standard §4.8, `Access-Control-Request-Headers` is only required when the request includes CORS-unsafe headers. Preflight requests containing only `Access-Control-Request-Method` should be treated as valid and succeed with a `204 No Content`.

This PR fixes the issue by updating `isValidPreflightRequest` to explicitly accept requests where `Access-Control-Request-Headers` is missing or undefined.

- Allowed `accessControlRequestHeaders` to be undefined/empty in the validation logic inside `packages/event-handler/src/http/middleware/cors.ts`.
- Added a unit test covering valid preflight requests without request headers in `packages/event-handler/tests/unit/http/middleware/cors.test.ts`.

**Issue number:** closes #5263

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
