### PR TITLE
refactor(event-handler): extract shared IP-extraction util for HTTP middleware

### DIFF
--- a/packages/event-handler/src/http/middleware/commons.ts
+++ b/packages/event-handler/src/http/middleware/commons.ts
@@ -1,0 +1,25 @@
+import type { RequestContext } from '../../types/http.js';
+
+/**
+ * Extracts the client IP address from the request context.
+ *
+ * For API Gateway events the source IP is taken from the request context, while
+ * for ALB (or any other source) it falls back to the `X-Forwarded-For` header.
+ *
+ * @param reqCtx - The request context for the current request
+ */
+const getClientIp = (reqCtx: RequestContext): string | undefined => {
+  if (reqCtx.responseType === 'ApiGatewayV1') {
+    return reqCtx.event.requestContext.identity.sourceIp;
+  }
+  if (reqCtx.responseType === 'ApiGatewayV2') {
+    return reqCtx.event.requestContext.http.sourceIp;
+  }
+  const xForwardedFor = reqCtx.req.headers.get('X-Forwarded-For');
+  if (xForwardedFor) {
+    return xForwardedFor.split(',')[0].trim();
+  }
+  return undefined;
+};
+
+export { getClientIp };

--- a/packages/event-handler/src/http/middleware/metrics.ts
+++ b/packages/event-handler/src/http/middleware/metrics.ts
@@ -1,6 +1,7 @@
 import type { Metrics } from '@aws-lambda-powertools/metrics';
 import type { Middleware, RequestContext } from '../../types/http.js';
 import { HttpError } from '../errors.js';
+import { getClientIp } from './commons.js';
 
 const getHeaderMetadata = (req: Request): Record<string, string> => {
   const metadata: Record<string, string> = {};
@@ -13,24 +14,10 @@ const getHeaderMetadata = (req: Request): Record<string, string> => {
   return metadata;
 };
 
-const getIpAddress = (reqCtx: RequestContext): string | undefined => {
-  if (reqCtx.responseType === 'ApiGatewayV1') {
-    return reqCtx.event.requestContext.identity.sourceIp;
-  }
-  if (reqCtx.responseType === 'ApiGatewayV2') {
-    return reqCtx.event.requestContext.http.sourceIp;
-  }
-  const xForwardedFor = reqCtx.req.headers.get('X-Forwarded-For');
-  if (xForwardedFor) {
-    return xForwardedFor.split(',')[0].trim();
-  }
-  return undefined;
-};
-
 const getEventMetadata = (reqCtx: RequestContext): Record<string, string> => {
   const metadata: Record<string, string> = {};
 
-  const ipAddress = getIpAddress(reqCtx);
+  const ipAddress = getClientIp(reqCtx);
   if (ipAddress) {
     metadata.ipAddress = ipAddress;
   }

--- a/packages/event-handler/src/http/middleware/tracer.ts
+++ b/packages/event-handler/src/http/middleware/tracer.ts
@@ -6,6 +6,7 @@ import type {
   SegmentHttpData,
   TracerOptions,
 } from '../../types/http.js';
+import { getClientIp } from './commons.js';
 import type { compress } from './compress.js';
 
 /**
@@ -16,28 +17,6 @@ import type { compress } from './compress.js';
  * optional property to attach request/response data without unsafe casts.
  */
 type HttpSubsegment = Subsegment & { http?: SegmentHttpData };
-
-/**
- * Extracts the client IP address from the request context.
- *
- * For API Gateway events the source IP is taken from the request context, while
- * for ALB (or any other source) it falls back to the `X-Forwarded-For` header.
- *
- * @param reqCtx - The request context for the current request
- */
-const getClientIp = (reqCtx: RequestContext): string | undefined => {
-  if (reqCtx.responseType === 'ApiGatewayV1') {
-    return reqCtx.event.requestContext.identity.sourceIp;
-  }
-  if (reqCtx.responseType === 'ApiGatewayV2') {
-    return reqCtx.event.requestContext.http.sourceIp;
-  }
-  const xForwardedFor = reqCtx.req.headers.get('X-Forwarded-For');
-  if (xForwardedFor) {
-    return xForwardedFor.split(',')[0].trim();
-  }
-  return undefined;
-};
 
 /**
  * Builds the `http.request` data for the X-Ray subsegment from the request context.


### PR DESCRIPTION
## Summary

### Changes

The HTTP `tracer` and `metrics` middleware both duplicated the same client-IP extraction logic (API Gateway v1/v2 request context, with an `X-Forwarded-For` fallback for ALB/other sources). This PR moves that logic into a shared `commons.ts` module under `packages/event-handler/src/http/middleware/` and has both middleware import `getClientIp` from it.

This was agreed as a follow-up during review of a [recent PR](https://github.com/aws-powertools/powertools-lambda-typescript/pull/5338):

- https://github.com/aws-powertools/powertools-lambda-typescript/pull/5338#discussion_r3403684597
- https://github.com/aws-powertools/powertools-lambda-typescript/pull/5338#discussion_r3404773688

No behavioural change: the extracted function is identical to the previous per-middleware implementations.

**Issue number:** closes #5345

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.