### PR TITLE
chore(commons): guard UA string against duplicate PTEnv suffix

### DIFF
--- a/packages/commons/src/index.ts
+++ b/packages/commons/src/index.ts
@@ -1,10 +1,11 @@
 import { PT_VERSION } from './version.js';
 
 const env = process.env.AWS_EXECUTION_ENV || 'NA';
-if (process.env.AWS_SDK_UA_APP_ID) {
-  process.env.AWS_SDK_UA_APP_ID = `${process.env.AWS_SDK_UA_APP_ID}/PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
-} else {
-  process.env.AWS_SDK_UA_APP_ID = `PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
+if (!process.env.AWS_SDK_UA_APP_ID?.includes('/PTEnv/')) {
+  const ptUserAgent = `PT/NO-OP/${PT_VERSION}/PTEnv/${env}`;
+  process.env.AWS_SDK_UA_APP_ID = process.env.AWS_SDK_UA_APP_ID
+    ? `${process.env.AWS_SDK_UA_APP_ID}/${ptUserAgent}`
+    : ptUserAgent;
 }
 
 export { addUserAgentMiddleware, isSdkClient } from './awsSdkUtils.js';

--- a/packages/commons/tests/unit/awsSdkUtils.test.ts
+++ b/packages/commons/tests/unit/awsSdkUtils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { customUserAgentMiddleware } from '../../src/awsSdkUtils.js';
 import {
   addUserAgentMiddleware,
@@ -87,6 +87,69 @@ describe('Helpers: awsSdk', () => {
     expect(process.env.AWS_SDK_UA_APP_ID).toEqual(
       `test/PT/NO-OP/${version}/PTEnv/NA`
     );
+  });
+
+  describe('Module init: AWS_SDK_UA_APP_ID', () => {
+    beforeEach(() => {
+      vi.resetModules();
+      vi.stubEnv('AWS_EXECUTION_ENV', '');
+    });
+
+    afterEach(() => {
+      vi.unstubAllEnvs();
+    });
+
+    it('sets the PT AWS_SDK_UA_APP_ID when one is not already set', async () => {
+      // Prepare
+      vi.stubEnv('AWS_SDK_UA_APP_ID', undefined);
+
+      // Act
+      await import('../../src/index.js');
+
+      // Assess
+      expect(process.env.AWS_SDK_UA_APP_ID).toEqual(
+        `PT/NO-OP/${version}/PTEnv/NA`
+      );
+    });
+
+    it('concatenates the PT AWS_SDK_UA_APP_ID when one is already set', async () => {
+      // Prepare
+      vi.stubEnv('AWS_SDK_UA_APP_ID', 'test');
+
+      // Act
+      await import('../../src/index.js');
+
+      // Assess
+      expect(process.env.AWS_SDK_UA_APP_ID).toEqual(
+        `test/PT/NO-OP/${version}/PTEnv/NA`
+      );
+    });
+
+    it('uses the execution environment when AWS_EXECUTION_ENV is set', async () => {
+      // Prepare
+      vi.stubEnv('AWS_SDK_UA_APP_ID', undefined);
+      vi.stubEnv('AWS_EXECUTION_ENV', 'AWS_Lambda_nodejs20.x');
+
+      // Act
+      await import('../../src/index.js');
+
+      // Assess
+      expect(process.env.AWS_SDK_UA_APP_ID).toEqual(
+        `PT/NO-OP/${version}/PTEnv/AWS_Lambda_nodejs20.x`
+      );
+    });
+
+    it('leaves the AWS_SDK_UA_APP_ID untouched when the PT UA is already present', async () => {
+      // Prepare
+      const existing = `test/PT/NO-OP/${version}/PTEnv/NA`;
+      vi.stubEnv('AWS_SDK_UA_APP_ID', existing);
+
+      // Act
+      await import('../../src/index.js');
+
+      // Assess
+      expect(process.env.AWS_SDK_UA_APP_ID).toEqual(existing);
+    });
   });
 
   describe('Function: customUserAgentMiddleware', () => {


### PR DESCRIPTION
## Summary

The Powertools user-agent suffix was appended to `AWS_SDK_UA_APP_ID` unconditionally at module load. If the module was evaluated more than once in the same process, the suffix could be appended repeatedly. This adds an idempotency guard so the suffix is only added when not already present, and removes the duplicated suffix template across the two branches.

### Changes

- Skip appending the Powertools user-agent when `AWS_SDK_UA_APP_ID` already contains a `/PTEnv/` segment
- Use optional chaining when checking `AWS_SDK_UA_APP_ID` so an unset value no longer throws
- Factor the shared `PT/NO-OP/${PT_VERSION}/PTEnv/${env}` suffix into a single `ptUserAgent` constant to remove repetition across branches
- Add module-init tests covering the set/unset branches, the `AWS_EXECUTION_ENV` interpolation, and the new idempotency guard

**Issue number:** closes #5082

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.