### PR TITLE
feat(metrics): add Disposable support for automatic flushing via using

### DIFF
--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -328,7 +328,9 @@ You can manually flush the metrics with `publishStoredMetrics` as follows:
 
 #### Using the `using` keyword
 
-If you are running on Node.js 24 or newer, the `Metrics` class implements the [`Disposable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose){target="_blank"} interface. This means you can declare your instance with the [`using`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using){target="_blank"} keyword and have your metrics flushed automatically when the binding goes out of scope, including when an exception is thrown. This is a lightweight alternative to wrapping your handler in a `try/finally` block.
+If you are running on Node.js 24 or newer, the `Metrics` class implements the [`Disposable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose){target="_blank"} interface.
+This means you can declare your instance with the [`using`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using){target="_blank"} keyword and have your metrics flushed automatically when the binding goes out of scope, including when an exception is thrown.
+This is a lightweight alternative to wrapping your handler in a `try/finally` block.
 
 !!! warning
     Metrics, dimensions and namespace validation still applies.

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -252,11 +252,12 @@ As you finish adding all your metrics, you need to serialize and "flush them" by
 You can flush metrics automatically using one of the following methods:  
 
 * manually
+* the `using` keyword
 * [Middy-compatible](https://github.com/middyjs/middy){target=_blank} middleware
 * class decorator
 
 Using the Middy middleware or decorator will **automatically validate, serialize, and flush** all your metrics. During metrics validation, if no metrics are provided then a warning will be logged, but no exception will be thrown.
-If you do not use the middleware or decorator, you have to flush your metrics manually.
+If you do not use the middleware or decorator, you have to flush your metrics manually or rely on the `using` keyword.
 
 !!! warning "Metric validation"
     If metrics are provided, and any of the following criteria are not met, a **`RangeError`** error will be thrown:
@@ -318,6 +319,27 @@ You can manually flush the metrics with `publishStoredMetrics` as follows:
     ```typescript hl_lines="13"
     --8<-- "examples/snippets/metrics/manual.ts"
     ```
+
+=== "Example CloudWatch Logs excerpt"
+
+    ```json
+    --8<-- "examples/snippets/metrics/samples/manualLog.json"
+    ```
+
+#### Using the `using` keyword
+
+If you are running on Node.js 24 or newer, the `Metrics` class implements the [`Disposable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose){target="_blank"} interface. This means you can declare your instance with the [`using`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using){target="_blank"} keyword and have your metrics flushed automatically when the binding goes out of scope, including when an exception is thrown. This is a lightweight alternative to wrapping your handler in a `try/finally` block.
+
+!!! warning
+    Metrics, dimensions and namespace validation still applies.
+
+=== "handler.ts"
+
+    ```typescript hl_lines="12"
+    --8<-- "examples/snippets/metrics/usingKeyword.ts"
+    ```
+
+    1. The metrics are flushed automatically via `[Symbol.dispose]()` when the binding leaves the handler scope.
 
 === "Example CloudWatch Logs excerpt"
 

--- a/examples/snippets/metrics/usingKeyword.ts
+++ b/examples/snippets/metrics/usingKeyword.ts
@@ -1,0 +1,15 @@
+import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
+
+const metrics = new Metrics({
+  namespace: 'serverlessAirline',
+  serviceName: 'orders',
+});
+
+export const handler = async (
+  _event: unknown,
+  _context: unknown
+): Promise<void> => {
+  using _ = metrics; // (1)!
+  metrics.addMetric('successfulBooking', MetricUnit.Count, 10);
+  // metrics are flushed automatically when the scope exits, including on errors
+};

--- a/packages/metrics/src/Metrics.ts
+++ b/packages/metrics/src/Metrics.ts
@@ -637,6 +637,36 @@ class Metrics extends Utility implements MetricsInterface {
   }
 
   /**
+   * Flush the stored metrics when the instance goes out of a `using` scope.
+   *
+   * This implements the [`Disposable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose)
+   * interface by delegating to {@link Metrics.publishStoredMetrics | `publishStoredMetrics()`}.
+   * When the binding declared with `using` leaves scope—including when an exception is thrown—the stored
+   * metrics are automatically flushed, removing the need for a manual `try/finally` block.
+   *
+   * The `using` keyword requires Node.js 24 or newer.
+   *
+   * @example
+   * ```typescript
+   * import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
+   *
+   * const metrics = new Metrics({
+   *   namespace: 'serverlessAirline',
+   *   serviceName: 'orders'
+   * });
+   *
+   * export const handler = async () => {
+   *   using _ = metrics;
+   *   metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+   *   // metrics are automatically flushed when the scope exits, including on exceptions
+   * };
+   * ```
+   */
+  public [Symbol.dispose](): void {
+    this.publishStoredMetrics();
+  }
+
+  /**
    * Sets the timestamp for the metric.
    *
    * If an integer is provided, it is assumed to be the epoch time in milliseconds.

--- a/packages/metrics/src/types/Metrics.ts
+++ b/packages/metrics/src/types/Metrics.ts
@@ -430,6 +430,33 @@ interface MetricsInterface {
    */
   publishStoredMetrics(): void;
   /**
+   * Flush the stored metrics when the instance goes out of a `using` scope.
+   *
+   * This implements the [`Disposable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/dispose)
+   * interface by delegating to {@link MetricsInterface.publishStoredMetrics | `publishStoredMetrics()`}.
+   * When the binding declared with `using` leaves scope—including when an exception is thrown—the stored
+   * metrics are automatically flushed, removing the need for a manual `try/finally` block.
+   *
+   * The `using` keyword requires Node.js 24 or newer.
+   *
+   * @example
+   * ```typescript
+   * import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
+   *
+   * const metrics = new Metrics({
+   *   namespace: 'serverlessAirline',
+   *   serviceName: 'orders'
+   * });
+   *
+   * export const handler = async () => {
+   *   using _ = metrics;
+   *   metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+   *   // metrics are automatically flushed when the scope exits, including on exceptions
+   * };
+   * ```
+   */
+  [Symbol.dispose](): void;
+  /**
    * Serialize the stored metrics into a JSON object compliant with the Amazon CloudWatch EMF (Embedded Metric Format) schema.
    *
    * The EMF schema is a JSON object that contains the following properties:

--- a/packages/metrics/tests/e2e/basicFeatures.using.test.functionCode.ts
+++ b/packages/metrics/tests/e2e/basicFeatures.using.test.functionCode.ts
@@ -1,0 +1,25 @@
+import type { Context } from 'aws-lambda';
+import { Metrics, MetricUnit } from '../../src/index.js';
+import type { MetricUnit as MetricUnitType } from '../../src/types/index.js';
+
+const namespace = process.env.EXPECTED_NAMESPACE ?? 'CdkExample';
+const serviceName =
+  process.env.EXPECTED_SERVICE_NAME ?? 'MyFunctionWithStandardHandler';
+const metricName = process.env.EXPECTED_METRIC_NAME ?? 'MyMetric';
+const metricUnit =
+  (process.env.EXPECTED_METRIC_UNIT as MetricUnitType) ?? MetricUnit.Count;
+const metricValue = process.env.EXPECTED_METRIC_VALUE ?? '1';
+const defaultDimensions =
+  process.env.EXPECTED_DEFAULT_DIMENSIONS ?? '{"MyDimension":"MyValue"}';
+
+const metrics = new Metrics({ namespace: namespace, serviceName: serviceName });
+
+export const handler = (_event: unknown, _context: Context) => {
+  // The metrics are automatically flushed via `[Symbol.dispose]()` when the
+  // `using` binding leaves the handler scope, even if an error is thrown.
+  using _ = metrics;
+
+  metrics.captureColdStartMetric();
+  metrics.setDefaultDimensions(JSON.parse(defaultDimensions));
+  metrics.addMetric(metricName, metricUnit, Number.parseInt(metricValue, 10));
+};

--- a/packages/metrics/tests/e2e/basicFeatures.using.test.ts
+++ b/packages/metrics/tests/e2e/basicFeatures.using.test.ts
@@ -1,0 +1,167 @@
+import { join } from 'node:path';
+import {
+  invokeFunction,
+  TestStack,
+} from '@aws-lambda-powertools/testing-utils';
+import {
+  CloudWatchClient,
+  GetMetricStatisticsCommand,
+} from '@aws-sdk/client-cloudwatch';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getMetrics, sortDimensions } from '../helpers/metricsUtils.js';
+import { MetricsTestNodejsFunction } from '../helpers/resources.js';
+import { commonEnvironmentVars, RESOURCE_NAME_PREFIX } from './constants.js';
+
+// The `using` keyword requires Node.js 24 or newer.
+describe.skipIf(Number(process.versions.node.split('.')[0]) < 24)(
+  'Metrics E2E tests, using keyword',
+  () => {
+    const testStack = new TestStack({
+      stackNameProps: {
+        stackNamePrefix: RESOURCE_NAME_PREFIX,
+        testName: 'BasicFeatures-Using',
+      },
+    });
+
+    // Location of the lambda function code
+    const lambdaFunctionCodeFilePath = join(
+      __dirname,
+      'basicFeatures.using.test.functionCode.ts'
+    );
+    const startTime = new Date();
+
+    const expectedServiceName = 'e2eUsing';
+    new MetricsTestNodejsFunction(
+      testStack,
+      {
+        entry: lambdaFunctionCodeFilePath,
+        environment: {
+          EXPECTED_SERVICE_NAME: expectedServiceName,
+        },
+      },
+      {
+        nameSuffix: 'Using',
+      }
+    );
+
+    const cloudwatchClient = new CloudWatchClient({});
+    const invocations = 2;
+
+    beforeAll(async () => {
+      // Deploy the stack
+      await testStack.deploy();
+
+      // Get the actual function names from the stack outputs
+      const functionName = testStack.findAndGetStackOutputValue('Using');
+
+      // Act
+      await invokeFunction({
+        functionName,
+        times: invocations,
+        invocationMode: 'SEQUENTIAL',
+      });
+    });
+
+    describe('ColdStart metrics', () => {
+      it('captures the ColdStart Metric', async () => {
+        const { EXPECTED_NAMESPACE: expectedNamespace } = commonEnvironmentVars;
+
+        // Check coldstart metric dimensions
+        const coldStartMetrics = await getMetrics(
+          cloudwatchClient,
+          expectedNamespace,
+          'ColdStart',
+          1
+        );
+        expect(coldStartMetrics.Metrics?.length).toBe(1);
+        const coldStartMetric = coldStartMetrics.Metrics?.[0];
+        expect(coldStartMetric?.Dimensions).toContainEqual({
+          Name: 'service',
+          Value: expectedServiceName,
+        });
+
+        // Check coldstart metric value
+        const adjustedStartTime = new Date(startTime.getTime() - 60 * 1000);
+        const endTime = new Date(Date.now() + 60 * 1000);
+        const coldStartMetricStat = await cloudwatchClient.send(
+          new GetMetricStatisticsCommand({
+            Namespace: expectedNamespace,
+            StartTime: adjustedStartTime,
+            Dimensions: [{ Name: 'service', Value: expectedServiceName }],
+            EndTime: endTime,
+            Period: 60,
+            MetricName: 'ColdStart',
+            Statistics: ['Sum'],
+          })
+        );
+
+        // Despite the lambda being called twice, the coldstart metric sum should only be 1
+        const singleDataPoint = coldStartMetricStat.Datapoints
+          ? coldStartMetricStat.Datapoints[0]
+          : {};
+        expect(singleDataPoint?.Sum).toBe(1);
+      });
+    });
+
+    describe('Default dimensions', () => {
+      it('produces a Metric with the default dimensions', async () => {
+        const {
+          EXPECTED_NAMESPACE: expectedNamespace,
+          EXPECTED_METRIC_NAME: expectedMetricName,
+          EXPECTED_METRIC_VALUE: expectedMetricValue,
+          EXPECTED_DEFAULT_DIMENSIONS: expectedDefaultDimensions,
+        } = commonEnvironmentVars;
+
+        // Check metric dimensions
+        const metrics = await getMetrics(
+          cloudwatchClient,
+          expectedNamespace,
+          expectedMetricName,
+          1
+        );
+
+        expect(metrics.Metrics?.length).toBe(1);
+        const metric = metrics.Metrics?.[0];
+        const expectedDimensions = [
+          { Name: 'service', Value: expectedServiceName },
+          {
+            Name: Object.keys(expectedDefaultDimensions)[0],
+            Value: expectedDefaultDimensions.MyDimension,
+          },
+        ];
+        expect(sortDimensions(metric?.Dimensions)).toStrictEqual(
+          sortDimensions(expectedDimensions)
+        );
+
+        // Check metric value
+        const adjustedStartTime = new Date(startTime.getTime() - 3 * 60 * 1000);
+        const endTime = new Date(Date.now() + 60 * 1000);
+        const metricStat = await cloudwatchClient.send(
+          new GetMetricStatisticsCommand({
+            Namespace: expectedNamespace,
+            StartTime: adjustedStartTime,
+            Dimensions: expectedDimensions,
+            EndTime: endTime,
+            Period: 60,
+            MetricName: expectedMetricName,
+            Statistics: ['Sum'],
+          })
+        );
+
+        // Since the lambda has been called twice in this test, the metric sum should be at least of expectedMetricValue * invocationCount
+        const singleDataPoint = metricStat.Datapoints
+          ? metricStat.Datapoints[0]
+          : {};
+        expect(singleDataPoint.Sum).toBeGreaterThanOrEqual(
+          Number.parseInt(expectedMetricValue, 10) * invocations
+        );
+      });
+    });
+
+    afterAll(async () => {
+      if (!process.env.DISABLE_TEARDOWN) {
+        await testStack.destroy();
+      }
+    });
+  }
+);

--- a/packages/metrics/tests/unit/dispose.test.ts
+++ b/packages/metrics/tests/unit/dispose.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_NAMESPACE } from '../../src/constants.js';
 import { Metrics, MetricUnit } from '../../src/index.js';
 
@@ -82,22 +82,36 @@ describe.skipIf(Number(process.versions.node.split('.')[0]) < 24)(
         expect.stringContaining('No application metrics to publish')
       );
     });
-
-    it('delegates to publishStoredMetrics when disposed directly', () => {
-      // Prepare
-      const metrics = new Metrics({
-        singleMetric: false,
-        namespace: DEFAULT_NAMESPACE,
-      });
-      vi.spyOn(metrics, 'publishStoredMetrics');
-      metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
-
-      // Act
-      metrics[Symbol.dispose]();
-
-      // Assess
-      expect(metrics.publishStoredMetrics).toHaveBeenCalledTimes(1);
-      expect(console.log).toHaveBeenCalledTimes(1);
-    });
   }
 );
+
+// `Symbol.dispose` itself is available on Node.js 22, so the method can be
+// exercised directly even where the `using` keyword is not supported.
+describe('Disposable support (direct dispose)', () => {
+  beforeEach(() => {
+    vi.stubEnv('POWERTOOLS_DEV', 'true');
+    vi.stubEnv('POWERTOOLS_METRICS_DISABLED', 'false');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('delegates to publishStoredMetrics when disposed directly', () => {
+    // Prepare
+    const metrics = new Metrics({
+      singleMetric: false,
+      namespace: DEFAULT_NAMESPACE,
+    });
+    vi.spyOn(metrics, 'publishStoredMetrics');
+    metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+
+    // Act
+    metrics[Symbol.dispose]();
+
+    // Assess
+    expect(metrics.publishStoredMetrics).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/metrics/tests/unit/dispose.test.ts
+++ b/packages/metrics/tests/unit/dispose.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_NAMESPACE } from '../../src/constants.js';
+import { Metrics, MetricUnit } from '../../src/index.js';
+
+// The `using` keyword requires Node.js 24 or newer.
+describe.skipIf(Number(process.versions.node.split('.')[0]) < 24)(
+  'Disposable support (using keyword)',
+  () => {
+    const ENVIRONMENT_VARIABLES = process.env;
+
+    beforeEach(() => {
+      process.env = {
+        ...ENVIRONMENT_VARIABLES,
+        POWERTOOLS_DEV: 'true',
+        POWERTOOLS_METRICS_DISABLED: 'false',
+      };
+      vi.clearAllMocks();
+    });
+
+    it('flushes the stored metrics when the scope exits', () => {
+      // Prepare
+      const metrics = new Metrics({
+        singleMetric: false,
+        namespace: DEFAULT_NAMESPACE,
+      });
+      vi.spyOn(metrics, 'publishStoredMetrics');
+
+      // Act
+      {
+        using _ = metrics;
+        metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+      }
+
+      // Assess
+      expect(metrics.publishStoredMetrics).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveEmittedNthEMFWith(
+        1,
+        expect.objectContaining({ successfulBooking: 1 })
+      );
+    });
+
+    it('flushes the stored metrics even when an error is thrown', () => {
+      // Prepare
+      const metrics = new Metrics({
+        singleMetric: false,
+        namespace: DEFAULT_NAMESPACE,
+      });
+      vi.spyOn(metrics, 'publishStoredMetrics');
+
+      // Act & Assess
+      expect(() => {
+        using _ = metrics;
+        metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+        throw new Error('Something went wrong');
+      }).toThrow('Something went wrong');
+
+      expect(metrics.publishStoredMetrics).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveEmittedNthEMFWith(
+        1,
+        expect.objectContaining({ successfulBooking: 1 })
+      );
+    });
+
+    it('warns instead of throwing when no metrics are stored', () => {
+      // Prepare
+      const metrics = new Metrics({
+        singleMetric: false,
+        namespace: DEFAULT_NAMESPACE,
+      });
+      const warnSpy = vi.spyOn(console, 'warn');
+
+      // Act
+      {
+        using _ = metrics;
+      }
+
+      // Assess
+      expect(console.log).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No application metrics to publish')
+      );
+    });
+
+    it('delegates to publishStoredMetrics when disposed directly', () => {
+      // Prepare
+      const metrics = new Metrics({
+        singleMetric: false,
+        namespace: DEFAULT_NAMESPACE,
+      });
+      vi.spyOn(metrics, 'publishStoredMetrics');
+      metrics.addMetric('successfulBooking', MetricUnit.Count, 1);
+
+      // Act
+      metrics[Symbol.dispose]();
+
+      // Assess
+      expect(metrics.publishStoredMetrics).toHaveBeenCalledTimes(1);
+      expect(console.log).toHaveBeenCalledTimes(1);
+    });
+  }
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,10 @@
     "target": "ES2024", // Node.js 22
     // `Disposable`/`Symbol.dispose` are not part of any yearly ES lib yet (not ES2024 nor
     // ES2025 as of TS 6.x), so we pull them in explicitly. Compile-time only: it doesn't
-    // change emitted code or require a runtime polyfill.
-    "lib": ["ES2024", "ESNext.Disposable"],
+    // change emitted code or require a runtime polyfill. DOM libs must be listed too:
+    // setting `lib` replaces the target's implicit default (ES2024 + DOM + DOM.Iterable),
+    // and the codebase relies on DOM types like `BodyInit` and `Response`.
+    "lib": ["ES2024", "DOM", "DOM.Iterable", "ESNext.Disposable"],
     "experimentalDecorators": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
     "incremental": true,
     "composite": true,
     "target": "ES2024", // Node.js 22
+    // `Disposable`/`Symbol.dispose` are not part of any yearly ES lib yet (not ES2024 nor
+    // ES2025 as of TS 6.x), so we pull them in explicitly. Compile-time only: it doesn't
+    // change emitted code or require a runtime polyfill.
+    "lib": ["ES2024", "ESNext.Disposable"],
     "experimentalDecorators": true,
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## Summary

Implements the `Disposable` interface on the `Metrics` class so instances can be declared with the `using` keyword (Node.js 24+). When the binding leaves scope — including when an exception is thrown — stored metrics are flushed automatically via `publishStoredMetrics()`, offering a lightweight alternative to a manual `try/finally` block or the middleware/decorator.

### Changes

- Add `[Symbol.dispose]()` to `Metrics` (`packages/metrics/src/Metrics.ts`), delegating to `publishStoredMetrics()`, and declare it on `MetricsInterface` (`packages/metrics/src/types/Metrics.ts`) with TSDoc and examples
- Add `ESNext.Disposable` to `lib` in the root `tsconfig.json` — `Symbol.dispose` types aren't part of any yearly ES lib yet; compile-time only, no emitted-code or polyfill impact
- Add unit tests (`packages/metrics/tests/unit/dispose.test.ts`) covering flush on scope exit, flush on thrown error, empty-metrics warning, and direct disposal — skipped on Node.js < 24
- Add e2e test (`packages/metrics/tests/e2e/basicFeatures.using.test.ts`) verifying metrics are delivered to CloudWatch when flushed via `using`
- Document the new flushing method in `docs/features/metrics.md` with a new snippet (`examples/snippets/metrics/usingKeyword.ts`)

**Issue number:** closes #5200

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.