### PR TITLE
chore(idempotency): pin @aws/durable-execution-sdk-js to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2954,19 +2954,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws/durable-execution-sdk-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@aws/durable-execution-sdk-js/-/durable-execution-sdk-js-1.1.3.tgz",
-      "integrity": "sha512-Ne/7lz5NFuhekjBG3jCd2+jlrIGI3d7nYFC3bAOxGR3/1esZLEZpM9fLwgc1zNtzejj8jMh+Fz9jcC0sskFmNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-lambda": "^3.943.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -10474,7 +10461,7 @@
         "@aws-sdk/client-dynamodb": "^3.1014.0",
         "@aws-sdk/lib-dynamodb": "^3.1014.0",
         "@aws-sdk/util-dynamodb": "^3.996.2",
-        "@aws/durable-execution-sdk-js": "^1.1.3",
+        "@aws/durable-execution-sdk-js": "1.1.2",
         "aws-sdk-client-mock": "^4.1.0"
       },
       "peerDependencies": {
@@ -10500,6 +10487,19 @@
         "@valkey/valkey-glide": {
           "optional": true
         }
+      }
+    },
+    "packages/idempotency/node_modules/@aws/durable-execution-sdk-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@aws/durable-execution-sdk-js/-/durable-execution-sdk-js-1.1.2.tgz",
+      "integrity": "sha512-STJU58rInEBfsPyUDtH/XIL8/jaCfpkTkx37EAwee7fFO1tdaXwInCmkOjxtIrImhSdkPJU8bRORKTij/N0I8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-lambda": "^3.943.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "packages/jmespath": {

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -154,7 +154,7 @@
     "@aws-sdk/client-dynamodb": "^3.1014.0",
     "@aws-sdk/lib-dynamodb": "^3.1014.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
-    "@aws/durable-execution-sdk-js": "^1.1.3",
+    "@aws/durable-execution-sdk-js": "1.1.2",
     "aws-sdk-client-mock": "^4.1.0"
   }
 }


### PR DESCRIPTION
## Summary

The `1.1.3` release of `@aws/durable-execution-sdk-js` is incompatible with the way our idempotency e2e durable-function tests are bundled, causing the deployed Lambda to fail at init with `TypeError: fileURLToPath(undefined)` (see #5280 for full logs and reproduction). The same handler bundles and runs cleanly on `1.1.2`. This PR temporarily pins the dev dependency to the exact version `1.1.2` so the e2e suite is unblocked, with a plan to re-bump to a caret range once the related upstream change at https://github.com/aws/aws-durable-execution-sdk-js/pull/546 lands in a release.

### Changes

- `packages/idempotency/package.json`: change `@aws/durable-execution-sdk-js` from `^1.1.3` to an exact pin `1.1.2` (no caret, so npm does not re-resolve forward to `1.1.3`).
- `package-lock.json`: refreshed via `npm install` so the SDK resolves to `1.1.2` for the idempotency workspace.

### Test plan

- `npm run test:unit` from `packages/idempotency` — all 123 unit tests pass locally.
- The idempotency e2e durable-function suite passes

**Issue number:** closes #5280

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.