### PR TITLE
fix(tracer): scope middy middleware segment state per invocation

### DIFF
--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -8,17 +8,18 @@ import type { Tracer } from '../Tracer.js';
 import type { CaptureLambdaHandlerOptions } from '../types/Tracer.js';
 
 /**
- * Keys used to store the per-invocation segments and CLS context in the
- * middy `request.internal` object.
+ * Keys used to store the per-invocation segments in the middy
+ * `request.internal` object.
  *
  * Storing this state per-request rather than in factory-closure variables is
  * required for correctness when multiple invocations are multiplexed into the
  * same execution environment (e.g. Lambda Managed Instances with
- * `perExecutionEnvironmentMaxConcurrency` > 1).
+ * `perExecutionEnvironmentMaxConcurrency` > 1): closure variables are shared
+ * by all in-flight invocations, so one invocation's `after`/`onError` hook
+ * would close and restore another invocation's segments.
  */
 const lambdaSegmentKey = `${TRACER_KEY}.lambdaSegment`;
 const handlerSegmentKey = `${TRACER_KEY}.handlerSegment`;
-const clsContextKey = `${TRACER_KEY}.clsContext`;
 
 /**
  * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
@@ -63,35 +64,11 @@ const captureLambdaHandler = (
     };
   };
 
-  /**
-   * Open a new handler subsegment inside a fresh CLS context dedicated to
-   * this invocation.
-   *
-   * In Lambda mode the X-Ray SDK enters a single process-wide CLS context at
-   * initialization, so `setSegment()` alone writes the active segment into a
-   * slot shared by all concurrent invocations. To keep interleaved
-   * invocations isolated, we create and enter a new CLS context first: the
-   * context tracking in `cls-hooked` is based on `async_hooks` resource
-   * creation, so — as long as this function runs synchronously within the
-   * `before` hook — every async resource created downstream (the handler and
-   * the `after`/`onError` hooks) inherits the new context, while other
-   * in-flight invocations keep operating on their own. This mirrors what
-   * `captureAsyncFunc` does in the decorator path via `namespace.run()`.
-   *
-   * The created context prototypally inherits the facade segment from the
-   * SDK's root context, and `setSegment()` then shadows it with the handler
-   * subsegment for this invocation only.
-   *
-   * @param request - The request object
-   */
   const open = (request: MiddyLikeRequest): void => {
     const segment = target.getSegment();
     if (segment === undefined) {
       return;
     }
-    const namespace = target.provider.getNamespace();
-    const clsContext = namespace.createContext();
-    namespace.enter(clsContext);
     // If segment is defined, then it is a Segment as this middleware is only used for Lambda Handlers
     const lambdaSegment = segment as Segment;
     const handlerSegment = lambdaSegment.addNewSubsegment(
@@ -102,16 +79,9 @@ const captureLambdaHandler = (
       ...request.internal,
       [lambdaSegmentKey]: lambdaSegment,
       [handlerSegmentKey]: handlerSegment,
-      [clsContextKey]: clsContext,
     };
   };
 
-  /**
-   * Close the handler subsegment for this invocation, restore the facade
-   * segment, and exit the invocation's CLS context.
-   *
-   * @param request - The request object
-   */
   const close = (request: MiddyLikeRequest): void => {
     const handlerSegment = request.internal[handlerSegmentKey] as
       | Subsegment
@@ -132,10 +102,6 @@ const captureLambdaHandler = (
       );
     }
     target.setSegment(lambdaSegment);
-    const clsContext = request.internal[clsContextKey];
-    if (clsContext !== undefined) {
-      target.provider.getNamespace().exit(clsContext);
-    }
   };
 
   const before = (request: MiddyLikeRequest) => {

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -8,6 +8,19 @@ import type { Tracer } from '../Tracer.js';
 import type { CaptureLambdaHandlerOptions } from '../types/Tracer.js';
 
 /**
+ * Keys used to store the per-invocation segments and CLS context in the
+ * middy `request.internal` object.
+ *
+ * Storing this state per-request rather than in factory-closure variables is
+ * required for correctness when multiple invocations are multiplexed into the
+ * same execution environment (e.g. Lambda Managed Instances with
+ * `perExecutionEnvironmentMaxConcurrency` > 1).
+ */
+const lambdaSegmentKey = `${TRACER_KEY}.lambdaSegment`;
+const handlerSegmentKey = `${TRACER_KEY}.handlerSegment`;
+const clsContextKey = `${TRACER_KEY}.clsContext`;
+
+/**
  * A middy middleware automating capture of metadata and annotations on segments or subsegments for a Lambda Handler.
  *
  * Using this middleware on your handler function will automatically:
@@ -38,9 +51,6 @@ const captureLambdaHandler = (
   target: Tracer,
   options?: CaptureLambdaHandlerOptions
 ): MiddlewareLikeObj => {
-  let lambdaSegment: Segment;
-  let handlerSegment: Subsegment;
-
   /**
    * Set the cleanup function to be called in case other middlewares return early.
    *
@@ -53,21 +63,63 @@ const captureLambdaHandler = (
     };
   };
 
-  const open = (): void => {
+  /**
+   * Open a new handler subsegment inside a fresh CLS context dedicated to
+   * this invocation.
+   *
+   * In Lambda mode the X-Ray SDK enters a single process-wide CLS context at
+   * initialization, so `setSegment()` alone writes the active segment into a
+   * slot shared by all concurrent invocations. To keep interleaved
+   * invocations isolated, we create and enter a new CLS context first: the
+   * context tracking in `cls-hooked` is based on `async_hooks` resource
+   * creation, so — as long as this function runs synchronously within the
+   * `before` hook — every async resource created downstream (the handler and
+   * the `after`/`onError` hooks) inherits the new context, while other
+   * in-flight invocations keep operating on their own. This mirrors what
+   * `captureAsyncFunc` does in the decorator path via `namespace.run()`.
+   *
+   * The created context prototypally inherits the facade segment from the
+   * SDK's root context, and `setSegment()` then shadows it with the handler
+   * subsegment for this invocation only.
+   *
+   * @param request - The request object
+   */
+  const open = (request: MiddyLikeRequest): void => {
     const segment = target.getSegment();
     if (segment === undefined) {
       return;
     }
+    const namespace = target.provider.getNamespace();
+    const clsContext = namespace.createContext();
+    namespace.enter(clsContext);
     // If segment is defined, then it is a Segment as this middleware is only used for Lambda Handlers
-    lambdaSegment = segment as Segment;
-    handlerSegment = lambdaSegment.addNewSubsegment(
+    const lambdaSegment = segment as Segment;
+    const handlerSegment = lambdaSegment.addNewSubsegment(
       `## ${process.env._HANDLER}`
     );
     target.setSegment(handlerSegment);
+    request.internal = {
+      ...request.internal,
+      [lambdaSegmentKey]: lambdaSegment,
+      [handlerSegmentKey]: handlerSegment,
+      [clsContextKey]: clsContext,
+    };
   };
 
-  const close = (): void => {
-    if (handlerSegment === undefined || lambdaSegment === null) {
+  /**
+   * Close the handler subsegment for this invocation, restore the facade
+   * segment, and exit the invocation's CLS context.
+   *
+   * @param request - The request object
+   */
+  const close = (request: MiddyLikeRequest): void => {
+    const handlerSegment = request.internal[handlerSegmentKey] as
+      | Subsegment
+      | undefined;
+    const lambdaSegment = request.internal[lambdaSegmentKey] as
+      | Segment
+      | undefined;
+    if (handlerSegment === undefined || lambdaSegment === undefined) {
       return;
     }
     try {
@@ -80,11 +132,15 @@ const captureLambdaHandler = (
       );
     }
     target.setSegment(lambdaSegment);
+    const clsContext = request.internal[clsContextKey];
+    if (clsContext !== undefined) {
+      target.provider.getNamespace().exit(clsContext);
+    }
   };
 
   const before = (request: MiddyLikeRequest) => {
     if (target.isTracingEnabled()) {
-      open();
+      open(request);
       setCleanupFunction(request);
       target.annotateColdStart();
       target.addServiceNameAnnotation();
@@ -96,14 +152,14 @@ const captureLambdaHandler = (
       if (options?.captureResponse ?? true) {
         target.addResponseAsMetadata(request.response, process.env._HANDLER);
       }
-      close();
+      close(request);
     }
   };
 
   const onError = (request: MiddyLikeRequest) => {
     if (target.isTracingEnabled()) {
       target.addErrorAsMetadata(request.error as Error);
-      close();
+      close(request);
     }
   };
 

--- a/packages/tracer/tests/unit/middy.concurrency.test.ts
+++ b/packages/tracer/tests/unit/middy.concurrency.test.ts
@@ -2,132 +2,134 @@ import context from '@aws-lambda-powertools/testing-utils/context';
 import middy from '@middy/core';
 import type { Context } from 'aws-lambda';
 import { Segment, Subsegment } from 'aws-xray-sdk-core';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Tracer } from '../../src/index.js';
 import { captureLambdaHandler } from '../../src/middleware/middy.js';
 
-// Must run before aws-xray-sdk-core is imported so the SDK initializes in
-// Lambda mode with its real CLS context, which is what these tests exercise:
-// in Lambda mode the SDK enters a single process-wide CLS context at init,
-// so per-invocation isolation must be provided by the middleware itself.
-vi.hoisted(() => {
-  vi.stubEnv('LAMBDA_TASK_ROOT', '/var/task');
-  vi.stubEnv('AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR');
-  vi.stubEnv(
-    '_X_AMZN_TRACE_ID',
-    'Root=1-abcdef12-3456abcdef123456abcdef12;Parent=1234abcd1234abcd;Sampled=1'
-  );
-});
-
-type SubsegmentWithAnnotations = Subsegment & {
-  annotations?: Record<string, unknown>;
-};
-
 /**
- * Track every handler subsegment created by the middleware, in creation
- * order, regardless of which parent it was attached to; `annotations` is
- * not part of the SDK's public type but is where `addAnnotation()` writes.
+ * When multiple invocations are multiplexed into the same execution
+ * environment (e.g. Lambda Managed Instances with
+ * `perExecutionEnvironmentMaxConcurrency` > 1), the same middleware instance
+ * handles overlapping invocations. Per-invocation state must therefore live
+ * in `request.internal` rather than in factory-closure variables, so each
+ * invocation closes the subsegment it opened and restores the facade segment
+ * it captured - regardless of interleaving or completion order.
+ *
+ * Note: correct *attribution* of annotations/metadata under concurrent
+ * invocations (aws-powertools/powertools-lambda-typescript#5434) is not
+ * covered here as it requires per-invocation context isolation in the X-Ray
+ * SDK and cannot be provided from within a middy middleware.
  */
-const trackHandlerSubsegments = (): SubsegmentWithAnnotations[] => {
-  const handlerSubsegments: SubsegmentWithAnnotations[] = [];
-  for (const proto of [Segment.prototype, Subsegment.prototype]) {
-    const original = proto.addNewSubsegment;
-    vi.spyOn(proto, 'addNewSubsegment').mockImplementation(function (
-      this: Segment | Subsegment,
-      name: string
-    ) {
-      const subsegment = original.call(this, name);
-      if (name.startsWith('## ')) {
-        handlerSubsegments.push(subsegment);
-      }
-      return subsegment;
-    });
-  }
-  return handlerSubsegments;
-};
-
 describe('Middy middleware: concurrent invocations', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('records annotations on the subsegment of the invocation that produced them when invocations overlap', async () => {
-    // Prepare
+  const setupOverlappingInvocations = () => {
     const tracer = new Tracer({ serviceName: 'concurrency-test' });
-    const handlerSubsegments = trackHandlerSubsegments();
+    vi.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
+    vi.spyOn(tracer, 'addServiceNameAnnotation').mockImplementation(
+      () => ({})
+    );
+    const setSegmentSpy = vi
+      .spyOn(tracer.provider, 'setSegment')
+      .mockImplementation(() => ({}));
+
+    const facadeSegmentA = new Segment('facadeA');
+    const handlerSubsegmentA = new Subsegment('## index.handlerA');
+    vi.spyOn(facadeSegmentA, 'addNewSubsegment').mockImplementation(
+      () => handlerSubsegmentA
+    );
+    const facadeSegmentB = new Segment('facadeB');
+    const handlerSubsegmentB = new Subsegment('## index.handlerB');
+    vi.spyOn(facadeSegmentB, 'addNewSubsegment').mockImplementation(
+      () => handlerSubsegmentB
+    );
+    vi.spyOn(tracer.provider, 'getSegment')
+      .mockImplementationOnce(() => facadeSegmentA)
+      .mockImplementationOnce(() => facadeSegmentB);
+    const closeSpyA = vi.spyOn(handlerSubsegmentA, 'close');
+    const closeSpyB = vi.spyOn(handlerSubsegmentB, 'close');
+
     // Gates to interleave the two invocations: each handler blocks until released
     const gates = [
       Promise.withResolvers<void>(),
       Promise.withResolvers<void>(),
     ];
     const handler = middy(
-      async (event: { idx: number; name: string }, _context: Context) => {
+      async (event: { idx: number }, _context: Context) => {
         await gates[event.idx].promise;
-        tracer.putAnnotation('invocation', event.name);
       }
     ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+
+    return {
+      handler,
+      gates,
+      facadeSegmentA,
+      facadeSegmentB,
+      handlerSubsegmentA,
+      handlerSubsegmentB,
+      closeSpyA,
+      closeSpyB,
+      setSegmentSpy,
+    };
+  };
+
+  it('closes the subsegment opened by the same invocation when invocations overlap', async () => {
+    // Prepare
+    const {
+      handler,
+      gates,
+      facadeSegmentA,
+      facadeSegmentB,
+      closeSpyA,
+      closeSpyB,
+      setSegmentSpy,
+    } = setupOverlappingInvocations();
 
     // Act
     // Invocation A enters the handler and blocks, then invocation B enters
-    // while A is still in flight, then A resumes and annotates, then B does
-    // the same.
-    const invocationA = handler({ idx: 0, name: 'A' }, context);
-    const invocationB = handler({ idx: 1, name: 'B' }, context);
+    // while A is still in flight, then A completes, then B completes.
+    const invocationA = handler({ idx: 0 }, context);
+    const invocationB = handler({ idx: 1 }, context);
     gates[0].resolve();
     await invocationA;
     gates[1].resolve();
     await invocationB;
 
     // Assess
-    // Each invocation's annotation must land on the subsegment opened by
-    // that invocation's `before` hook
-    expect(handlerSubsegments).toHaveLength(2);
-    expect(handlerSubsegments[0].annotations).toStrictEqual(
-      expect.objectContaining({ invocation: 'A' })
-    );
-    expect(handlerSubsegments[1].annotations).toStrictEqual(
-      expect.objectContaining({ invocation: 'B' })
-    );
-    // Each invocation must have closed its own subsegment
-    expect(handlerSubsegments[0].isClosed()).toBe(true);
-    expect(handlerSubsegments[1].isClosed()).toBe(true);
+    // Each invocation must close its own subsegment exactly once ...
+    expect(closeSpyA).toHaveBeenCalledTimes(1);
+    expect(closeSpyB).toHaveBeenCalledTimes(1);
+    // ... and restore the facade segment it captured at open time
+    expect(setSegmentSpy).toHaveBeenCalledTimes(4);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(3, facadeSegmentA);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegmentB);
   });
 
-  it('stays isolated when invocations complete in reverse order', async () => {
+  it('closes the right subsegments when invocations complete in reverse order', async () => {
     // Prepare
-    const tracer = new Tracer({ serviceName: 'concurrency-test' });
-    const handlerSubsegments = trackHandlerSubsegments();
-    const gates = [
-      Promise.withResolvers<void>(),
-      Promise.withResolvers<void>(),
-    ];
-    const handler = middy(
-      async (event: { idx: number; name: string }, _context: Context) => {
-        await gates[event.idx].promise;
-        tracer.putAnnotation('invocation', event.name);
-      }
-    ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+    const {
+      handler,
+      gates,
+      facadeSegmentA,
+      facadeSegmentB,
+      closeSpyA,
+      closeSpyB,
+      setSegmentSpy,
+    } = setupOverlappingInvocations();
 
     // Act
     // Invocation A enters first but finishes last; invocation B enters
-    // second, finishes first, and tears down its CLS context while A is
-    // still in flight (out-of-order exit).
-    const invocationA = handler({ idx: 0, name: 'A' }, context);
-    const invocationB = handler({ idx: 1, name: 'B' }, context);
+    // second and finishes first.
+    const invocationA = handler({ idx: 0 }, context);
+    const invocationB = handler({ idx: 1 }, context);
     gates[1].resolve();
     await invocationB;
     gates[0].resolve();
     await invocationA;
 
     // Assess
-    expect(handlerSubsegments).toHaveLength(2);
-    expect(handlerSubsegments[0].annotations).toStrictEqual(
-      expect.objectContaining({ invocation: 'A' })
-    );
-    expect(handlerSubsegments[1].annotations).toStrictEqual(
-      expect.objectContaining({ invocation: 'B' })
-    );
-    expect(handlerSubsegments[0].isClosed()).toBe(true);
-    expect(handlerSubsegments[1].isClosed()).toBe(true);
+    expect(closeSpyA).toHaveBeenCalledTimes(1);
+    expect(closeSpyB).toHaveBeenCalledTimes(1);
+    expect(setSegmentSpy).toHaveBeenCalledTimes(4);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(3, facadeSegmentB);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegmentA);
   });
 });

--- a/packages/tracer/tests/unit/middy.concurrency.test.ts
+++ b/packages/tracer/tests/unit/middy.concurrency.test.ts
@@ -1,0 +1,133 @@
+import context from '@aws-lambda-powertools/testing-utils/context';
+import middy from '@middy/core';
+import type { Context } from 'aws-lambda';
+import { Segment, Subsegment } from 'aws-xray-sdk-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Tracer } from '../../src/index.js';
+import { captureLambdaHandler } from '../../src/middleware/middy.js';
+
+// Must run before aws-xray-sdk-core is imported so the SDK initializes in
+// Lambda mode with its real CLS context, which is what these tests exercise:
+// in Lambda mode the SDK enters a single process-wide CLS context at init,
+// so per-invocation isolation must be provided by the middleware itself.
+vi.hoisted(() => {
+  vi.stubEnv('LAMBDA_TASK_ROOT', '/var/task');
+  vi.stubEnv('AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR');
+  vi.stubEnv(
+    '_X_AMZN_TRACE_ID',
+    'Root=1-abcdef12-3456abcdef123456abcdef12;Parent=1234abcd1234abcd;Sampled=1'
+  );
+});
+
+type SubsegmentWithAnnotations = Subsegment & {
+  annotations?: Record<string, unknown>;
+};
+
+/**
+ * Track every handler subsegment created by the middleware, in creation
+ * order, regardless of which parent it was attached to; `annotations` is
+ * not part of the SDK's public type but is where `addAnnotation()` writes.
+ */
+const trackHandlerSubsegments = (): SubsegmentWithAnnotations[] => {
+  const handlerSubsegments: SubsegmentWithAnnotations[] = [];
+  for (const proto of [Segment.prototype, Subsegment.prototype]) {
+    const original = proto.addNewSubsegment;
+    vi.spyOn(proto, 'addNewSubsegment').mockImplementation(function (
+      this: Segment | Subsegment,
+      name: string
+    ) {
+      const subsegment = original.call(this, name);
+      if (name.startsWith('## ')) {
+        handlerSubsegments.push(subsegment);
+      }
+      return subsegment;
+    });
+  }
+  return handlerSubsegments;
+};
+
+describe('Middy middleware: concurrent invocations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('records annotations on the subsegment of the invocation that produced them when invocations overlap', async () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    const handlerSubsegments = trackHandlerSubsegments();
+    // Gates to interleave the two invocations: each handler blocks until released
+    const gates = [
+      Promise.withResolvers<void>(),
+      Promise.withResolvers<void>(),
+    ];
+    const handler = middy(
+      async (event: { idx: number; name: string }, _context: Context) => {
+        await gates[event.idx].promise;
+        tracer.putAnnotation('invocation', event.name);
+      }
+    ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+
+    // Act
+    // Invocation A enters the handler and blocks, then invocation B enters
+    // while A is still in flight, then A resumes and annotates, then B does
+    // the same.
+    const invocationA = handler({ idx: 0, name: 'A' }, context);
+    const invocationB = handler({ idx: 1, name: 'B' }, context);
+    gates[0].resolve();
+    await invocationA;
+    gates[1].resolve();
+    await invocationB;
+
+    // Assess
+    // Each invocation's annotation must land on the subsegment opened by
+    // that invocation's `before` hook
+    expect(handlerSubsegments).toHaveLength(2);
+    expect(handlerSubsegments[0].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'A' })
+    );
+    expect(handlerSubsegments[1].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'B' })
+    );
+    // Each invocation must have closed its own subsegment
+    expect(handlerSubsegments[0].isClosed()).toBe(true);
+    expect(handlerSubsegments[1].isClosed()).toBe(true);
+  });
+
+  it('stays isolated when invocations complete in reverse order', async () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    const handlerSubsegments = trackHandlerSubsegments();
+    const gates = [
+      Promise.withResolvers<void>(),
+      Promise.withResolvers<void>(),
+    ];
+    const handler = middy(
+      async (event: { idx: number; name: string }, _context: Context) => {
+        await gates[event.idx].promise;
+        tracer.putAnnotation('invocation', event.name);
+      }
+    ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+
+    // Act
+    // Invocation A enters first but finishes last; invocation B enters
+    // second, finishes first, and tears down its CLS context while A is
+    // still in flight (out-of-order exit).
+    const invocationA = handler({ idx: 0, name: 'A' }, context);
+    const invocationB = handler({ idx: 1, name: 'B' }, context);
+    gates[1].resolve();
+    await invocationB;
+    gates[0].resolve();
+    await invocationA;
+
+    // Assess
+    expect(handlerSubsegments).toHaveLength(2);
+    expect(handlerSubsegments[0].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'A' })
+    );
+    expect(handlerSubsegments[1].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'B' })
+    );
+    expect(handlerSubsegments[0].isClosed()).toBe(true);
+    expect(handlerSubsegments[1].isClosed()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

The `captureLambdaHandler` middy middleware stored the per-invocation facade segment and handler subsegment in factory-closure variables created once at handler initialization. When multiple invocations are multiplexed into the same execution environment (Lambda Managed Instances with `perExecutionEnvironmentMaxConcurrency` > 1), those variables are shared by all in-flight invocations: one invocation's `after`/`onError` hook would close another invocation's subsegment and restore the wrong facade segment.

This PR moves the per-invocation state to `request.internal`, so each invocation closes the subsegment it opened and restores the facade segment it captured, regardless of interleaving or completion order.

> [!note]
> This PR was originally scoped to also address #5434 (wrong-segment attribution of annotations/metadata under LMI concurrency) via per-invocation CLS contexts. Real-Lambda testing showed that approach cannot work from within a middy middleware: the context entered in a `before` hook does not propagate to the handler because middy's `runRequest` continuations are created before the hook runs, and `cls-hooked` restores their captured (root) context. See [this comment on #5434](https://github.com/aws-powertools/powertools-lambda-typescript/issues/5434) for the full analysis - that part requires per-invocation context isolation in `aws-xray-sdk-node` and is tracked separately.

### Changes

- `packages/tracer/src/middleware/middy.ts`: store `lambdaSegment` and `handlerSegment` in `request.internal` under `TRACER_KEY`-prefixed keys instead of factory-closure variables; `close()` reads them from the request so cleanup always targets the invocation that opened them
- `packages/tracer/tests/unit/middy.concurrency.test.ts`: new regression tests running two interleaved invocations through the middleware, asserting each invocation closes its own subsegment exactly once and restores its own facade segment - including a reverse-completion-order variant

**Issue number:** closes #5433

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
