### PR TITLE
ci(layers): update SSM latest parameter on release

### DIFF
--- a/.github/workflows/publish_layer.yml
+++ b/.github/workflows/publish_layer.yml
@@ -96,6 +96,7 @@ jobs:
       id-token: write
     with:
       environment: prod
+      write_latest: ${{ !inputs.pre_release }}
       package_version: ${{ inputs.latest_published_version }}
       layer-version: ${{ needs.deploy-prod.outputs.layer-version }}
     secrets:

--- a/docs/getting-started/lambda-layers.md
+++ b/docs/getting-started/lambda-layers.md
@@ -294,7 +294,7 @@ Change `{aws::region}` to your AWS region, e.g. `eu-west-1`, and run the followi
     ```terraform
       data "aws_ssm_parameter" "powertools_version" {
         # Replace {version} with your chosen Powertools for AWS Lambda version or latest
-        name = "/aws/service/powertools/python/generic/all/latest"
+        name = "/aws/service/powertools/typescript/generic/all/latest"
       }
 
       resource "aws_lambda_function" "test_lambda" {


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

The `latest` SSM parameter (`/aws/service/powertools/typescript/generic/all/latest`) was stale and still pointed to layer `v35` (`v2.25.2`, last updated August 2025), while the version-specific parameters kept advancing (newest is `v2.33.1`).

The release pipeline calls the SSM update job but never passed `write_latest`, so the `write-latest` step (gated on `inputs.write_latest == true`) was always skipped on automated releases. Only the version-specific parameter (`.../generic/all/<version>`) was written.

This passes `write_latest` to the `update-ssm-prod` job, gated on `!inputs.pre_release` so pre-releases don't move `latest`.

It also fixes the Terraform example in the Lambda Layers docs, which used the Python SSM parameter path (`/aws/service/powertools/python/generic/all/latest`) instead of the TypeScript one.

Note: the `latest` parameter has already been re-pointed to the current layer version manually to unstick it immediately; this PR ensures future releases keep it up to date.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #5368

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.