### PR TITLE
fix(ci): skip paused regions in update_layer_arn.sh

### DIFF
--- a/.github/scripts/update_layer_arn.sh
+++ b/.github/scripts/update_layer_arn.sh
@@ -15,6 +15,19 @@ if [ -z "$new_version" ]; then
     exit 1
 fi
 
+# Regions that are temporarily excluded from the deploy matrix and must NOT have
+# their layer ARN version bumped in the docs/examples. Keep this list in sync
+# with the commented-out regions in .github/workflows/reusable_deploy_layer_stack.yml.
+paused_regions=(
+    "me-south-1"
+    "me-central-1"
+)
+
+# Build a sed address pattern that matches any line referencing a paused region,
+# e.g. "/me-south-1|me-central-1/". The replacement is then only applied to
+# lines that do NOT match this pattern (via the `!` negation address).
+paused_pattern=$(IFS='|'; echo "${paused_regions[*]}")
+
 # Find all files with specified extensions in ./docs and ./examples directories
 # -type f: only find files (not directories)
 # \( ... \): group conditions
@@ -27,8 +40,10 @@ find ./docs ./examples -type f \( -name "*.md" -o -name "*.ts" -o -name "*.yaml"
     # -i: edit files in-place without creating a backup
     # -E: use extended regular expressions
     # IF TESTING IN MAC, replace `-i` with `-i ''`
-    # The regex matches the layer name and replaces only the version number at the end
-    sed -i -E "s/AWSLambdaPowertoolsTypeScriptV2:[0-9]+/AWSLambdaPowertoolsTypeScriptV2:$new_version/g" "$file"
+    # The regex matches the layer name and replaces only the version number at the end.
+    # Lines referencing a paused region are skipped via the `!` negation address
+    # so their (frozen) layer version is preserved.
+    sed -i -E "/${paused_pattern}/!s/AWSLambdaPowertoolsTypeScriptV2:[0-9]+/AWSLambdaPowertoolsTypeScriptV2:$new_version/g" "$file"
     if [ $? -eq 0 ]; then
         echo "Updated $file successfully"
         grep "arn:aws:lambda:" "$file"


### PR DESCRIPTION
## Summary

`update_layer_arn.sh` blindly rewrote every `AWSLambdaPowertoolsTypeScriptV2:<n>` occurrence across `docs/` and `examples/`, bumping the version for the paused `me-south-1` and `me-central-1` regions as well. Maintainers had to add a manual revert commit on every release PR. This change teaches the script to leave paused regions alone.

### Changes

- Introduce a `paused_regions` array in `.github/scripts/update_layer_arn.sh` documented as needing to stay in sync with the commented-out entries in `.github/workflows/reusable_deploy_layer_stack.yml`
- Build a sed alternation pattern from that array and use a `!` negation address so the version replacement is applied only to lines that do NOT reference a paused region
- Preserve the frozen layer versions for `me-south-1` and `me-central-1` in docs/examples on release

**Issue number:** closes #5453

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.