### PR TITLE
docs: document npm package name reservation in maintainers playbook

### DIFF
--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -163,6 +163,65 @@ When necessary, be upfront that the time to review, approve, and implement a RFC
 
 Some examples using our initial and new RFC templates: [#447](https://github.com/aws-powertools/powertools-lambda-typescript/issues/447)
 
+### Reserving a package name on npm
+
+When a brand-new package is about to be merged into `main` for the first time (e.g. a new utility), its name must be manually published to npm **once**, ahead of its first real release.
+
+!!! important
+    The `Make Release` workflow publishes packages using [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers){target="_blank" rel="nofollow"} via GitHub Actions OIDC, so we get provenance/attestation without storing a long-lived `NPM_TOKEN`.
+
+    Trusted publishers can only be configured for a package that **already exists** on npm (under `npmjs.com/package/<name>/access`), so a package can't reserve its own name this way the first time around.
+
+    A maintainer must publish an initial placeholder version manually to reserve the name and unlock Trusted Publishing for it.
+
+Follow these steps before the new package's first real release:
+
+1. **Create a temporary local package** using the same placeholder shape adopted by every utility before its first release, for example:
+
+    ```json title="package.json"
+    {
+      "name": "@aws-lambda-powertools/<name>",
+      "version": "0.0.0",
+      "description": "The <name> package for the Powertools for AWS Lambda (TypeScript) library",
+      "author": { "name": "Amazon Web Services", "url": "https://aws.amazon.com" },
+      "publishConfig": { "access": "public" },
+      "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript",
+      "license": "MIT-0",
+      "main": "./lib/index.js",
+      "types": "./lib/index.d.ts",
+      "files": ["lib"],
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/aws-powertools/powertools-lambda-typescript.git"
+      },
+      "bugs": { "url": "https://github.com/aws-powertools/powertools-lambda-typescript/issues" },
+      "dependencies": {},
+      "keywords": ["aws", "lambda", "powertools", "handler", "nodejs", "serverless"],
+      "devDependencies": {}
+    }
+    ```
+
+    Add a `README.md` with the same "do not use this in production yet" disclaimer used by other placeholders (see [`@aws-lambda-powertools/validation@0.0.0`](https://www.npmjs.com/package/@aws-lambda-powertools/validation/v/0.0.0){target="_blank" rel="nofollow"} as a reference).
+
+    Also add a `lib/index.js`/`lib/index.d.ts` pair, where the former only logs that it's a placeholder used to reserve the name.
+
+2. **Authenticate locally** as an npm user who's a member of the `@aws-lambda-powertools` org with publish rights. Use a short-lived, least-privilege token and never commit it to `.npmrc` - remove and rotate/revoke it as soon as you're done.
+
+3. **Publish with the `pre` dist-tag**, not `latest`:
+
+    ```bash
+    npm publish --access public --tag pre
+    ```
+
+    !!! note
+        npm always assigns `latest` to the very first version ever published for a package, regardless of `--tag`. This means `0.0.0` will briefly carry both `latest` and `pre`. This is expected and self-corrects: the next real release (published without an explicit tag) will move `latest` forward, while `pre` stays pinned to `0.0.0` as a permanent marker of the placeholder.
+
+4. **Configure Trusted Publishing** for the new package: go to `https://www.npmjs.com/package/<name>/access`, add a Trusted Publisher for GitHub Actions, and point it at this repository and the `make-release.yml` workflow. This is what lets `Make Release` publish real versions of this package with OIDC/provenance going forward, without ever needing an `NPM_TOKEN`.
+
+5. Make sure the PR adding the new package also adds it to the `workspaces` array in the root `package.json`, and to any workflow that enumerates packages individually (e.g. `reusable-run-linting-check-and-unit-tests.yml`, `run-e2e-tests.yml`), so it's picked up by CI and by the next `Make Release` run.
+
+Once these steps are done, the new package is released like any other in the [normal release process](#releasing-a-new-version) the next time `Make Release` runs.
+
 ### Releasing a new version
 
 Releasing a new version is a multi-step process that requires up to 3 hours to complete. Below a checklist of the main steps to follow:


### PR DESCRIPTION
## Summary

Document, in the maintainers playbook, the manual process required to reserve a brand-new package's name on npm before its first real release, since npm Trusted Publishing (the OIDC mechanism our Make Release workflow relies on for tokenless, provenance-attested publishing) can only be configured for packages that already exist on npm.

### Changes

- Add a "Reserving a package name on npm" section to `docs/maintainers.md`, placed before "Releasing a new version"
- Explain why the manual step exists (Trusted Publisher config requires an already-existing package)
- Document how to create the placeholder `0.0.0` package matching the shape of prior placeholders (e.g. `@aws-lambda-powertools/validation@0.0.0`)
- Document publishing the placeholder with the `pre` dist-tag, including a note on npm's behavior of always tagging the first-ever publish as `latest` regardless of `--tag`
- Document configuring the npm Trusted Publisher for the new package before its first automated release
- Note the need to add the new package to the root `workspaces` array and relevant CI workflows

**Issue number:** closes #5417

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.