### PR TITLE
chore(skills): make create-issue checkbox handling template-driven

### DIFF
--- a/.agents/skills/create-issue/SKILL.md
+++ b/.agents/skills/create-issue/SKILL.md
@@ -21,5 +21,6 @@ When creating GitHub issues for this project, follow the issue templates defined
 ## Rules
 
 - ALWAYS show the draft before creating
-- Present the tenets acknowledgment checkbox as checked — the issue implicitly asserts compliance, and the user's approval of the draft confirms it
+- If the template has a `checkboxes` field (e.g. the Acknowledgment section in feature_request.yml and maintenance.yml), reproduce its options verbatim as a section with checkbox syntax (`- [ ]`), checking the required ones — the issue implicitly asserts compliance, and the user's approval of the draft confirms it
+- If the template has no `checkboxes` field (e.g. bug_report.yml), do NOT invent one
 - If unsure which template to use, ask the user


### PR DESCRIPTION
## Summary

The `create-issue` agent skill unconditionally instructed adding a checked tenets acknowledgment checkbox to every issue it drafts. `bug_report.yml` has no `checkboxes` field, so skill-created bug reports ended with a fabricated `- [x] I acknowledge that this issue follows the project tenets` line that exists in no template. This makes the rule template-driven so CLI-created issues match what the GitHub template UI produces.

### Changes

- Replace the unconditional "present the tenets checkbox as checked" rule in `.agents/skills/create-issue/SKILL.md` with two template-driven rules: reproduce the template's `checkboxes` options verbatim (checking required ones) when the field exists, and never invent checkboxes when it doesn't

**Issue number:** closes #5438

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
