### PR TITLE
fix(commons): clear LRUCache pointers on eviction of last item

### DIFF
--- a/packages/commons/src/LRUCache.ts
+++ b/packages/commons/src/LRUCache.ts
@@ -197,6 +197,9 @@ class LRUCache<K, V> {
     if (item[NEWER]) {
       this.leastRecentlyUsed = item[NEWER];
       this.leastRecentlyUsed[OLDER] = undefined;
+    } else {
+      this.leastRecentlyUsed = undefined;
+      this.mostRecentlyUsed = undefined;
     }
 
     // Remove the item from the map

--- a/packages/commons/tests/unit/LRUCache.test.ts
+++ b/packages/commons/tests/unit/LRUCache.test.ts
@@ -52,9 +52,14 @@ describe('Class: LRUMap', () => {
 
       // Act
       cache.add('a', 1);
+      cache.add('b', 2);
+      cache.add('c', 3);
 
       // Assess
       expect(cache.size()).toBe(0);
+      expect(cache.get('a')).toBeUndefined();
+      expect(cache.get('b')).toBeUndefined();
+      expect(cache.get('c')).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary

### Changes

When LRUCache is configured with maxSize 0, adding any item triggers immediate eviction. When the evicted item has no newer neighbor, shift() was not clearing the leastRecentlyUsed and mostRecentlyUsed pointers. Subsequent additions would incorrectly link onto these stale pointers, causing the cache to permanently retain one stale entry.

This change sets both pointers to undefined in shift() when the evicted item is the only one in the cache.

**Issue number:** closes #5290

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.