### PR TITLE
docs(idempotency): explain persistence layer reuse across multiple operations

### DIFF
--- a/docs/features/idempotency.md
+++ b/docs/features/idempotency.md
@@ -253,6 +253,31 @@ Imagine the function executes successfully, but the client never receives the re
     --8<-- "examples/snippets/idempotency/types.ts:3:16"
     ```
 
+### Using multiple idempotent operations
+
+You can make multiple functions idempotent within the same Lambda function, each with its own configuration.
+
+In most cases, you can and should share the same persistence layer instance across idempotent operations. All the settings you pass when instantiating it - i.e. table name, attribute names, or a custom AWS SDK client - are safe to share.
+
+However, a persistence layer instance also carries the [idempotency configuration](#customizing-the-default-behavior) of the **first operation that uses it**, and silently ignores subsequent ones. This means that when your operations need different `IdempotencyConfig` settings - for example different `eventKeyJmesPath` expressions - each operation must use its own persistence layer instance. Otherwise, the second operation would extract the idempotency key using the first operation's expression, which can cause it to always resolve to the same key and return stale results.
+
+When using multiple persistence layer instances, you can still share the same AWS SDK client to reuse the underlying connection.
+
+=== "index.ts"
+
+    ```typescript hl_lines="11 20-23 37-40"
+    --8<-- "examples/snippets/idempotency/makeIdempotentMultipleOperations.ts"
+    ```
+
+=== "types.ts"
+
+    ```typescript
+    --8<-- "examples/snippets/idempotency/types.ts:3:16"
+    ```
+
+???+ note
+    The same applies to the [`@idempotent` decorator](#idempotent-decorator) and the [`makeHandlerIdempotent` Middy middleware](#makehandleridempotent-middy-middleware): operations with different idempotency configurations need their own persistence layer instance.
+
 ### Lambda timeouts
 
 To prevent against extended failed retries when a [Lambda function times out](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-verify-invocation-timeouts/), Powertools for AWS Lambda calculates and includes the remaining invocation available time as part of the idempotency record.

--- a/docs/features/idempotency.md
+++ b/docs/features/idempotency.md
@@ -259,7 +259,9 @@ You can make multiple functions idempotent within the same Lambda function, each
 
 In most cases, you can and should share the same persistence layer instance across idempotent operations. All the settings you pass when instantiating it - i.e. table name, attribute names, or a custom AWS SDK client - are safe to share.
 
-However, a persistence layer instance also carries the [idempotency configuration](#customizing-the-default-behavior) of the **first operation that uses it**, and silently ignores subsequent ones. This means that when your operations need different `IdempotencyConfig` settings - for example different `eventKeyJmesPath` expressions - each operation must use its own persistence layer instance. Otherwise, the second operation would extract the idempotency key using the first operation's expression, which can cause it to always resolve to the same key and return stale results.
+However, a persistence layer instance also carries the [idempotency configuration](#customizing-the-default-behavior) of the **first operation that uses it**, and silently ignores subsequent ones.
+
+For this reason, operations that need different `IdempotencyConfig` settings - i.e. different `eventKeyJmesPath` expressions - must each use their own persistence layer instance. If they shared one, the second operation would extract the idempotency key using the first operation's expression, which can cause it to always resolve to the same key and return stale results.
 
 When using multiple persistence layer instances, you can still share the same AWS SDK client to reuse the underlying connection.
 

--- a/examples/snippets/idempotency/makeIdempotentMultipleOperations.ts
+++ b/examples/snippets/idempotency/makeIdempotentMultipleOperations.ts
@@ -1,0 +1,59 @@
+import {
+  IdempotencyConfig,
+  makeIdempotent,
+} from '@aws-lambda-powertools/idempotency';
+import { DynamoDBPersistenceLayer } from '@aws-lambda-powertools/idempotency/dynamodb';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import type { Context } from 'aws-lambda';
+import type { Request, Response } from './types.js';
+
+// You can share the same AWS SDK client across persistence layer instances
+const dynamoDBClient = new DynamoDBClient({});
+
+const processUser = makeIdempotent(
+  async (user: { userId: string }) => {
+    // ... process user
+    return { userId: user.userId };
+  },
+  {
+    // Operations with different configs need their own persistence layer instance
+    persistenceStore: new DynamoDBPersistenceLayer({
+      tableName: 'idempotencyTableName',
+      awsSdkV3Client: dynamoDBClient,
+    }),
+    config: new IdempotencyConfig({
+      eventKeyJmesPath: 'userId',
+    }),
+  }
+);
+
+const processProduct = makeIdempotent(
+  async (product: { productId: string }) => {
+    // ... process product
+    return { productId: product.productId };
+  },
+  {
+    // Don't reuse the instance above: this operation has a different config
+    persistenceStore: new DynamoDBPersistenceLayer({
+      tableName: 'idempotencyTableName',
+      awsSdkV3Client: dynamoDBClient,
+    }),
+    config: new IdempotencyConfig({
+      eventKeyJmesPath: 'productId',
+    }),
+  }
+);
+
+export const handler = async (
+  event: Request,
+  _context: Context
+): Promise<Response> => {
+  const user = await processUser({ userId: event.user });
+  const product = await processProduct({ productId: event.productId });
+
+  return {
+    user,
+    product,
+    statusCode: 200,
+  };
+};


### PR DESCRIPTION
## Summary

Documents how the persistence layer behaves when reused across multiple idempotent operations. A persistence layer instance captures the `IdempotencyConfig` of the first operation that uses it and silently ignores subsequent ones, which can lead to stale results when operations use different configurations (e.g. different `eventKeyJmesPath` expressions). This behavior is intended and consistent with other Powertools runtimes, so we're addressing it with explicit documentation rather than a behavior change.

### Changes

- Add a "Using multiple idempotent operations" section to the Idempotency docs explaining that sharing a persistence layer instance is safe and recommended in most cases, and that operations with different idempotency configurations need their own instance
- Add a new snippet (`makeIdempotentMultipleOperations.ts`) showing two idempotent operations with different `eventKeyJmesPath` expressions, each with its own `DynamoDBPersistenceLayer` sharing a single AWS SDK client

**Issue number:** closes #5409

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.