### PR TITLE
fix(logger): scope lambda context per invocation under LMI concurrency

### DIFF
--- a/packages/logger/src/LogAttributesStore.ts
+++ b/packages/logger/src/LogAttributesStore.ts
@@ -1,7 +1,7 @@
 import '@aws/lambda-invoke-store';
 import { deepMerge } from '@aws-lambda-powertools/commons';
 import { shouldUseInvokeStore } from '@aws-lambda-powertools/commons/utils/env';
-import type { LogAttributes } from './types/logKeys.js';
+import type { LogAttributes, PowertoolsLogData } from './types/logKeys.js';
 
 /**
  * Manages storage of log attributes with automatic context detection.
@@ -16,10 +16,12 @@ class LogAttributesStore {
     'powertools.logger.temporaryAttributes'
   );
   readonly #keysKey = Symbol('powertools.logger.keys');
+  readonly #lambdaContextKey = Symbol('powertools.logger.lambdaContext');
 
   #fallbackTemporaryAttributes: LogAttributes = {};
   readonly #fallbackKeys: Map<string, 'temp' | 'persistent'> = new Map();
   #persistentAttributes: LogAttributes = {};
+  #fallbackLambdaContext: PowertoolsLogData['lambdaContext'];
 
   #getTemporaryAttributes(): LogAttributes {
     if (!shouldUseInvokeStore()) {
@@ -108,6 +110,27 @@ class LogAttributesStore {
     }
 
     globalThis.awslambda.InvokeStore?.set(this.#temporaryAttributesKey, {});
+  }
+
+  public setLambdaContext(context: PowertoolsLogData['lambdaContext']): void {
+    if (!shouldUseInvokeStore()) {
+      this.#fallbackLambdaContext = context;
+      return;
+    }
+
+    if (globalThis.awslambda?.InvokeStore === undefined) {
+      throw new Error('InvokeStore is not available');
+    }
+
+    globalThis.awslambda.InvokeStore.set(this.#lambdaContextKey, context);
+  }
+
+  public getLambdaContext(): PowertoolsLogData['lambdaContext'] {
+    if (!shouldUseInvokeStore()) {
+      return this.#fallbackLambdaContext;
+    }
+
+    return globalThis.awslambda?.InvokeStore?.get(this.#lambdaContextKey);
   }
 
   public setPersistentAttributes(attributes: LogAttributes): void {

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -274,16 +274,14 @@ class Logger extends Utility implements LoggerInterface {
    * @param context - The Lambda function's invocation context.
    */
   public addContext(context: Context): void {
-    this.addToPowertoolsLogData({
-      lambdaContext: {
-        invokedFunctionArn: context.invokedFunctionArn,
-        coldStart: this.getColdStart(),
-        awsRequestId: context.awsRequestId,
-        memoryLimitInMB: context.memoryLimitInMB,
-        functionName: context.functionName,
-        functionVersion: context.functionVersion,
-        tenantId: context.tenantId,
-      },
+    this.#attributesStore.setLambdaContext({
+      invokedFunctionArn: context.invokedFunctionArn,
+      coldStart: this.getColdStart(),
+      awsRequestId: context.awsRequestId,
+      memoryLimitInMB: context.memoryLimitInMB,
+      functionName: context.functionName,
+      functionVersion: context.functionVersion,
+      tenantId: context.tenantId,
     });
   }
 
@@ -366,10 +364,9 @@ class Logger extends Utility implements LoggerInterface {
         options
       )
     );
-    if (this.powertoolsLogData.lambdaContext)
-      childLogger.addContext(
-        this.powertoolsLogData.lambdaContext as unknown as Context
-      );
+    const lambdaContext = this.#attributesStore.getLambdaContext();
+    if (lambdaContext)
+      childLogger.addContext(lambdaContext as unknown as Context);
     const temporaryAttributes = this.#attributesStore.getTemporaryAttributes();
     if (Object.keys(temporaryAttributes).length > 0) {
       childLogger.appendKeys(temporaryAttributes);
@@ -855,7 +852,7 @@ class Logger extends Utility implements LoggerInterface {
       logLevel: this.getLogLevelNameFromNumber(logLevel),
       timestamp: new Date(),
       xRayTraceId: getXRayTraceIdFromEnv(),
-      ...this.getPowertoolsLogData(),
+      ...this.#getPowertoolsLogData(),
       message: '',
     };
     const additionalAttributes = this.#attributesStore.getAllAttributes();
@@ -992,8 +989,13 @@ class Logger extends Utility implements LoggerInterface {
    * Get information that will be added in all log item by
    * this Logger instance (different from user-provided persistent attributes).
    */
-  private getPowertoolsLogData(): PowertoolsLogData {
-    return this.powertoolsLogData;
+  #getPowertoolsLogData(): PowertoolsLogData {
+    const lambdaContext = this.#attributesStore.getLambdaContext();
+    if (lambdaContext === undefined) {
+      return this.powertoolsLogData;
+    }
+
+    return { ...this.powertoolsLogData, lambdaContext };
   }
 
   /**

--- a/packages/logger/tests/unit/concurrency/logger.test.ts
+++ b/packages/logger/tests/unit/concurrency/logger.test.ts
@@ -1,5 +1,6 @@
 import { InvokeStore } from '@aws/lambda-invoke-store';
 import { sequence } from '@aws-lambda-powertools/testing-utils';
+import context from '@aws-lambda-powertools/testing-utils/context';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Logger } from '../../../src/index.js';
 
@@ -67,6 +68,17 @@ describe('Logger concurrent invocation isolation', () => {
       // Act & Assess
       expect(() => {
         logger.appendPersistentKeys({ env: 'prod' });
+      }).toThrow('InvokeStore is not available');
+    });
+
+    it('throws error when adding lambda context with InvokeStore unavailable', () => {
+      // Prepare
+      vi.stubEnv('AWS_LAMBDA_MAX_CONCURRENCY', '10');
+      const logger = new Logger({ serviceName: 'test' });
+
+      // Act & Assess
+      expect(() => {
+        logger.addContext(context);
       }).toThrow('InvokeStore is not available');
     });
   });
@@ -352,6 +364,96 @@ describe('Logger concurrent invocation isolation', () => {
             logger.appendKeys({ requestId: 'req-2', env: 'dev' });
             logger.removeKeys(['env']);
             logger.info('Test message');
+          },
+        ],
+        return: () => {},
+      },
+      { useInvokeStore }
+    );
+
+    // Assess
+    for (const expectedOutput of expectedKeys) {
+      expect(console.info).toHaveLogged(
+        expect.objectContaining(expectedOutput)
+      );
+    }
+  });
+
+  it.each([
+    {
+      description: 'without InvokeStore',
+      useInvokeStore: false,
+      expectedKeys: [
+        {
+          message: 'from inv1',
+          function_request_id: 'req-2',
+          tenant_id: 'tenant-2',
+          cold_start: false,
+        },
+        {
+          message: 'from inv2',
+          function_request_id: 'req-2',
+          tenant_id: 'tenant-2',
+          cold_start: false,
+        },
+      ],
+    },
+    {
+      description: 'with InvokeStore',
+      useInvokeStore: true,
+      expectedKeys: [
+        {
+          message: 'from inv1',
+          function_request_id: 'req-1',
+          tenant_id: 'tenant-1',
+          cold_start: true,
+        },
+        {
+          message: 'from inv2',
+          function_request_id: 'req-2',
+          tenant_id: 'tenant-2',
+          cold_start: false,
+        },
+      ],
+    },
+  ])('handles lambda context $description', async ({
+    useInvokeStore,
+    expectedKeys,
+  }) => {
+    // Prepare
+    if (useInvokeStore) {
+      vi.stubEnv('AWS_LAMBDA_MAX_CONCURRENCY', '10');
+    }
+    const logger = new Logger({ serviceName: 'test' });
+
+    // Act
+    await sequence(
+      {
+        sideEffects: [
+          () =>
+            logger.addContext({
+              ...context,
+              awsRequestId: 'req-1',
+              tenantId: 'tenant-1',
+            }),
+          () => {}, // Wait for inv2 to add its context
+          () => {
+            logger.info('from inv1');
+          },
+        ],
+        return: () => {},
+      },
+      {
+        sideEffects: [
+          () => {}, // Wait for inv1 to add its context
+          () =>
+            logger.addContext({
+              ...context,
+              awsRequestId: 'req-2',
+              tenantId: 'tenant-2',
+            }),
+          () => {
+            logger.info('from inv2');
           },
         ],
         return: () => {},


### PR DESCRIPTION
## Summary

`Logger.addContext()` stored the Lambda context in plain instance state, so when Lambda Managed Instances multiplexes concurrent invocations into the same execution environment, invocations overwrite each other's context and emitted log lines carry the wrong `function_request_id`, `tenant_id`, and `cold_start`. This PR scopes the whole `lambdaContext` per invocation via the InvokeStore when `AWS_LAMBDA_MAX_CONCURRENCY` is set, using the same dual-path pattern already used for temporary attributes.

### Changes

- Add `setLambdaContext()`/`getLambdaContext()` to `LogAttributesStore`, storing the context in the InvokeStore under a private symbol when `shouldUseInvokeStore()` is true, and in instance state otherwise (throws `InvokeStore is not available` if the store is missing, matching the existing attribute methods)
- `Logger.addContext()` writes through the store; `getPowertoolsLogData()` and `createChild()` read through it, so formatters and child loggers stay consistent
- Add a concurrency unit test that interleaves two invocations' `addContext()`/`info()` calls via `sequence()`: with the InvokeStore each log line carries its own invocation's request id, tenant id, and cold start; without it the last-write-wins behavior is preserved

**Issue number:** closes #5429

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
