### PR TITLE
fix(tracer): scope middy middleware segments per invocation

### DIFF
--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -38,8 +38,11 @@ const captureLambdaHandler = (
   target: Tracer,
   options?: CaptureLambdaHandlerOptions
 ): MiddlewareLikeObj => {
-  let lambdaSegment: Segment;
-  let handlerSegment: Subsegment;
+  // The segments are stored in `request.internal` rather than in variables scoped
+  // to this factory so that each invocation operates on its own segments when
+  // multiple invocations run concurrently in the same execution environment.
+  const lambdaSegmentKey = `${TRACER_KEY}.lambdaSegment`;
+  const handlerSegmentKey = `${TRACER_KEY}.handlerSegment`;
 
   /**
    * Set the cleanup function to be called in case other middlewares return early.
@@ -53,21 +56,29 @@ const captureLambdaHandler = (
     };
   };
 
-  const open = (): void => {
+  const open = (request: MiddyLikeRequest): void => {
     const segment = target.getSegment();
     if (segment === undefined) {
       return;
     }
     // If segment is defined, then it is a Segment as this middleware is only used for Lambda Handlers
-    lambdaSegment = segment as Segment;
-    handlerSegment = lambdaSegment.addNewSubsegment(
+    const lambdaSegment = segment as Segment;
+    const handlerSegment = lambdaSegment.addNewSubsegment(
       `## ${process.env._HANDLER}`
     );
+    request.internal[lambdaSegmentKey] = lambdaSegment;
+    request.internal[handlerSegmentKey] = handlerSegment;
     target.setSegment(handlerSegment);
   };
 
-  const close = (): void => {
-    if (handlerSegment === undefined || lambdaSegment === null) {
+  const close = (request: MiddyLikeRequest): void => {
+    const lambdaSegment = request.internal[lambdaSegmentKey] as
+      | Segment
+      | undefined;
+    const handlerSegment = request.internal[handlerSegmentKey] as
+      | Subsegment
+      | undefined;
+    if (handlerSegment === undefined || lambdaSegment === undefined) {
       return;
     }
     try {
@@ -84,7 +95,7 @@ const captureLambdaHandler = (
 
   const before = (request: MiddyLikeRequest) => {
     if (target.isTracingEnabled()) {
-      open();
+      open(request);
       setCleanupFunction(request);
       target.annotateColdStart();
       target.addServiceNameAnnotation();
@@ -96,14 +107,14 @@ const captureLambdaHandler = (
       if (options?.captureResponse ?? true) {
         target.addResponseAsMetadata(request.response, process.env._HANDLER);
       }
-      close();
+      close(request);
     }
   };
 
   const onError = (request: MiddyLikeRequest) => {
     if (target.isTracingEnabled()) {
       target.addErrorAsMetadata(request.error as Error);
-      close();
+      close(request);
     }
   };
 

--- a/packages/tracer/src/middleware/middy.ts
+++ b/packages/tracer/src/middleware/middy.ts
@@ -66,8 +66,11 @@ const captureLambdaHandler = (
     const handlerSegment = lambdaSegment.addNewSubsegment(
       `## ${process.env._HANDLER}`
     );
-    request.internal[lambdaSegmentKey] = lambdaSegment;
-    request.internal[handlerSegmentKey] = handlerSegment;
+    request.internal = {
+      ...request.internal,
+      [lambdaSegmentKey]: lambdaSegment,
+      [handlerSegmentKey]: handlerSegment,
+    };
     target.setSegment(handlerSegment);
   };
 

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -369,4 +369,51 @@ describe('Middy middleware', () => {
     // Check that the segments are restored
     expect(setSegmentSpy).toHaveBeenNthCalledWith(2, facadeSegment);
   });
+
+  it('closes each subsegment and restores each facade segment when invocations overlap', async () => {
+    // Prepare
+    const tracer = new Tracer();
+    vi.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
+    vi.spyOn(tracer, 'addServiceNameAnnotation').mockImplementation(() => ({}));
+    const setSegmentSpy = vi
+      .spyOn(tracer.provider, 'setSegment')
+      .mockImplementation(() => ({}));
+    const facadeSegmentA = new Segment('facade');
+    const handlerSubsegmentA = new Subsegment('## index.handler');
+    vi.spyOn(facadeSegmentA, 'addNewSubsegment').mockImplementation(
+      () => handlerSubsegmentA
+    );
+    const facadeSegmentB = new Segment('facade');
+    const handlerSubsegmentB = new Subsegment('## index.handler');
+    vi.spyOn(facadeSegmentB, 'addNewSubsegment').mockImplementation(
+      () => handlerSubsegmentB
+    );
+    vi.spyOn(tracer.provider, 'getSegment')
+      .mockImplementationOnce(() => facadeSegmentA)
+      .mockImplementationOnce(() => facadeSegmentB);
+    // Each invocation blocks in the handler until released, so the two
+    // invocations can be interleaved like under Lambda Managed Instances
+    // concurrency
+    const gates = [
+      Promise.withResolvers<void>(),
+      Promise.withResolvers<void>(),
+    ];
+    const handler = middy(async (event: { idx: number }, _context: Context) => {
+      await gates[event.idx].promise;
+    }).use(captureLambdaHandler(tracer, { captureResponse: false }));
+
+    // Act
+    const invocationA = handler({ idx: 0 }, context);
+    const invocationB = handler({ idx: 1 }, context);
+    gates[0].resolve();
+    await invocationA;
+    gates[1].resolve();
+    await invocationB;
+
+    // Assess
+    expect(handlerSubsegmentA.isClosed()).toBe(true);
+    expect(handlerSubsegmentB.isClosed()).toBe(true);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(3, facadeSegmentA);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegmentB);
+  });
 });

--- a/packages/tracer/tests/unit/middy.test.ts
+++ b/packages/tracer/tests/unit/middy.test.ts
@@ -370,7 +370,12 @@ describe('Middy middleware', () => {
     expect(setSegmentSpy).toHaveBeenNthCalledWith(2, facadeSegment);
   });
 
-  it('closes each subsegment and restores each facade segment when invocations overlap', async () => {
+  it.each([
+    { completionOrder: 'in the order they started', completeFirst: 0 },
+    { completionOrder: 'in reverse order', completeFirst: 1 },
+  ])('closes each subsegment exactly once and restores each facade segment when overlapping invocations complete $completionOrder', async ({
+    completeFirst,
+  }) => {
     // Prepare
     const tracer = new Tracer();
     vi.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
@@ -378,19 +383,22 @@ describe('Middy middleware', () => {
     const setSegmentSpy = vi
       .spyOn(tracer.provider, 'setSegment')
       .mockImplementation(() => ({}));
-    const facadeSegmentA = new Segment('facade');
-    const handlerSubsegmentA = new Subsegment('## index.handler');
-    vi.spyOn(facadeSegmentA, 'addNewSubsegment').mockImplementation(
-      () => handlerSubsegmentA
+    const facadeSegments = [new Segment('facade'), new Segment('facade')];
+    const handlerSubsegments = [
+      new Subsegment('## index.handler'),
+      new Subsegment('## index.handler'),
+    ];
+    const closeSpies = handlerSubsegments.map((subsegment) =>
+      vi.spyOn(subsegment, 'close')
     );
-    const facadeSegmentB = new Segment('facade');
-    const handlerSubsegmentB = new Subsegment('## index.handler');
-    vi.spyOn(facadeSegmentB, 'addNewSubsegment').mockImplementation(
-      () => handlerSubsegmentB
-    );
+    for (const [idx, facadeSegment] of facadeSegments.entries()) {
+      vi.spyOn(facadeSegment, 'addNewSubsegment').mockImplementation(
+        () => handlerSubsegments[idx]
+      );
+    }
     vi.spyOn(tracer.provider, 'getSegment')
-      .mockImplementationOnce(() => facadeSegmentA)
-      .mockImplementationOnce(() => facadeSegmentB);
+      .mockImplementationOnce(() => facadeSegments[0])
+      .mockImplementationOnce(() => facadeSegments[1]);
     // Each invocation blocks in the handler until released, so the two
     // invocations can be interleaved like under Lambda Managed Instances
     // concurrency
@@ -403,17 +411,28 @@ describe('Middy middleware', () => {
     }).use(captureLambdaHandler(tracer, { captureResponse: false }));
 
     // Act
-    const invocationA = handler({ idx: 0 }, context);
-    const invocationB = handler({ idx: 1 }, context);
-    gates[0].resolve();
-    await invocationA;
-    gates[1].resolve();
-    await invocationB;
+    const invocations = [
+      handler({ idx: 0 }, context),
+      handler({ idx: 1 }, context),
+    ];
+    const completeSecond = 1 - completeFirst;
+    gates[completeFirst].resolve();
+    await invocations[completeFirst];
+    gates[completeSecond].resolve();
+    await invocations[completeSecond];
 
     // Assess
-    expect(handlerSubsegmentA.isClosed()).toBe(true);
-    expect(handlerSubsegmentB.isClosed()).toBe(true);
-    expect(setSegmentSpy).toHaveBeenNthCalledWith(3, facadeSegmentA);
-    expect(setSegmentSpy).toHaveBeenNthCalledWith(4, facadeSegmentB);
+    expect(closeSpies[0]).toHaveBeenCalledTimes(1);
+    expect(closeSpies[1]).toHaveBeenCalledTimes(1);
+    expect(handlerSubsegments[0].isClosed()).toBe(true);
+    expect(handlerSubsegments[1].isClosed()).toBe(true);
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(
+      3,
+      facadeSegments[completeFirst]
+    );
+    expect(setSegmentSpy).toHaveBeenNthCalledWith(
+      4,
+      facadeSegments[completeSecond]
+    );
   });
 });


### PR DESCRIPTION
## Summary

### Changes

The `captureLambdaHandler` middy middleware stored the facade segment and handler subsegment in variables scoped to the middleware factory, which runs once per handler. Under Lambda Managed Instances concurrency, overlapping invocations share these variables: a later invocation's `before` hook overwrites them, so an earlier invocation closes the wrong subsegment, leaves its own subsegment open, and restores another invocation's facade segment.

Following the direction agreed in the issue, both segments are now stored in `request.internal`, so each middy request carries its own segments through `after`, `onError`, and the early-return cleanup path (`cleanupMiddlewares` already passes `request` to the stored cleanup function).

Added a unit test that interleaves two invocations through the same handler and asserts each closes its own subsegment and restores its own facade segment. It fails on `main` and passes with this change.

**Issue number:** closes #5433

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.