### PR TITLE
docs(event-handler): mention HTTP event handler in package README

### DIFF
--- a/packages/event-handler/README.md
+++ b/packages/event-handler/README.md
@@ -6,7 +6,7 @@ You can use the library in both TypeScript and JavaScript code bases.
 
 ## Intro
 
-Event handler for AWS AppSync GraphQL APIs and AWS AppSync Events APIs.
+Event handler for Amazon API Gateway REST and HTTP APIs, Application Load Balancer (ALB), Lambda Function URLs, AWS AppSync GraphQL APIs, and AWS AppSync Events APIs.
 
 ## Usage
 
@@ -15,6 +15,80 @@ To get started, install the library by running:
 ```sh
 npm i @aws-lambda-powertools/event-handler
 ```
+
+## HTTP
+
+Event Handler for Amazon API Gateway REST and HTTP APIs, Application Load Balancer (ALB), and Lambda Function URLs.
+
+* Lightweight routing to reduce boilerplate for API Gateway REST/HTTP API, ALB and Lambda Function URLs
+* Web standards based - incoming events are automatically converted into [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) objects, and you can return [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) objects from your handlers
+* Automatic event type detection and response format transformation, so you can swap integrations (e.g. from ALB to API Gateway) with little to no code changes
+* Built-in middleware engine for request/response transformation and validation
+* Works with micro function (one or a few routes) and monolithic functions
+
+### Handle HTTP requests
+
+You can register handlers for specific HTTP methods and paths using the corresponding method, for example `get()` or `post()`. The handler will be called whenever a request matches the method and path.
+
+```typescript
+import { Router } from '@aws-lambda-powertools/event-handler/http';
+import type { Context } from 'aws-lambda';
+
+const app = new Router();
+
+app.get('/todos', async () => {
+  // your logic here
+  return [
+    {
+      id: 'todo-id',
+      title: 'Todo Title',
+      completed: false,
+    },
+  ];
+});
+
+app.post('/todos', async ({ req }) => {
+  const body = await req.json();
+  // your logic here
+  return body;
+});
+
+export const handler = async (event: unknown, context: Context) =>
+  app.resolve(event, context);
+```
+
+### Dynamic routes
+
+You can use dynamic path parameters in your routes, which are automatically parsed and passed to your handler.
+
+```typescript
+import { Router } from '@aws-lambda-powertools/event-handler/http';
+import type { Context } from 'aws-lambda';
+
+const app = new Router();
+
+app.get('/todos/:todoId', async ({ params: { todoId } }) => {
+  // your logic here
+  return {
+    id: todoId,
+    title: 'Todo Title',
+    completed: false,
+  };
+});
+
+export const handler = async (event: unknown, context: Context) =>
+  app.resolve(event, context);
+```
+
+There's much more to the HTTP event handler, including:
+
+* Request and response validation using [Standard Schema](https://standardschema.dev) compatible libraries like Zod, Valibot, and ArkType
+* Error handling with built-in and custom error handlers, and typed HTTP errors
+* CORS, compression, and AWS X-Ray tracing via built-in middleware
+* Split routers to organize routes across multiple files
+* Response streaming and binary responses
+
+See the [documentation](https://docs.aws.amazon.com/powertools/typescript/latest/features/event-handler/http) for more details on how to use the HTTP event handler.
 
 ## AppSync Events
 
@@ -101,6 +175,8 @@ app.onSubscribe('/default/foo', async (event) => {
 export const handler = async (event, context) =>
   app.resolve(event, context);
 ```
+
+See the [documentation](https://docs.aws.amazon.com/powertools/typescript/latest/features/event-handler/appsync-events) for more details on how to use the AppSync Events event handler.
 
 ## AppSync GraphQL
 
@@ -211,7 +287,7 @@ export const handler = async (event: unknown, context: Context) =>
   app.resolve(event, context);
 ```
 
-See the [documentation](https://docs.aws.amazon.com/powertools/typescript/latest/features/event-handler/appsync-events) for more details on how to use the AppSync event handler.
+See the [documentation](https://docs.aws.amazon.com/powertools/typescript/latest/features/event-handler/appsync-graphql) for more details on how to use the AppSync GraphQL event handler.
 
 ## Contribute
 


### PR DESCRIPTION
## Summary

The `@aws-lambda-powertools/event-handler` package README did not mention the HTTP event handler at all, making the feature invisible on npm, which is a primary discovery surface for the package. This PR adds an HTTP section mirroring the style of the existing AppSync sections.

### Changes

- Update the intro line to include Amazon API Gateway REST and HTTP APIs, ALB, and Lambda Function URLs
- Add an HTTP section with feature highlights (web standards based `Request`/`Response`, automatic event type detection and response format transformation, middleware engine) and short usage examples for basic routes and dynamic path parameters
- Add a list of additional HTTP event handler features (validation via Standard Schema, error handling, CORS/compression/tracer middleware, split routers, response streaming and binary responses) with a link to the full documentation
- Fix the AppSync GraphQL section's documentation link, which pointed to the AppSync Events docs, and give the AppSync Events section its own correctly-linked closing line

**Issue number:** closes #5428

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.