### PR TITLE
chore(idempotency): bump @aws/durable-execution-sdk-js to ^1.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2970,9 +2970,9 @@
       }
     },
     "node_modules/@aws/durable-execution-sdk-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@aws/durable-execution-sdk-js/-/durable-execution-sdk-js-1.1.3.tgz",
-      "integrity": "sha512-Ne/7lz5NFuhekjBG3jCd2+jlrIGI3d7nYFC3bAOxGR3/1esZLEZpM9fLwgc1zNtzejj8jMh+Fz9jcC0sskFmNA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@aws/durable-execution-sdk-js/-/durable-execution-sdk-js-1.1.6.tgz",
+      "integrity": "sha512-BinSNwKg9TJVa7VWIVBKzoTZi/2/qKjyPrn6B6ytQvEWxSiKGzbMAe1KIPJaee0Fyp7h+xsi6Qe/KHkzOC9Dfg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10463,7 +10463,7 @@
         "@aws-sdk/client-dynamodb": "^3.1014.0",
         "@aws-sdk/lib-dynamodb": "^3.1014.0",
         "@aws-sdk/util-dynamodb": "^3.996.2",
-        "@aws/durable-execution-sdk-js": "^1.1.3",
+        "@aws/durable-execution-sdk-js": "^1.1.6",
         "aws-sdk-client-mock": "^4.1.0"
       },
       "peerDependencies": {

--- a/packages/idempotency/package.json
+++ b/packages/idempotency/package.json
@@ -154,7 +154,7 @@
     "@aws-sdk/client-dynamodb": "^3.1014.0",
     "@aws-sdk/lib-dynamodb": "^3.1014.0",
     "@aws-sdk/util-dynamodb": "^3.996.2",
-    "@aws/durable-execution-sdk-js": "^1.1.3",
+    "@aws/durable-execution-sdk-js": "^1.1.6",
     "aws-sdk-client-mock": "^4.1.0"
   }
 }


### PR DESCRIPTION
## Summary

`@aws/durable-execution-sdk-js@1.1.6` is now on npm with the upstream fix for the bundling regression that shipped in `1.1.3`-`1.1.5` (a top-level `esmShim()` banner in `dist/index.mjs` that crashed downstream esbuild → CJS bundles at module init with `TypeError: fileURLToPath(undefined)`). This PR bumps the idempotency dev dependency from `^1.1.3` straight to `^1.1.6`.

### Changes

- `packages/idempotency/package.json`: `@aws/durable-execution-sdk-js` from `^1.1.3` to `^1.1.6`.
- `package-lock.json`: refreshed via `npm install`; the SDK resolves to `1.1.6` for the idempotency workspace and dedupes with the middy transitive dependency.

### Test plan

- `npm run test:unit` from `packages/idempotency` — all 123 unit tests pass locally on `1.1.6`.
- The idempotency durable-function e2e suite was already exercised against npm-published `1.1.6`: https://github.com/aws-powertools/powertools-lambda-typescript/actions/runs/26496025342

**Issue number:** closes #5297

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.