### PR TITLE
ci(maintenance): remove PR/branch checkout input from Run e2e Tests workflow

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -2,11 +2,6 @@ name: Run e2e Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      prNumber:
-        description: 'Optional PR number to checkout useful to run e2e tests on forks. When specified the branch field will be ignored.'
-        required: false
-        default: ''
 
 permissions:
   contents: read
@@ -16,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_ENV: dev
-      PR_NUMBER: ${{ inputs.prNumber }}
-      GH_TOKEN: ${{ github.token }}
     environment: e2e-tests
     permissions:
       id-token: write # needed to interact with GitHub's OIDC Token endpoint.
@@ -42,15 +35,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      # Only if a PR Number was passed and the headSHA of the PR extracted,
-      # we checkout the PR at that point in time
-      - name: Checkout PR code
-        if: ${{ inputs.prNumber != '' }}
-        env:
-          PR_NUMBER: ${{ inputs.prNumber }}
-        run: |
-          set -euo pipefail
-          gh pr checkout "$PR_NUMBER"
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -299,10 +299,7 @@ This will kick off the [Post Release workflow](https://github.com/aws-powertools
 
 ### Run end to end tests
 
-!!! note
-    We are planning to automate this process in the future so that tests are run automatically when a PR is merged, see [#1149](https://github.com/aws-powertools/powertools-lambda-typescript/issues/1149){target="_blank" rel="nofollow"}
-
-E2E tests should be ran before every merge to `main` or manually via [Run e2e Tests workflow](https://github.com/aws-powertools/powertools-lambda-typescript/actions/workflows/run-e2e-tests.yml) before making a release.
+E2E tests must be ran before making a release, manually via the [Run e2e Tests workflow](https://github.com/aws-powertools/powertools-lambda-typescript/actions/workflows/run-e2e-tests.yml). Maintainers should also run them manually for large contributions authored by maintainers before merging to `main`.
 
 To run locally, you need [AWS CDK CLI](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html#getting_started_prerequisites) and an [account bootstrapped](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html) (`cdk bootstrap`). With a default AWS CLI profile configured, or `AWS_PROFILE` environment variable set, run `make e2e tests`.
 


### PR DESCRIPTION
## Summary

### Changes

This PR simplifies the `Run e2e Tests` workflow by removing the optional `prNumber` `workflow_dispatch` input and the associated "Checkout PR code" step. In practice this code path isn't used by maintainers — e2e runs are dispatched against trusted branches before a release — so removing it reduces the workflow's surface area and keeps it focused on its actual use case.

Specifically:

- Removed the `prNumber` input and the "Checkout PR code" step from `.github/workflows/run-e2e-tests.yml`, so the job only checks out the dispatched ref.
- Removed the now-unused `PR_NUMBER` and `GH_TOKEN` env vars.
- Updated `docs/maintainers.md` to state that e2e tests are run manually before a release, and manually by maintainers for large maintainer-authored contributions; removed the stale automation note.

**Issue number:** closes #5325

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
