### PR TITLE
docs(maintainers): remove stale layer version note-taking instruction

### DIFF
--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -233,8 +233,7 @@ a changelog. Visually inspect the diff and make sure the changelog and version a
 3/ build and deploy the Lambda layers to the `Beta` and `Prod` environments in all commercial Regions, 4/ run canary
 tests, 5/ update the documentation with the new version.
 4. **Review and approve docs PR**: Once the `Make Release` workflow is complete, a PR will be created to update the
-documentation with the new version. Review and approve this PR **but do not merge it yet**. Take note of the Lambda
-layer version that was deployed, as this will be used in the next steps.
+documentation with the new version. Review and approve this PR **but do not merge it yet**.
 5. **Publish GovCloud Layers**: Run the `Layer Deployment (Partitions)` workflow with the `main` branch, targeting the `GovCloud` partition. This will publish the Lambda layers to the AWS GovCloud (US-East) and AWS GovCloud (US-West) Regions.
 6. **Publish China Layer**: Run the `Layer Deployment (Partitions)` workflow with the `main` branch, targeting the `China` partition. This will publish the Lambda layer to the AWS China (Beijing) Region.
 7. **Merge docs PR**: Once the `Layer Deployment (Partition)` workflow for the production China partition is complete,


### PR DESCRIPTION
## Summary

The "Review and approve docs PR" step of the release checklist instructed maintainers to manually note the Lambda layer version that was deployed, for use in later steps. This is no longer necessary — the `Layer Deployment (Partitions)` workflow already resolves the latest layer version itself via `aws lambda list-layer-versions` before copying it to GovCloud/China.

### Changes

- Remove the sentence "Take note of the Lambda layer version that was deployed, as this will be used in the next steps." from step 4 of the release checklist in `docs/maintainers.md`

**Issue number:** closes #5450

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.