### PR TITLE
fix(tracer): isolate active segment per invocation under LMI concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9126,6 +9126,7 @@
       "license": "MIT-0",
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.33.1",
+        "@aws/lambda-invoke-store": "0.3.0",
         "aws-xray-sdk-core": "^3.12.0"
       },
       "devDependencies": {

--- a/packages/tracer/package.json
+++ b/packages/tracer/package.json
@@ -89,6 +89,7 @@
   },
   "dependencies": {
     "@aws-lambda-powertools/commons": "2.33.1",
+    "@aws/lambda-invoke-store": "0.3.0",
     "aws-xray-sdk-core": "^3.12.0"
   },
   "keywords": [

--- a/packages/tracer/src/provider/ProviderService.ts
+++ b/packages/tracer/src/provider/ProviderService.ts
@@ -26,8 +26,13 @@ const {
 import { subscribe } from 'node:diagnostics_channel';
 import http from 'node:http';
 import https from 'node:https';
+import type { InvokeStoreBase } from '@aws/lambda-invoke-store';
+import '@aws/lambda-invoke-store';
 import { addUserAgentMiddleware } from '@aws-lambda-powertools/commons';
-import { getXRayTraceIdFromEnv } from '@aws-lambda-powertools/commons/utils/env';
+import {
+  getXRayTraceIdFromEnv,
+  shouldUseInvokeStore,
+} from '@aws-lambda-powertools/commons/utils/env';
 import type { DiagnosticsChannel } from 'undici-types';
 import {
   findHeaderAndDecode,
@@ -47,6 +52,28 @@ import {
  * they should work as expected. However, support for these methods is not guaranteed.
  */
 class ProviderService implements ProviderServiceInterface {
+  /**
+   * Key used to store the active segment in the Lambda Invoke Store when
+   * multiple invocations may be multiplexed into the same execution
+   * environment (Lambda Managed Instances with
+   * `perExecutionEnvironmentMaxConcurrency` > 1).
+   *
+   * In Lambda mode the X-Ray SDK keeps the active segment in a single
+   * process-wide CLS context shared by all concurrent invocations, so
+   * writing to it from one invocation clobbers the others. The Invoke Store
+   * is scoped to the invocation by the runtime, so it provides the isolation
+   * the SDK context can't.
+   */
+  readonly #segmentKey = Symbol('powertools.tracer.segment');
+
+  #getInvokeStore(): InvokeStoreBase {
+    const store = globalThis.awslambda?.InvokeStore;
+    if (store === undefined) {
+      throw new Error('InvokeStore is not available');
+    }
+    return store;
+  }
+
   /**
    * @deprecated Use {@link captureAWSv3Client} instead.
    */
@@ -94,6 +121,18 @@ class ProviderService implements ProviderServiceInterface {
   }
 
   public getSegment(): Segment | Subsegment | undefined {
+    if (shouldUseInvokeStore()) {
+      // The facade segment isn't stored per-invocation: it's created by the
+      // X-Ray SDK at init and lives in its process-wide context, so when the
+      // current invocation hasn't set an active segment yet we fall through
+      // to the SDK
+      const segment = this.#getInvokeStore().get<Segment | Subsegment>(
+        this.#segmentKey
+      );
+      if (segment !== undefined) {
+        return segment;
+      }
+    }
     return getSegment();
   }
 
@@ -271,6 +310,13 @@ class ProviderService implements ProviderServiceInterface {
   }
 
   public setSegment(segment: Segment | Subsegment): void {
+    if (shouldUseInvokeStore()) {
+      // Writing to the SDK context here would clobber the shared slot for
+      // every other in-flight invocation, so the active segment goes in the
+      // invocation-scoped store instead
+      this.#getInvokeStore().set(this.#segmentKey, segment);
+      return;
+    }
     setSegment(segment);
   }
 }

--- a/packages/tracer/tests/unit/middy.concurrency.test.ts
+++ b/packages/tracer/tests/unit/middy.concurrency.test.ts
@@ -1,0 +1,222 @@
+import { InvokeStore } from '@aws/lambda-invoke-store';
+import context from '@aws-lambda-powertools/testing-utils/context';
+import middy from '@middy/core';
+import type { Context } from 'aws-lambda';
+import { Segment, Subsegment } from 'aws-xray-sdk-core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Tracer } from '../../src/index.js';
+import { captureLambdaHandler } from '../../src/middleware/middy.js';
+
+// Must run before aws-xray-sdk-core is imported so the SDK initializes in
+// Lambda mode with its real CLS context, which is what these tests exercise:
+// in Lambda mode the SDK enters a single process-wide CLS context at init,
+// shared by all concurrent invocations. `AWS_LAMBDA_MAX_CONCURRENCY` must be
+// set before the InvokeStore instance is created so it uses per-invocation
+// AsyncLocalStorage contexts, mirroring the Lambda Managed Instances runtime.
+vi.hoisted(() => {
+  vi.stubEnv('LAMBDA_TASK_ROOT', '/var/task');
+  vi.stubEnv('AWS_XRAY_CONTEXT_MISSING', 'IGNORE_ERROR');
+  vi.stubEnv(
+    '_X_AMZN_TRACE_ID',
+    'Root=1-abcdef12-3456abcdef123456abcdef12;Parent=1234abcd1234abcd;Sampled=1'
+  );
+  vi.stubEnv('AWS_LAMBDA_MAX_CONCURRENCY', '10');
+});
+
+type SubsegmentWithAnnotations = Subsegment & {
+  annotations?: Record<string, unknown>;
+};
+
+/**
+ * Track every handler subsegment created by the middleware, in creation
+ * order, regardless of which parent it was attached to; `annotations` is
+ * not part of the SDK's public type but is where `addAnnotation()` writes.
+ */
+const trackHandlerSubsegments = (): SubsegmentWithAnnotations[] => {
+  const handlerSubsegments: SubsegmentWithAnnotations[] = [];
+  for (const proto of [Segment.prototype, Subsegment.prototype]) {
+    const original = proto.addNewSubsegment;
+    vi.spyOn(proto, 'addNewSubsegment').mockImplementation(function (
+      this: Segment | Subsegment,
+      name: string
+    ) {
+      const subsegment = original.call(this, name);
+      if (name.startsWith('## ')) {
+        handlerSubsegments.push(subsegment);
+      }
+      return subsegment;
+    });
+  }
+  return handlerSubsegments;
+};
+
+describe('Middy middleware: concurrent invocations', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('throws when AWS_LAMBDA_MAX_CONCURRENCY is set but the InvokeStore is not available', () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    vi.stubGlobal('awslambda', undefined);
+
+    // Act & Assess
+    expect(() => tracer.getSegment()).toThrow('InvokeStore is not available');
+  });
+
+  it('records annotations on the subsegment of the invocation that produced them when invocations overlap', async () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    const handlerSubsegments = trackHandlerSubsegments();
+    // Gates to interleave the two invocations: each handler blocks until released
+    const gates = [
+      Promise.withResolvers<void>(),
+      Promise.withResolvers<void>(),
+    ];
+    const handler = middy(
+      async (event: { idx: number; name: string }, _context: Context) => {
+        await gates[event.idx].promise;
+        tracer.putAnnotation('invocation', event.name);
+      }
+    ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+    const invokeStore = await InvokeStore.getInstanceAsync();
+
+    // Act
+    // Each invocation runs in its own InvokeStore context, as it does under
+    // the Lambda Managed Instances runtime. Invocation A enters the handler
+    // and blocks, then invocation B enters while A is still in flight, then
+    // A resumes and annotates, then B does the same.
+    const invocationA = invokeStore.run({}, () =>
+      handler({ idx: 0, name: 'A' }, context)
+    );
+    const invocationB = invokeStore.run({}, () =>
+      handler({ idx: 1, name: 'B' }, context)
+    );
+    gates[0].resolve();
+    await invocationA;
+    gates[1].resolve();
+    await invocationB;
+
+    // Assess
+    // Each invocation's annotation must land on the subsegment opened by
+    // that invocation's `before` hook
+    expect(handlerSubsegments).toHaveLength(2);
+    expect(handlerSubsegments[0].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'A' })
+    );
+    expect(handlerSubsegments[1].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'B' })
+    );
+    // Each invocation must have closed its own subsegment
+    expect(handlerSubsegments[0].isClosed()).toBe(true);
+    expect(handlerSubsegments[1].isClosed()).toBe(true);
+  });
+
+  it('stays isolated when invocations complete in reverse order', async () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    const handlerSubsegments = trackHandlerSubsegments();
+    const gates = [
+      Promise.withResolvers<void>(),
+      Promise.withResolvers<void>(),
+    ];
+    const handler = middy(
+      async (event: { idx: number; name: string }, _context: Context) => {
+        await gates[event.idx].promise;
+        tracer.putAnnotation('invocation', event.name);
+      }
+    ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+    const invokeStore = await InvokeStore.getInstanceAsync();
+
+    // Act
+    // Invocation A enters first but finishes last; invocation B enters
+    // second, finishes first, and tears down while A is still in flight
+    const invocationA = invokeStore.run({}, () =>
+      handler({ idx: 0, name: 'A' }, context)
+    );
+    const invocationB = invokeStore.run({}, () =>
+      handler({ idx: 1, name: 'B' }, context)
+    );
+    gates[1].resolve();
+    await invocationB;
+    gates[0].resolve();
+    await invocationA;
+
+    // Assess
+    expect(handlerSubsegments).toHaveLength(2);
+    expect(handlerSubsegments[0].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'A' })
+    );
+    expect(handlerSubsegments[1].annotations).toStrictEqual(
+      expect.objectContaining({ invocation: 'B' })
+    );
+    expect(handlerSubsegments[0].isClosed()).toBe(true);
+    expect(handlerSubsegments[1].isClosed()).toBe(true);
+  });
+
+  it('annotates the handler subsegment when an async before-middleware precedes captureLambdaHandler', async () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    const handlerSubsegments = trackHandlerSubsegments();
+    const asyncMiddleware = (): middy.MiddlewareObj => ({
+      before: async () => {
+        // Force a real async suspension before the tracer's `before` runs,
+        // so isolation can't rely on the tracer's hook being the first async
+        // boundary in the invocation
+        await new Promise((resolve) => setImmediate(resolve));
+      },
+    });
+    const handler = middy(async (_event: unknown, _context: Context) => {
+      tracer.putAnnotation('fromHandler', true);
+    })
+      .use(asyncMiddleware())
+      .use(captureLambdaHandler(tracer, { captureResponse: false }));
+    const invokeStore = await InvokeStore.getInstanceAsync();
+
+    // Act
+    await invokeStore.run({}, () => handler({}, context));
+
+    // Assess
+    expect(handlerSubsegments).toHaveLength(1);
+    expect(handlerSubsegments[0].annotations).toStrictEqual(
+      expect.objectContaining({ fromHandler: true })
+    );
+    expect(handlerSubsegments[0].isClosed()).toBe(true);
+  });
+
+  it('attributes errors to the invocation that threw when invocations overlap', async () => {
+    // Prepare
+    const tracer = new Tracer({ serviceName: 'concurrency-test' });
+    const handlerSubsegments = trackHandlerSubsegments();
+    const gates = [
+      Promise.withResolvers<void>(),
+      Promise.withResolvers<void>(),
+    ];
+    const handler = middy(
+      async (event: { idx: number; shouldThrow?: boolean }) => {
+        await gates[event.idx].promise;
+        if (event.shouldThrow) {
+          throw new Error('invocation error');
+        }
+      }
+    ).use(captureLambdaHandler(tracer, { captureResponse: false }));
+    const invokeStore = await InvokeStore.getInstanceAsync();
+
+    // Act
+    const invocationA = invokeStore.run({}, () =>
+      handler({ idx: 0, shouldThrow: true }, context)
+    );
+    const invocationB = invokeStore.run({}, () => handler({ idx: 1 }, context));
+    gates[0].resolve();
+    await expect(invocationA).rejects.toThrow('invocation error');
+    gates[1].resolve();
+    await invocationB;
+
+    // Assess
+    // Only the invocation that threw carries the error
+    expect(handlerSubsegments).toHaveLength(2);
+    expect('cause' in handlerSubsegments[0]).toBe(true);
+    expect('cause' in handlerSubsegments[1]).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

In Lambda mode the X-Ray SDK keeps the active segment in a single process-wide CLS context shared by all concurrent invocations. When multiple invocations are multiplexed into the same execution environment (Lambda Managed Instances with `perExecutionEnvironmentMaxConcurrency` > 1), one invocation's `setSegment()` clobbers the slot for every other in-flight invocation, so `putAnnotation`, `putMetadata`, response capture, and error capture resolve to whichever subsegment was set last — annotations land on the wrong trace and response payloads attach to another invocation's (potentially another tenant's) subsegment.

This PR isolates the active segment per invocation by routing `ProviderService.getSegment()`/`setSegment()` through the Lambda Invoke Store when `AWS_LAMBDA_MAX_CONCURRENCY` is set — the same pattern already used by Logger (#5429), Metrics, and Batch. Unlike the per-invocation CLS context approach explored and invalidated in #5440 (a context entered in a middy `before` hook never reaches the handler because middy's continuations are created before the hook runs), the middleware never establishes an async context here — the LMI runtime does, wrapping the entire invocation in its own `AsyncLocalStorage` context before any user code runs, so isolation doesn't depend on hook timing or middleware registration order. Builds on the per-request segment state introduced in #5444.

Design note: no dedicated `*Store` class as in Logger/Metrics/Batch — `ProviderService` already is the tracer's segment-state seam and the non-LMI fallback is the SDK's CLS context rather than instance state, so a `SegmentStore` would be a pure pass-through layer.

Scope boundary: anything resolving its parent through the SDK's own context (`captureAWSv3Client`-patched clients, direct `AWSXRay.getSegment()` calls) still reads the shared slot and remains subject to aws/aws-xray-sdk-node#760.

### Changes

- `packages/tracer/src/provider/ProviderService.ts`: `getSegment()`/`setSegment()` gain a dual path gated on `shouldUseInvokeStore()` — under `AWS_LAMBDA_MAX_CONCURRENCY` the active segment is read/written in the Invoke Store under a private `Symbol` (throwing `InvokeStore is not available` if the store is missing, matching Logger); otherwise behavior is unchanged. `getSegment()` falls through to the SDK context when the invocation hasn't set a segment yet so the facade segment stays reachable
- `packages/tracer/tests/unit/middy.concurrency.test.ts`: regression tests running interleaved invocations through the real middleware, real `Tracer`, and the SDK's real Lambda-mode CLS context, each wrapped in `invokeStore.run()` as on LMI — covering in-order and reverse-order completion, error attribution, an async `before` middleware registered ahead of the tracer, and the store-unavailable error path
- `packages/tracer/package.json` / `package-lock.json`: add `@aws/lambda-invoke-store` 0.3.0 (same pin as logger/metrics/batch)

**Issue number:** closes #5434

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
