### PR TITLE
ci: slow CDK stack-event polling to avoid CFN throttling

### DIFF
--- a/packages/testing/src/TestStack.ts
+++ b/packages/testing/src/TestStack.ts
@@ -9,7 +9,10 @@ import {
 } from '@aws-cdk/toolkit-lib';
 import { App, Stack } from 'aws-cdk-lib';
 import { generateTestUniqueName } from './helpers.js';
+import { patchCdkStackEventPolling } from './patchCdkStackEventPolling.js';
 import type { TestStackProps } from './types.js';
+
+patchCdkStackEventPolling();
 
 const testConsole = new Console({
   stdout: process.stdout,

--- a/packages/testing/src/patchCdkStackEventPolling.ts
+++ b/packages/testing/src/patchCdkStackEventPolling.ts
@@ -1,0 +1,66 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+/**
+ * How often the CDK toolkit polls `DescribeStackEvents` for each in-flight
+ * stack operation once patched. The default is 2s; our e2e `ioHost` only
+ * surfaces progress every 10s anyway, so nothing is lost by polling slower.
+ */
+const PATCHED_POLLING_INTERVAL_MS = 10_000;
+
+let patched = false;
+
+/**
+ * Slow down the CDK toolkit's CloudFormation stack-event polling.
+ *
+ * `@aws-cdk/toolkit-lib` polls `DescribeStackEvents` every 2s per active stack
+ * operation and exposes no way to configure this. During e2e runs the CI matrix
+ * deploys/destroys dozens of stacks concurrently, which saturates the
+ * account-level CloudFormation read API rate and randomly fails jobs with
+ * `Throttling: Rate exceeded` (CDK_TOOLKIT_E5500/E7900).
+ *
+ * Until the interval is configurable upstream, we reach into the toolkit's
+ * internals and raise it on every monitor before it starts. The patch is a
+ * no-op (with a warning) if the internal module moves in a future release.
+ */
+const patchCdkStackEventPolling = (): void => {
+  if (patched) return;
+  patched = true;
+  try {
+    const cjsRequire = createRequire(join(process.cwd(), 'index.js'));
+    const toolkitRoot = dirname(
+      cjsRequire.resolve('@aws-cdk/toolkit-lib/package.json')
+    );
+    const { StackActivityMonitor } = cjsRequire(
+      join(
+        toolkitRoot,
+        'lib',
+        'api',
+        'stack-events',
+        'stack-activity-monitor.js'
+      )
+    ) as {
+      StackActivityMonitor: {
+        prototype: {
+          pollingInterval: number;
+          start: (...args: unknown[]) => unknown;
+        };
+      };
+    };
+    const originalStart = StackActivityMonitor.prototype.start;
+    StackActivityMonitor.prototype.start = function (
+      this: { pollingInterval: number },
+      ...args: unknown[]
+    ) {
+      this.pollingInterval = PATCHED_POLLING_INTERVAL_MS;
+      return originalStart.apply(this, args);
+    };
+  } catch (error) {
+    console.warn(
+      'Unable to patch @aws-cdk/toolkit-lib stack-event polling interval; e2e runs may hit CloudFormation throttling',
+      error
+    );
+  }
+};
+
+export { PATCHED_POLLING_INTERVAL_MS, patchCdkStackEventPolling };


### PR DESCRIPTION
## Summary

Every recent "Run e2e Tests" run loses one or more matrix jobs to CloudFormation `Throttling: Rate exceeded` (`CDK_TOOLKIT_E5500`/`CDK_TOOLKIT_E7900`). `@aws-cdk/toolkit-lib`'s `StackActivityMonitor` polls `DescribeStackEvents` every 2 s per active stack operation with no public option to change it; with 36 matrix jobs deploying stacks concurrently, that saturates the account-level CloudFormation read-API rate. This PR patches the monitor at module load to poll every 10 s instead — a 5× cut in call volume with no observable cost, since our `ioHost` only surfaces progress every 10 s anyway.

This is an interim fix: we've asked for a public `pollingInterval` option upstream (aws/aws-cdk-cli#1709) and offered to implement it. Once it ships, the patch gets replaced by the supported option in `TestStack.ts`. If a future toolkit release moves the internal module, the patch degrades to a console warning rather than breaking e2e.

### Changes

- Add `packages/testing/src/patchCdkStackEventPolling.ts`: wraps `StackActivityMonitor.prototype.start` via a deep CJS require into toolkit-lib internals and raises `pollingInterval` from 2 s to 10 s; no-ops with a warning if the internal module can't be resolved
- Invoke the patch at module load in `packages/testing/src/TestStack.ts`, so every e2e suite gets it with no per-package changes

**Issue number:** closes #5404

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
