### PR TITLE
test(event-handler): fix stale httpRouter e2e trailing-slash test

### DIFF
--- a/packages/event-handler/tests/e2e/httpRouter.test.ts
+++ b/packages/event-handler/tests/e2e/httpRouter.test.ts
@@ -754,11 +754,13 @@ describe('REST Event Handler E2E tests', () => {
       expect(data.version).toBe('1.0.0');
     });
 
-    it('returns 404 for path with trailing slash when route has no trailing slash', async () => {
+    it('normalizes a trailing slash to match a route registered without one', async () => {
       // Prepare
       const response = await fetch(`${apiUrl}/methods/`);
+      const data = await response.json();
 
-      expect(response.status).toBe(404);
+      expect(response.status).toBe(200);
+      expect(data.method).toBe('GET');
     });
 
     it('handles path without trailing slash', async () => {


### PR DESCRIPTION
## Summary

We recently made the HTTP Router trailing-slash insensitive, aligning our behavior with Python's `APIGatewayRestResolver` (aws-powertools/powertools-lambda-python#1552). A request to `/methods/` now correctly normalizes to `/methods` and matches the route (`200`). The corresponding e2e test was not updated and still asserted the old `404` behavior, so it failed — this PR fixes the stale test.

### Changes

- Update `tests/e2e/httpRouter.test.ts` to expect `200` with `{ method: 'GET' }` for a request to `/methods/`, matching the route registered without a trailing slash
- Rename the test to `normalizes a trailing slash to match a route registered without one` to reflect the intended behavior

**Issue number:** closes #5313

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
