### PR TITLE
fix(event-handler): avoid runtime import of metrics package in HTTP metrics middleware

### DIFF
--- a/packages/event-handler/src/http/middleware/metrics.ts
+++ b/packages/event-handler/src/http/middleware/metrics.ts
@@ -1,5 +1,4 @@
 import type { Metrics } from '@aws-lambda-powertools/metrics';
-import { MetricUnit } from '@aws-lambda-powertools/metrics';
 import type { Middleware, RequestContext } from '../../types/http.js';
 import { HttpError } from '../errors.js';
 
@@ -99,19 +98,15 @@ const metrics = (metrics: Metrics): Middleware => {
       for (const [key, value] of Object.entries(metadata)) {
         metrics.addMetadata(key, value);
       }
+      // The metric units are inlined as string literals rather than imported
+      // from the `MetricUnit` value of `@aws-lambda-powertools/metrics`. A value
+      // import would be retained by bundlers and force a runtime dependency on
+      // the metrics package even for consumers that never use this middleware.
       metrics
         .addDimension('route', reqCtx.route ?? 'NOT_FOUND')
-        .addMetric(
-          'latency',
-          MetricUnit.Milliseconds,
-          performance.now() - start
-        )
-        .addMetric('fault', MetricUnit.Count, status >= 500 ? 1 : 0)
-        .addMetric(
-          'error',
-          MetricUnit.Count,
-          status >= 400 && status < 500 ? 1 : 0
-        )
+        .addMetric('latency', 'Milliseconds', performance.now() - start)
+        .addMetric('fault', 'Count', status >= 500 ? 1 : 0)
+        .addMetric('error', 'Count', status >= 400 && status < 500 ? 1 : 0)
         .publishStoredMetrics();
     }
   };

--- a/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
@@ -422,15 +422,42 @@ describe('Metrics Middleware', () => {
     const source = readFileSync(
       new URL('../../../../src/http/middleware/metrics.ts', import.meta.url),
       'utf-8'
-    )
-      // Strip comments so documentation examples (e.g. JSDoc `@example`
-      // snippets that show a value import) don't trigger a false positive.
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/.*$/gm, '');
-    const valueImportFromMetrics =
-      /import\s+(?!type\b)[^;]*from\s+['"]@aws-lambda-powertools\/metrics['"]/;
+    );
 
-    // Act & Assess
-    expect(source).not.toMatch(valueImportFromMetrics);
+    // Strip comments with a linear character scan (no regex) so documentation
+    // examples that show a value import don't cause a false positive, while
+    // avoiding ReDoS-prone backtracking patterns.
+    const stripComments = (code: string): string => {
+      let result = '';
+      let index = 0;
+      while (index < code.length) {
+        const marker = code.slice(index, index + 2);
+        if (marker === '/*') {
+          const end = code.indexOf('*/', index + 2);
+          index = end === -1 ? code.length : end + 2;
+        } else if (marker === '//') {
+          const end = code.indexOf('\n', index + 2);
+          index = end === -1 ? code.length : end;
+        } else {
+          result += code[index];
+          index += 1;
+        }
+      }
+      return result;
+    };
+
+    // Act
+    const importsMetricsAsValue = stripComments(source)
+      .split(';')
+      .map((statement) => statement.trim())
+      .some(
+        (statement) =>
+          statement.startsWith('import') &&
+          !statement.startsWith('import type') &&
+          statement.includes('@aws-lambda-powertools/metrics')
+      );
+
+    // Assess
+    expect(importsMetricsAsValue).toBe(false);
   });
 });

--- a/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import context from '@aws-lambda-powertools/testing-utils/context';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -410,36 +409,5 @@ describe('Metrics Middleware', () => {
         ipAddress: '127.0.0.1',
       })
     );
-  });
-
-  it('does not import any runtime value from the metrics package', () => {
-    // Prepare
-    // A value import (e.g. `import { MetricUnit }`) is retained by bundlers and
-    // forces a runtime dependency on `@aws-lambda-powertools/metrics` even for
-    // consumers that never use this middleware, breaking bundles where the
-    // optional peer dependency is absent (see issue #5309). Only type-only
-    // imports (erased at compile time) are allowed.
-    const source = readFileSync(
-      new URL('../../../../src/http/middleware/metrics.ts', import.meta.url),
-      'utf-8'
-    );
-
-    // Act
-    // Split on the statement terminator (handles multi-line imports) and check
-    // each statement with plain string methods, avoiding ReDoS-prone regexes.
-    // Comments never trim to start with `import` (JSDoc lines start with `*`,
-    // line comments with `//`), so they can't cause a false positive.
-    const importsMetricsAsValue = source
-      .split(';')
-      .map((statement) => statement.trim())
-      .some(
-        (statement) =>
-          statement.startsWith('import') &&
-          !statement.startsWith('import type') &&
-          statement.includes('@aws-lambda-powertools/metrics')
-      );
-
-    // Assess
-    expect(importsMetricsAsValue).toBe(false);
   });
 });

--- a/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
@@ -424,30 +424,12 @@ describe('Metrics Middleware', () => {
       'utf-8'
     );
 
-    // Strip comments with a linear character scan (no regex) so documentation
-    // examples that show a value import don't cause a false positive, while
-    // avoiding ReDoS-prone backtracking patterns.
-    const stripComments = (code: string): string => {
-      let result = '';
-      let index = 0;
-      while (index < code.length) {
-        const marker = code.slice(index, index + 2);
-        if (marker === '/*') {
-          const end = code.indexOf('*/', index + 2);
-          index = end === -1 ? code.length : end + 2;
-        } else if (marker === '//') {
-          const end = code.indexOf('\n', index + 2);
-          index = end === -1 ? code.length : end;
-        } else {
-          result += code[index];
-          index += 1;
-        }
-      }
-      return result;
-    };
-
     // Act
-    const importsMetricsAsValue = stripComments(source)
+    // Split on the statement terminator (handles multi-line imports) and check
+    // each statement with plain string methods, avoiding ReDoS-prone regexes.
+    // Comments never trim to start with `import` (JSDoc lines start with `*`,
+    // line comments with `//`), so they can't cause a false positive.
+    const importsMetricsAsValue = source
       .split(';')
       .map((statement) => statement.trim())
       .some(

--- a/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/metrics.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { Metrics } from '@aws-lambda-powertools/metrics';
 import context from '@aws-lambda-powertools/testing-utils/context';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -409,5 +410,27 @@ describe('Metrics Middleware', () => {
         ipAddress: '127.0.0.1',
       })
     );
+  });
+
+  it('does not import any runtime value from the metrics package', () => {
+    // Prepare
+    // A value import (e.g. `import { MetricUnit }`) is retained by bundlers and
+    // forces a runtime dependency on `@aws-lambda-powertools/metrics` even for
+    // consumers that never use this middleware, breaking bundles where the
+    // optional peer dependency is absent (see issue #5309). Only type-only
+    // imports (erased at compile time) are allowed.
+    const source = readFileSync(
+      new URL('../../../../src/http/middleware/metrics.ts', import.meta.url),
+      'utf-8'
+    )
+      // Strip comments so documentation examples (e.g. JSDoc `@example`
+      // snippets that show a value import) don't trigger a false positive.
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+    const valueImportFromMetrics =
+      /import\s+(?!type\b)[^;]*from\s+['"]@aws-lambda-powertools\/metrics['"]/;
+
+    // Act & Assess
+    expect(source).not.toMatch(valueImportFromMetrics);
   });
 });


### PR DESCRIPTION
## Summary

### Changes

The HTTP metrics middleware (`packages/event-handler/src/http/middleware/metrics.ts`) did a value import of `MetricUnit` from `@aws-lambda-powertools/metrics`:

```ts
import { MetricUnit } from '@aws-lambda-powertools/metrics';
```

Because `MetricUnit` is a runtime value (not a type), bundlers such as esbuild retain this import even when the consuming code only uses the `Router` and other middleware (e.g. `cors`) and never opts into the metrics middleware. The middleware barrel (`http/middleware/index.ts`) re-exports `metrics` alongside `cors`, and the package does not declare `sideEffects: false`, so a `Router + cors`-only bundle keeps `metrics.js` and its `MetricUnit` import.

Since `@aws-lambda-powertools/metrics` is an optional peer dependency, bundles that do not install it (and have no Powertools Lambda layer) crash at init on AWS Lambda with `ERR_MODULE_NOT_FOUND`, returning HTTP 502 behind API Gateway.

This change inlines the metric unit string literals (`'Milliseconds'`, `'Count'`) instead of importing the `MetricUnit` value. The literals are type-safe because `addMetric`'s `unit` parameter is typed as the union of those exact string literals. This matches the type-only approach already used by the sibling tracer middleware (`http/middleware/tracer.ts`), so no runtime dependency on the metrics package leaks into Router-only bundles.

A regression test asserts that the middleware source carries no value (non-`type`) import from `@aws-lambda-powertools/metrics`. Verified that reintroducing the value import makes the test fail. Also verified manually by bundling a `Router + cors`-only handler with esbuild (`format: 'esm'`, `bundle: true`, `platform: 'node'`): after the change the output contains no reference to `@aws-lambda-powertools/metrics`.

**Issue number:** closes #5309

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.