### PR TITLE
chore(governance): add shared agent skills for creating issues and PRs

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: create-issue
+description: Creates GitHub issues following the project's issue templates. Use when asked to create, file, or open a GitHub issue.
+---
+
+# Create GitHub Issue
+
+When creating GitHub issues for this project, follow the issue templates defined in `.github/ISSUE_TEMPLATE/`. The templates are the source of truth for fields, required/optional flags, labels, and title prefixes — always read the relevant template file rather than relying on remembered field names, since CLI-created issues bypass GitHub's template UI entirely.
+
+## Workflow
+
+1. Choose the template based on the issue type:
+   - **Bug report** (`bug_report.yml`): something is broken or behaving incorrectly and can be reproduced
+   - **Feature request** (`feature_request.yml`): a new capability or improvement for users of the library
+   - **Maintenance** (`maintenance.yml`): tech debt, governance, tooling, automation, or anything internal-facing
+2. Read the chosen template file from `.github/ISSUE_TEMPLATE/` to get the exact fields, title prefix, and labels
+3. Draft the issue body covering every field in the template — include required fields always, and optional fields when you have something useful to say
+4. Present the draft to the user for review
+5. Only create the issue after the user approves
+
+## Rules
+
+- ALWAYS show the draft before creating
+- Present the tenets acknowledgment checkbox as checked — the issue implicitly asserts compliance, and the user's approval of the draft confirms it
+- If unsure which template to use, ask the user

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: create-pr
+description: Creates GitHub pull requests following the project's PR template. Use when asked to create, open, or submit a pull request.
+---
+
+# Create Pull Request
+
+When creating pull requests for this project, you MUST follow the PR template defined in `.github/PULL_REQUEST_TEMPLATE.md`.
+
+**CRITICAL: NEVER run `gh pr create` without showing the user the full draft (title + body) first and getting their explicit approval. Always draft first, present, wait for approval, then create.**
+
+## Workflow
+
+1. Read `.github/PULL_REQUEST_TEMPLATE.md` to get the exact structure
+2. Run `git log` and `git diff main...HEAD` to understand all commits on the branch
+3. Draft the PR title and body following the template and conventions below
+4. **Show the complete draft (title + body) to the user and STOP. Wait for explicit approval before proceeding.**
+5. Only after the user approves, run `gh pr create`
+
+## PR title
+
+- Must follow [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2)
+- Keep under 70 characters
+- Examples: `feat(logger): add structured logging`, `fix(metrics): resolve dimension limit`, `chore: remove me-south-1 region`
+
+## PR body format
+
+The body MUST follow this structure:
+
+```markdown
+## Summary
+
+<1-3 sentence summary of what and why>
+
+### Changes
+
+<bullet list of specific changes made>
+
+**Issue number:** closes #<issue_number>
+
+---
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+
+**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
+```
+
+## Rules
+
+- ALWAYS use bullet points in the Changes section, NOT checklists
+- ALWAYS include the issue number if one exists
+- ALWAYS include the disclaimer and contribution confirmation from the template
+- The Summary section should explain the "what" and "why" concisely
+- The Changes section should list concrete changes (files, behaviors) as bullets
+- Do NOT use checklists (`- [x]`) in the Changes section
+- Push the branch before creating the PR if not already pushed

--- a/.claude/skills/create-issue
+++ b/.claude/skills/create-issue
@@ -1,0 +1,1 @@
+../../.agents/skills/create-issue

--- a/.claude/skills/create-pr
+++ b/.claude/skills/create-pr
@@ -1,0 +1,1 @@
+../../.agents/skills/create-pr

--- a/.gitignore
+++ b/.gitignore
@@ -49,15 +49,17 @@ tsconfig.tsbuildinfo
 .tsbuildinfo
 
 # LLMs
-.claude
+CLAUDE.md
+.claude/*
+!.claude/skills
+.claude/skills/*
+!.claude/skills/create-issue
+!.claude/skills/create-pr
 .amazonq
 .kiro
 .github/instructions
 aidlc-docsspecs/
 .specify/
-AGENTS.md
 # generated agent artifacts
 specs/
-.specify/
-AGENTS.md
 aidlc-docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Instructions
+
+## Skills
+
+Project-specific agent skills live in [`.agents/skills/`](.agents/skills/). Each skill is a directory containing a `SKILL.md` with frontmatter (`name`, `description`) describing when to use it.
+
+If your coding agent does not discover skills from `.agents/skills/` automatically, read the relevant `SKILL.md` and follow its instructions when performing a matching task:
+
+- [`create-issue`](.agents/skills/create-issue/SKILL.md) — creating GitHub issues following the project's issue templates
+- [`create-pr`](.agents/skills/create-pr/SKILL.md) — creating GitHub pull requests following the project's PR template


### PR DESCRIPTION
## Summary

Adds project-specific agent skills that encode this repository's conventions for creating GitHub issues and pull requests, so AI coding agents follow the project's templates instead of producing free-form output. Skills live once in `.agents/skills/` (an emerging cross-harness convention), avoiding duplicate copies per harness directory.

### Changes

- Add `.agents/skills/create-issue/SKILL.md` — instructs agents to read the templates in `.github/ISSUE_TEMPLATE/`, draft the issue, and get user approval before posting
- Add `.agents/skills/create-pr/SKILL.md` — instructs agents to follow the PR template, conventional-commit titles, and draft-first workflow
- Add committed symlinks `.claude/skills/create-issue` and `.claude/skills/create-pr` pointing into `.agents/skills/`, since Claude Code does not yet read `.agents/skills/` natively (removable once it does)
- Add `AGENTS.md` pointing agents without native skill discovery at `.agents/skills/`
- Update `.gitignore` with negation rules so the symlinks and `AGENTS.md` are tracked while the rest of `.claude/` stays ignored

**Issue number:** closes #5406

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.