### PR TITLE
refactor(logger): remove unsafe context cast in createChild

### DIFF
--- a/packages/logger/src/LogAttributesStore.ts
+++ b/packages/logger/src/LogAttributesStore.ts
@@ -1,7 +1,7 @@
 import '@aws/lambda-invoke-store';
 import { deepMerge } from '@aws-lambda-powertools/commons';
 import { shouldUseInvokeStore } from '@aws-lambda-powertools/commons/utils/env';
-import type { LogAttributes, PowertoolsLogData } from './types/logKeys.js';
+import type { LambdaFunctionContext, LogAttributes } from './types/logKeys.js';
 
 /**
  * Manages storage of log attributes with automatic context detection.
@@ -21,7 +21,7 @@ class LogAttributesStore {
   #fallbackTemporaryAttributes: LogAttributes = {};
   readonly #fallbackKeys: Map<string, 'temp' | 'persistent'> = new Map();
   #persistentAttributes: LogAttributes = {};
-  #fallbackLambdaContext: PowertoolsLogData['lambdaContext'];
+  #fallbackLambdaContext: LambdaFunctionContext | undefined;
 
   #getTemporaryAttributes(): LogAttributes {
     if (!shouldUseInvokeStore()) {
@@ -112,7 +112,7 @@ class LogAttributesStore {
     globalThis.awslambda.InvokeStore?.set(this.#temporaryAttributesKey, {});
   }
 
-  public setLambdaContext(context: PowertoolsLogData['lambdaContext']): void {
+  public setLambdaContext(context: LambdaFunctionContext): void {
     if (!shouldUseInvokeStore()) {
       this.#fallbackLambdaContext = context;
       return;
@@ -125,7 +125,7 @@ class LogAttributesStore {
     globalThis.awslambda.InvokeStore.set(this.#lambdaContextKey, context);
   }
 
-  public getLambdaContext(): PowertoolsLogData['lambdaContext'] {
+  public getLambdaContext(): LambdaFunctionContext | undefined {
     if (!shouldUseInvokeStore()) {
       return this.#fallbackLambdaContext;
     }

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -42,6 +42,7 @@ import type {
   LogLevel,
 } from './types/Logger.js';
 import type {
+  LambdaFunctionContext,
   LogKeys,
   PowertoolsLogData,
   UnformattedAttributes,
@@ -271,9 +272,13 @@ class Logger extends Utility implements LoggerInterface {
    * Add the current Lambda function's invocation context data to the powertoolLogData property of the instance.
    * This context data will be part of all printed log items.
    *
+   * The implementation signature also accepts the stored {@link LambdaFunctionContext} subset so that
+   * {@link Logger.createChild | `createChild()`} can propagate the parent's context without unsafe casts.
+   * The public contract ({@link LoggerInterface.addContext}) remains `Context`.
+   *
    * @param context - The Lambda function's invocation context.
    */
-  public addContext(context: Context): void {
+  public addContext(context: Context | LambdaFunctionContext): void {
     this.#attributesStore.setLambdaContext({
       invokedFunctionArn: context.invokedFunctionArn,
       coldStart: this.getColdStart(),
@@ -365,8 +370,7 @@ class Logger extends Utility implements LoggerInterface {
       )
     );
     const lambdaContext = this.#attributesStore.getLambdaContext();
-    if (lambdaContext)
-      childLogger.addContext(lambdaContext as unknown as Context);
+    if (lambdaContext) childLogger.addContext(lambdaContext);
     const temporaryAttributes = this.#attributesStore.getTemporaryAttributes();
     if (Object.keys(temporaryAttributes).length > 0) {
       childLogger.appendKeys(temporaryAttributes);

--- a/packages/logger/src/types/logKeys.ts
+++ b/packages/logger/src/types/logKeys.ts
@@ -268,6 +268,7 @@ type LogKeys = { [key: string]: unknown } & {
 
 export type {
   Environment,
+  LambdaFunctionContext,
   LogAttributes,
   LogAttributesWithMessage,
   LogKey,


### PR DESCRIPTION
## Summary

`Logger.createChild()` re-applied the parent's stored Lambda context via `addContext(lambdaContext as unknown as Context)`, a double cast that bypassed all structural checking — it only worked because `addContext()` happens to read just the six fields shared between `Context` and the stored `LambdaFunctionContext` subset. This change removes the cast by widening the `addContext()` implementation signature to `Context | LambdaFunctionContext`, making the contract explicit and compiler-enforced.

Per the discussion on the issue, this follows the widened-signature approach so all context interactions stay centralized in `LogAttributesStore` (introduced in aws-powertools/powertools-lambda-typescript#5430), while keeping the public API surface unchanged: `LoggerInterface.addContext(context: Context)` is untouched, and `LambdaFunctionContext` remains `@internal` — it is exported from `types/logKeys.ts` only for declaration emit and is not re-exported from the public `types` barrel (which is also not directly importable per the package `exports` map).

### Changes

- Widen `Logger.addContext()` implementation signature to `Context | LambdaFunctionContext`; method body unchanged (`coldStart` on the incoming object is still ignored and recomputed)
- Remove the `as unknown as Context` cast in `Logger.createChild()`
- Export `LambdaFunctionContext` from `types/logKeys.ts` (still `@internal`, not added to the public types barrel)
- Replace the `PowertoolsLogData['lambdaContext']` indexed-access type in `LogAttributesStore` with `LambdaFunctionContext` / `LambdaFunctionContext | undefined`

**Issue number:** closes #5431

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

