### PR TITLE
docs(readme): add Signer, Data Masking, and Kafka utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Find the complete project's [documentation here](https://docs.aws.amazon.com/pow
 - **[JMESPath Functions](https://docs.aws.amazon.com/powertools/typescript/latest/features/jmespath/)** - Built-in JMESPath functions to easily deserialize common encoded JSON payloads in Lambda functions.
 - **[Parser (Zod)](https://docs.aws.amazon.com/powertools/typescript/latest/features/parser/)** - Utility that provides data validation and parsing using Zod, a TypeScript-first schema declaration and validation library.
 - **[Validation](https://docs.aws.amazon.com/powertools/typescript/latest/features/validation/)** - JSON Schema validation for events and responses, including JMESPath support to unwrap events before validation.
+- **[Kafka](https://docs.aws.amazon.com/powertools/typescript/latest/features/kafka/)** - Utility to easily handle message deserialization and parsing of Kafka events in AWS Lambda functions.
+- **[Data Masking](https://docs.aws.amazon.com/powertools/typescript/latest/features/data-masking/)** - Utility to encrypt, decrypt, or irreversibly erase sensitive information to protect data confidentiality.
+- **[Signer](https://docs.aws.amazon.com/powertools/typescript/latest/features/signer/)** - Utility to sign HTTP requests to AWS services using AWS Signature Version 4 (SigV4), so you can call IAM-authenticated endpoints from your Lambda functions.
 
 ## Install
 
@@ -46,6 +49,9 @@ You can use Powertools for AWS Lambda (TypeScript) by installing it with your fa
 - **JMESPath Functions**: `npm install @aws-lambda-powertools/jmespath`
 - **Parser**: `npm install @aws-lambda-powertools/parser zod@~3`
 - **Validation**: `npm install @aws-lambda-powertools/validation`
+- **Kafka**: `npm install @aws-lambda-powertools/kafka` see [documentation](https://docs.aws.amazon.com/powertools/typescript/latest/features/kafka/#installation) for Avro and Protobuf support
+- **Data Masking**: `npm install @aws-lambda-powertools/data-masking @aws-crypto/client-node`
+- **Signer**: `npm install @aws-lambda-powertools/signer`
 
 ### Examples
 


### PR DESCRIPTION
## Summary

The README's Features and Install sections were missing three utilities that already ship as published packages: Kafka, Data Masking, and Signer. This adds them so new users get a complete overview of the library and how to install each utility.

### Changes

- Added Kafka, Data Masking, and Signer entries to the Features list, with descriptions sourced from their documentation pages
- Added the three utilities to the Install list, including their peer/optional dependencies:
  - Kafka: base install with a note pointing to the docs for Avro/Protobuf support
  - Data Masking: includes the `@aws-crypto/client-node` peer dependency for encryption/decryption
  - Signer: base install

**Issue number:** closes #5463

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.