### PR TITLE
chore(deps): bump transitive protobufjs from 7.5.8 to 7.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2860,34 +2860,26 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@protobufjs/aspromise": "^1.1.1"
       }
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "devOptional": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "devOptional": true,
       "license": "BSD-3-Clause"
     },
@@ -3829,9 +3821,9 @@
       ]
     },
     "node_modules/@valkey/valkey-glide/node_modules/protobufjs": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
@@ -3839,15 +3831,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8816,7 +8807,7 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.33.1",
-        "@aws/lambda-invoke-store": "^0.3.0",
+        "@aws/lambda-invoke-store": "0.3.0",
         "@standard-schema/spec": "^1.1.0"
       },
       "devDependencies": {
@@ -8831,7 +8822,7 @@
       "version": "2.33.1",
       "license": "MIT-0",
       "dependencies": {
-        "@aws/lambda-invoke-store": "^0.3.0"
+        "@aws/lambda-invoke-store": "0.3.0"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -8980,7 +8971,7 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.33.1",
-        "@aws/lambda-invoke-store": "^0.3.0"
+        "@aws/lambda-invoke-store": "0.3.0"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing"
@@ -9004,7 +8995,7 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.33.1",
-        "@aws/lambda-invoke-store": "^0.3.0"
+        "@aws/lambda-invoke-store": "0.3.0"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../testing",
@@ -9100,7 +9091,7 @@
         "@aws-cdk/toolkit-lib": "^1.32.0",
         "@aws-sdk/client-cloudwatch-logs": "^3.1079.0",
         "@aws-sdk/client-lambda": "^3.1079.0",
-        "@aws/lambda-invoke-store": "^0.3.0",
+        "@aws/lambda-invoke-store": "0.3.0",
         "@smithy/util-utf8": "^4.4.6",
         "aws-cdk-lib": "^2.261.0",
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
   "allowScripts": {
     "esbuild": true,
     "fsevents": true,
-    "protobufjs@7.5.8": true
+    "protobufjs@7.6.5": true
   }
 }


### PR DESCRIPTION
## Summary

Bumps the transitive `protobufjs` under `@valkey/valkey-glide` from 7.5.8 to 7.6.5 to clear two npm audit vulnerabilities (GHSA-f38q-mgvj-vph7, high; GHSA-wcpc-wj8m-hjx6, moderate). Dependabot cannot open this fix itself: the vulnerable copy is pinned only by the lockfile, and the declared range (`protobufjs: "7"`) already allows the patched version, so the fix is a lockfile-only refresh via `npm audit fix`.

### Changes

- Run `npm audit fix` to bump transitive `protobufjs` 7.5.8 → 7.6.5 in `package-lock.json`
- Update the `allowScripts` pin in the root `package.json` from `protobufjs@7.5.8` to `protobufjs@7.6.5`

**Issue number:** closes #5420

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
