### PR TITLE
fix(idempotency): recompute key prefix from base on each configure call

### DIFF
--- a/packages/idempotency/src/persistence/BasePersistenceLayer.ts
+++ b/packages/idempotency/src/persistence/BasePersistenceLayer.ts
@@ -38,12 +38,20 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
   #jmesPathOptions?: JMESPathParsingOptions;
   #maxLocalCacheSize?: number;
   #configMismatchWarned = false;
+  /**
+   * Base value for the idempotency key prefix, snapshotted at construction
+   * time so that {@link configure | `configure()`} - which runs on every
+   * invocation - can recompute the prefix deterministically instead of
+   * appending to an already-mutated value.
+   */
+  readonly #keyPrefixBase: string;
 
   public constructor() {
-    this.idempotencyKeyPrefix = getStringFromEnv({
+    this.#keyPrefixBase = getStringFromEnv({
       key: 'AWS_LAMBDA_FUNCTION_NAME',
       defaultValue: '',
     });
+    this.idempotencyKeyPrefix = this.#keyPrefixBase;
   }
 
   /**
@@ -57,7 +65,7 @@ abstract class BasePersistenceLayer implements BasePersistenceLayerInterface {
     if (keyPrefix?.trim()) {
       this.idempotencyKeyPrefix = keyPrefix.trim();
     } else if (functionName?.trim()) {
-      this.idempotencyKeyPrefix = `${this.idempotencyKeyPrefix}.${functionName.trim()}`;
+      this.idempotencyKeyPrefix = `${this.#keyPrefixBase}.${functionName.trim()}`;
     }
 
     // Prevent reconfiguration

--- a/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
+++ b/packages/idempotency/tests/unit/persistence/BasePersistenceLayer.test.ts
@@ -113,6 +113,37 @@ describe('Class: BasePersistenceLayer', () => {
       );
     });
 
+    it('keeps the idempotency key prefix stable when configured multiple times with the same function name', () => {
+      // Prepare
+      const config = new IdempotencyConfig({});
+      const persistenceLayer = new PersistenceLayerTestClass();
+
+      // Act
+      persistenceLayer.configure({ config, functionName: 'my-function' });
+      persistenceLayer.configure({ config, functionName: 'my-function' });
+      persistenceLayer.configure({ config, functionName: 'my-function' });
+
+      // Assess
+      expect(persistenceLayer.idempotencyKeyPrefix).toBe(
+        'my-lambda-function.my-function'
+      );
+    });
+
+    it('recomputes the idempotency key prefix from the base value when configured with a different function name', () => {
+      // Prepare
+      const config = new IdempotencyConfig({});
+      const persistenceLayer = new PersistenceLayerTestClass();
+
+      // Act
+      persistenceLayer.configure({ config, functionName: 'operation-a' });
+      persistenceLayer.configure({ config, functionName: 'operation-b' });
+
+      // Assess
+      expect(persistenceLayer.idempotencyKeyPrefix).toBe(
+        'my-lambda-function.operation-b'
+      );
+    });
+
     it('appends custom prefix to the idempotence key prefix', () => {
       // Prepare
       const config = new IdempotencyConfig({});


### PR DESCRIPTION
## Summary

The `functionName` branch in `BasePersistenceLayer.configure()` appended to the already-mutated `idempotencyKeyPrefix`, so every call grew the prefix (`fn.op`, `fn.op.op`, `fn.op.op.op`, …). Since `configure()` runs on every invocation, any caller passing `functionName` per invocation would produce a different idempotency key each time - silently defeating idempotency. None of the library's entry points pass `functionName`, but `configure()` is public, typed API reachable by direct callers and custom integrations.

This PR snapshots the base prefix (from `AWS_LAMBDA_FUNCTION_NAME`) at construction time and recomputes the prefix deterministically on every `configure()` call, mirroring the Python implementation.

### Changes

- Add a private `#keyPrefixBase` field to `BasePersistenceLayer`, snapshotted in the constructor, and use it in the `functionName` branch of `configure()` instead of the mutable `idempotencyKeyPrefix`
- Keep the prefix assignment above the reconfiguration guard: re-applying the prefix per operation is intentional and preserves the existing last-write-wins behavior for `keyPrefix`
- Add unit tests covering prefix stability across repeated `configure()` calls with the same `functionName`, and deterministic recomputation when a different `functionName` is passed

**Issue number:** closes #5441

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
