### PR TITLE
chore(deps): bump aws-cdk and aws-cdk-lib to clear fast-uri advisories

### DIFF
--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "25.9.1",
-    "aws-cdk-lib": "^2.244.0",
+    "aws-cdk-lib": "^2.257.0",
     "constructs": "^10.6.0",
     "source-map-support": "^0.5.21",
     "typescript": "^6.0.3",
@@ -49,7 +49,7 @@
     "@middy/core": "^4.7.0",
     "@types/aws-lambda": "^8.10.161",
     "@types/node": "25.9.1",
-    "aws-cdk": "^2.1113.0",
+    "aws-cdk": "^2.1124.1",
     "constructs": "^10.6.0",
     "esbuild": "^0.28.0",
     "typescript": "^6.0.3"

--- a/layers/package.json
+++ b/layers/package.json
@@ -41,8 +41,8 @@
     "source-map-support": "^0.5.21"
   },
   "dependencies": {
-    "aws-cdk": "^2.1113.0",
-    "aws-cdk-lib": "^2.244.0",
+    "aws-cdk": "^2.1124.1",
+    "aws-cdk-lib": "^2.257.0",
     "esbuild": "^0.28.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,18 +52,18 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/batch": "^2.33.0",
-        "@aws-lambda-powertools/idempotency": "^2.33.0",
-        "@aws-lambda-powertools/logger": "^2.33.0",
-        "@aws-lambda-powertools/metrics": "^2.33.0",
-        "@aws-lambda-powertools/parameters": "^2.33.0",
-        "@aws-lambda-powertools/tracer": "^2.33.0",
+        "@aws-lambda-powertools/batch": "^2.33.1",
+        "@aws-lambda-powertools/idempotency": "^2.33.1",
+        "@aws-lambda-powertools/logger": "^2.33.1",
+        "@aws-lambda-powertools/metrics": "^2.33.1",
+        "@aws-lambda-powertools/parameters": "^2.33.1",
+        "@aws-lambda-powertools/tracer": "^2.33.1",
         "@aws-sdk/client-ssm": "^3.1014.0",
         "@aws-sdk/lib-dynamodb": "^3.1014.0",
         "@middy/core": "^4.7.0",
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "25.9.1",
-        "aws-cdk": "^2.1113.0",
+        "aws-cdk": "^2.1124.1",
         "constructs": "^10.6.0",
         "esbuild": "^0.28.0",
         "typescript": "^6.0.3"
@@ -71,7 +71,7 @@
       "devDependencies": {
         "@types/aws-lambda": "^8.10.161",
         "@types/node": "25.9.1",
-        "aws-cdk-lib": "^2.244.0",
+        "aws-cdk-lib": "^2.257.0",
         "constructs": "^10.6.0",
         "source-map-support": "^0.5.21",
         "typescript": "^6.0.3",
@@ -87,15 +87,15 @@
         "valibot": "^1.4.0"
       },
       "devDependencies": {
-        "@aws-lambda-powertools/batch": "^2.33.0",
-        "@aws-lambda-powertools/event-handler": "^2.33.0",
-        "@aws-lambda-powertools/idempotency": "^2.33.0",
-        "@aws-lambda-powertools/jmespath": "^2.33.0",
-        "@aws-lambda-powertools/logger": "^2.33.0",
-        "@aws-lambda-powertools/metrics": "^2.33.0",
-        "@aws-lambda-powertools/parameters": "^2.33.0",
-        "@aws-lambda-powertools/parser": "^2.33.0",
-        "@aws-lambda-powertools/tracer": "^2.33.0",
+        "@aws-lambda-powertools/batch": "^2.33.1",
+        "@aws-lambda-powertools/event-handler": "^2.33.1",
+        "@aws-lambda-powertools/idempotency": "^2.33.1",
+        "@aws-lambda-powertools/jmespath": "^2.33.1",
+        "@aws-lambda-powertools/logger": "^2.33.1",
+        "@aws-lambda-powertools/metrics": "^2.33.1",
+        "@aws-lambda-powertools/parameters": "^2.33.1",
+        "@aws-lambda-powertools/parser": "^2.33.1",
+        "@aws-lambda-powertools/tracer": "^2.33.1",
         "@aws-sdk/client-appconfigdata": "^3.1014.0",
         "@aws-sdk/client-dynamodb": "^3.1014.0",
         "@aws-sdk/client-secrets-manager": "^3.1014.0",
@@ -109,11 +109,11 @@
       }
     },
     "layers": {
-      "version": "2.33.0",
+      "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "aws-cdk": "^2.1113.0",
-        "aws-cdk-lib": "^2.244.0",
+        "aws-cdk": "^2.1124.1",
+        "aws-cdk-lib": "^2.257.0",
         "esbuild": "^0.28.0"
       },
       "bin": {
@@ -246,24 +246,24 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.13.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.13.0.tgz",
-      "integrity": "sha512-LgRc8Sl1VzuhhPWmJ4hpajBe8Y8coA3KbpAmej7X4nPvWO/x4nUoZSysUKCx2YldLAAYlzwc0mkDHmc/YMZ6vg==",
+      "version": "53.27.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.27.0.tgz",
+      "integrity": "sha512-OTxe/L2Vc60r2nYih7kFaFpn93sa7shJu9T0tQZsryeDE3HHOAuazKNmS6tLInOjJjVx/dvM5XGyUA+lZAiKxA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -271,7 +271,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -431,14 +431,14 @@
       }
     },
     "node_modules/@aws-cdk/toolkit-lib": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.21.1.tgz",
-      "integrity": "sha512-IBW93mrQyrCsA9vv3dCjBqiMOOnGy7s3SK+Ra7bm23dr445jIIVjAMUoRq07kAfljroc3WYr9gQSxqwTHCg3Bw==",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/toolkit-lib/-/toolkit-lib-1.26.2.tgz",
+      "integrity": "sha512-plok0dACrRERMdyg/th3xPd+/UZY/Ol/Nlr/ZFc6IhfS9dl2+v27A3+ZBslABNST2CBNPMa3b2e2R4BYb8suZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/cdk-assets-lib": "^1",
-        "@aws-cdk/cloud-assembly-api": "2.2.1",
-        "@aws-cdk/cloud-assembly-schema": ">=53.13.0",
+        "@aws-cdk/cloud-assembly-api": "2.2.4",
+        "@aws-cdk/cloud-assembly-schema": ">=53.27.0",
         "@aws-cdk/cloudformation-diff": "^2",
         "@aws-cdk/cx-api": "^2",
         "@aws-sdk/client-appsync": "^3",
@@ -469,17 +469,16 @@
         "@smithy/util-retry": "^4",
         "@smithy/util-waiter": "^4",
         "archiver": "^7.0.1",
-        "cdk-from-cfn": "^0.291.0",
+        "cdk-from-cfn": "^0.300.0",
         "chalk": "^4",
         "chokidar": "^4",
         "fast-deep-equal": "^3.1.3",
         "fast-glob": "^3.3.3",
-        "fs-extra": "^9",
+        "fs-extra": "^11",
         "p-limit": "^3",
         "picomatch": "^4",
-        "semver": "^7.7.4",
+        "semver": "^7.8.0",
         "split2": "^4.2.0",
-        "uuid": "^11.1.0",
         "wrap-ansi": "^7",
         "yaml": "^1"
       },
@@ -488,6 +487,22 @@
       },
       "peerDependencies": {
         "@aws-cdk/cli-plugin-contract": "^2"
+      }
+    },
+    "node_modules/@aws-cdk/toolkit-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-api/-/cloud-assembly-api-2.2.4.tgz",
+      "integrity": "sha512-ob4M97DuBQ3HpwtUD6Wosuc731pPbqQuNGZuZfRBEcaOwEsJFwbXkZJC0M4JaDUqi2c50uLHkR346v6wIn5GDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
     "node_modules/@aws-cdk/toolkit-lib/node_modules/ansi-regex": {
@@ -5678,15 +5693,6 @@
         "node": "^4.7 || >=6.9 || >=7.3"
       }
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
@@ -5704,9 +5710,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1117.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1117.0.tgz",
-      "integrity": "sha512-2NbSDDw8LTkGv0uhEDffttmNvgyTAWV5EkLkyPUGAGECzBdwCmbgmRxSoUhbzxZ0XEd1eaqbdVTFRWgtsbj31g==",
+      "version": "2.1124.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1124.1.tgz",
+      "integrity": "sha512-sRYdPMdkX+02EHaT946AFV0w0CMfbHKWpLZPv525xTCkaVu1eYu6DzHFuTdimxdSN0uGQ2D4LHrD1sr94tRhow==",
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
@@ -5716,9 +5722,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.248.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.248.0.tgz",
-      "integrity": "sha512-PGQycx/OdyX+t0o6QUFI1KJAOLoyIVj2WwrN0syrwCi8lYxW2KzldZsW0X+/UN/ALNQwcjSr927ImTpuDOh+bg==",
+      "version": "2.257.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.257.0.tgz",
+      "integrity": "sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -5737,8 +5743,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.0",
-        "@aws-cdk/cloud-assembly-schema": "^53.0.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.4",
+        "@aws-cdk/cloud-assembly-schema": "^53.25.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -5759,34 +5765,22 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.0",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.4",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.0.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
-      "version": "1.4.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
+        "@aws-cdk/cloud-assembly-schema": ">=53.25.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5900,7 +5894,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",
@@ -6321,9 +6315,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6386,9 +6380,9 @@
       "license": "MIT"
     },
     "node_modules/cdk-from-cfn": {
-      "version": "0.291.0",
-      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.291.0.tgz",
-      "integrity": "sha512-9yHwjLTwAySrKw9GYlfcMSdGBKxXygEI18sRCiniamdu8b3oF+ueZXKSJrl42q1cO9ChhVogmirDvBKEliGcfg==",
+      "version": "0.300.0",
+      "resolved": "https://registry.npmjs.org/cdk-from-cfn/-/cdk-from-cfn-0.300.0.tgz",
+      "integrity": "sha512-BtTAthyg3EeBoO0o77A3PMfwID7mvm3R1BvM/avjwfPHbSnt598vv0qGGSZMM0KPM77DB5UtK6/z4VhBto4VJw==",
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/chai": {
@@ -7050,18 +7044,17 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "license": "MIT",
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/fsevents": {
@@ -7469,9 +7462,9 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -7488,6 +7481,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/just-extend": {
@@ -9346,9 +9348,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10014,19 +10016,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/valibot": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.0.tgz",
@@ -10414,12 +10403,12 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
         "@aws/lambda-invoke-store": "0.2.4",
         "@standard-schema/spec": "^1.1.0"
       },
       "devDependencies": {
-        "@aws-lambda-powertools/parser": "2.33.0",
+        "@aws-lambda-powertools/parser": "2.33.1",
         "@aws-lambda-powertools/testing-utils": "file:../testing",
         "@aws-sdk/client-sqs": "^3.1014.0",
         "zod": "^4.4.3"
@@ -10442,14 +10431,14 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0"
+        "@aws-lambda-powertools/commons": "2.33.1"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing"
       },
       "peerDependencies": {
-        "@aws-lambda-powertools/metrics": ">=2.33.0",
-        "@aws-lambda-powertools/tracer": ">=2.33.0",
+        "@aws-lambda-powertools/metrics": ">=2.33.1",
+        "@aws-lambda-powertools/tracer": ">=2.33.1",
         "@standard-schema/spec": "^1.0.0"
       },
       "peerDependenciesMeta": {
@@ -10466,8 +10455,8 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
-        "@aws-lambda-powertools/jmespath": "2.33.0"
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws-lambda-powertools/jmespath": "2.33.1"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -10507,7 +10496,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0"
+        "@aws-lambda-powertools/commons": "2.33.1"
       }
     },
     "packages/kafka": {
@@ -10515,7 +10504,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
         "@standard-schema/spec": "^1.1.0"
       },
       "devDependencies": {
@@ -10545,14 +10534,14 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
         "@aws/lambda-invoke-store": "0.2.4"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing"
       },
       "peerDependencies": {
-        "@aws-lambda-powertools/jmespath": "2.33.0",
+        "@aws-lambda-powertools/jmespath": "2.33.1",
         "@middy/core": "4.x || 5.x || 6.x || 7.x"
       },
       "peerDependenciesMeta": {
@@ -10569,7 +10558,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
         "@aws/lambda-invoke-store": "0.2.4"
       },
       "devDependencies": {
@@ -10592,7 +10581,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0"
+        "@aws-lambda-powertools/commons": "2.33.1"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -10638,7 +10627,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
         "@standard-schema/spec": "^1.1.0"
       },
       "devDependencies": {
@@ -10662,12 +10651,12 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-cdk/toolkit-lib": "^1.19.1",
+        "@aws-cdk/toolkit-lib": "^1.26.2",
         "@aws-sdk/client-cloudwatch-logs": "^3.1014.0",
         "@aws-sdk/client-lambda": "^3.1014.0",
         "@aws/lambda-invoke-store": "0.2.4",
         "@smithy/util-utf8": "^4.2.0",
-        "aws-cdk-lib": "^2.244.0",
+        "aws-cdk-lib": "^2.257.0",
         "esbuild": "^0.28.0",
         "promise-retry": "^2.0.1"
       },
@@ -10681,7 +10670,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
         "aws-xray-sdk-core": "^3.12.0"
       },
       "devDependencies": {
@@ -10703,8 +10692,8 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "2.33.0",
-        "@aws-lambda-powertools/jmespath": "2.33.0",
+        "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws-lambda-powertools/jmespath": "2.33.1",
         "ajv": "^8.20.0"
       }
     }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -98,12 +98,12 @@
   },
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript/tree/main/packages/testing#readme",
   "dependencies": {
-    "@aws-cdk/toolkit-lib": "^1.19.1",
+    "@aws-cdk/toolkit-lib": "^1.26.2",
     "@aws-sdk/client-lambda": "^3.1014.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1014.0",
     "@aws/lambda-invoke-store": "0.2.4",
     "@smithy/util-utf8": "^4.2.0",
-    "aws-cdk-lib": "^2.244.0",
+    "aws-cdk-lib": "^2.257.0",
     "esbuild": "^0.28.0",
     "promise-retry": "^2.0.1"
   },


### PR DESCRIPTION
## Summary

Manual dependency bump to clear two open security advisories that Dependabot is currently unable to deliver. `aws-cdk-lib` is bumped from `^2.244.0` to `^2.257.0`, `aws-cdk` from `^2.1113.0` to `^2.1124.1`, and `@aws-cdk/toolkit-lib` from `^1.19.1` to `^1.26.2`.

### Changes

- Bump `aws-cdk-lib` to `^2.257.0` in `packages/testing`, `layers`, and `examples/app`
- Bump `aws-cdk` to `^2.1124.1` in `layers` and `examples/app`
- Bump `@aws-cdk/toolkit-lib` to `^1.26.2` in `packages/testing`
- Refresh `package-lock.json`
- Resolves both `fast-uri` advisories ([GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6), [GHSA-v39h-62p7-jpjc](https://github.com/advisories/GHSA-v39h-62p7-jpjc) — CVSS 7.5) and the top-level copy of `brace-expansion` ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) — CVSS 6.5)
- Note: `aws-cdk-lib@2.257.0` still bundles `brace-expansion@5.0.5` inside its tarball, so `npm audit` will continue to report one moderate-severity finding until upstream rebundles. This is dev-only tooling and not shipped to runtime consumers.

**Issue number:** closes #5291

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.