### PR TITLE
fix(event-handler): preserve original string for invalid Bedrock Agent number params

### DIFF
--- a/packages/event-handler/src/bedrock-agent/BedrockAgentFunctionResolver.ts
+++ b/packages/event-handler/src/bedrock-agent/BedrockAgentFunctionResolver.ts
@@ -226,7 +226,11 @@ class BedrockAgentFunctionResolver {
         }
         case 'number':
         case 'integer': {
-          toolParams[param.name] = Number(param.value);
+          const parsed = Number(param.value);
+          // Fall back to the original string when the value is not a valid
+          // number (e.g. `Number('abc')` is `NaN`, which serializes to `null`).
+          // This matches the behavior of the Python runtime - see #3988.
+          toolParams[param.name] = Number.isNaN(parsed) ? param.value : parsed;
           break;
         }
         // this default will also catch array types but we leave them as strings

--- a/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
+++ b/packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts
@@ -451,6 +451,44 @@ describe('Class: BedrockAgentFunctionResolver', () => {
     );
   });
 
+  it.each([
+    { type: 'number' as const },
+    { type: 'integer' as const },
+  ])(
+    'preserves the original string when a $type parameter is not a valid number',
+    async ({ type }) => {
+      // Prepare
+      const toolFunction: ToolFunction<{ arg: number | string }> = async (
+        params,
+        _options
+      ) => params.arg;
+
+      const toolParams: Configuration = {
+        name: 'echo',
+        description: 'Echoes the received parameter',
+      };
+
+      const parameters: Parameter[] = [
+        { name: 'arg', type, value: 'not-a-number' },
+      ];
+
+      const app = new BedrockAgentFunctionResolver();
+      app.tool(toolFunction, toolParams);
+
+      // Act
+      const actual = await app.resolve(
+        createEvent(toolParams.name, parameters),
+        context
+      );
+
+      // Assess
+      expect(actual.response.function).toEqual(toolParams.name);
+      expect(actual.response.functionResponse.responseBody.TEXT.body).toEqual(
+        '"not-a-number"'
+      );
+    }
+  );
+
   it('correctly parses string parameters', async () => {
     // Prepare
     const toolFunction: ToolFunction<{ arg: string }> = async (


### PR DESCRIPTION
## Summary

First, thank you to the maintainers for Powertools for AWS Lambda — it makes building Lambda functions a pleasure, and the cross-runtime parity work is much appreciated.

This is a small follow-up to that alignment effort. The `BedrockAgentFunctionResolver` coerces `number`/`integer` parameters with `Number(param.value)` **unconditionally**. When a Bedrock Agent sends a `number`/`integer`-typed parameter whose value is not a valid numeric string, `Number(...)` returns `NaN`, which serializes to `null` via `JSON.stringify` — the original value sent by the agent is silently lost.

The Python runtime already guards against this: it wraps `int()`/`float()` in `try`/`except` and falls back to the original string ([`bedrock_agent_function.py` at `L212-L221`](https://github.com/aws-powertools/powertools-lambda-python/blob/develop/aws_lambda_powertools/event_handler/bedrock_agent_function.py#L212-L221)). This PR carries the same fallback over to the TypeScript resolver, so the two runtimes behave consistently.

### Changes

`packages/event-handler/src/bedrock-agent/BedrockAgentFunctionResolver.ts` — for the `number`/`integer` case, fall back to the original string when `Number(...)` yields `NaN`:

```ts
case 'number':
case 'integer': {
  const parsed = Number(param.value);
  // Fall back to the original string when the value is not a valid
  // number (e.g. `Number('abc')` is `NaN`, which serializes to `null`).
  // This matches the behavior of the Python runtime.
  toolParams[param.name] = Number.isNaN(parsed) ? param.value : parsed;
  break;
}
```

This is the minimal change required: it touches only the `NaN` branch and leaves every other path untouched.

### Before / After

Tool that echoes back a `number`-typed parameter with value `'not-a-number'`:

| Case | Before | After |
|------|--------|-------|
| `number`/`integer` param, **non-numeric** value (`'not-a-number'`) | ❌ `NaN` → response body `null` (value lost) | ✅ original string `"not-a-number"` preserved (matches Python) |
| `number`/`integer` param, **valid** value (`'42'`) | ✅ `42` | ✅ `42` (unchanged) |
| `boolean` / `string` / `array` params | ✅ unchanged | ✅ unchanged |
| Public API / method signatures / valid-number behavior | — | ✅ unchanged |

**Issue number:** Closes #5362

This continues the Bedrock Agent Function resolver alignment effort, which was previously tracked under the resolver parity work released in v2.21.0.

## Testing

Added a parametrized regression test (`it.each(['number', 'integer'])`) in `packages/event-handler/tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts` asserting the original string is preserved.

**Green (with fix):**

```
✓ tests/unit/bedrock-agent/BedrockAgentFunctionResolver.test.ts (24 tests)
 Test Files  1 passed (1)
      Tests  24 passed (24)
```

**Red (fix reverted via `git stash`, new test kept) — proves the test catches the bug:**

```
 FAIL  ... > preserves the original string when a 'number' parameter is not a valid number
 FAIL  ... > preserves the original string when a 'integer' parameter is not a valid number
AssertionError: expected 'null' to deeply equal '"not-a-number"'
Expected: ""not-a-number""
Received: "null"
      Tests  2 failed | 22 passed (24)
```

Local gates:

- `npx biome lint` on both changed files → clean.
- Coverage on the changed file: `Statements 100% (33/33), Branches 100% (23/23), Functions 100% (4/4), Lines 100% (33/33)` — the new branch is fully covered.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

_This contribution was prepared with the help of an AI agent (Claude Code); a human reviewed the change, the rationale, and the test results before submitting._

