### PR TITLE
chore(ci): remove SonarCloud integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ timeline
                                     : Contribution size check
                                     : Contribution category check
                                     : GitHub Actions security check
-                                    : Quality checks (SonarCloud)
+                                    : Static analysis (CodeQL)
                                     : End-to-end tests (manual by maintainer)
                                     : +pre-commit & pre-pull request checks
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 ![NodeSupport](https://img.shields.io/static/v1?label=node&message=%2022|%2024&style=flat&logo=nodedotjs)
 ![GitHub Release](https://img.shields.io/github/v/release/aws-powertools/powertools-lambda-typescript?style=flat)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aws-powertools_powertools-lambda-typescript&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aws-powertools_powertools-lambda-typescript)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=aws-powertools_powertools-lambda-typescript&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=aws-powertools_powertools-lambda-typescript)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/aws-powertools/powertools-lambda-typescript/badge)](https://scorecard.dev/viewer/?uri=github.com/aws-powertools/powertools-lambda-typescript)
 
 [![Discord](https://img.shields.io/badge/Discord-Join_Community-7289da.svg)](https://discord.gg/B8zZKbbyET)

--- a/packages/event-handler/src/appsync-events/RouteHandlerRegistry.ts
+++ b/packages/event-handler/src/appsync-events/RouteHandlerRegistry.ts
@@ -155,7 +155,7 @@ class RouteHandlerRegistry {
       /([.*+?^=!:${}()|[\]/\\])/g,
       String.raw`\$1`
     );
-    return `^${escapedPath.replaceAll('\\*', '.*')}$`; // NOSONAR - Need literal backslash to match escaped asterisks
+    return `^${escapedPath.replaceAll('\\*', '.*')}$`;
   }
 }
 

--- a/packages/jmespath/src/Functions.ts
+++ b/packages/jmespath/src/Functions.ts
@@ -198,7 +198,7 @@ class Functions {
       return Math.max(...(arg as number[]));
     }
     // Math.max doesn't work with strings (returns NaN), so we use reduce for lexicographic comparison
-    return arg.reduce((a, b) => (a > b ? a : b)); // NOSONAR - Math.max only works with numbers
+    return arg.reduce((a, b) => (a > b ? a : b));
   }
 
   /**
@@ -280,7 +280,7 @@ class Functions {
       return Math.min(...arg);
     }
     // Math.min doesn't work with strings (returns NaN), so we use reduce for lexicographic comparison
-    return arg.reduce((a, b) => (a < b ? a : b)); // NOSONAR - Math.min only works with numbers
+    return arg.reduce((a, b) => (a < b ? a : b));
   }
 
   /**

--- a/packages/jmespath/tests/unit/compliance/escape.test.ts
+++ b/packages/jmespath/tests/unit/compliance/escape.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { search } from '../../../src/index.js';
 
-// NOSONAR - This file contains JMESPath compliance tests that intentionally use escape sequences
 describe('Escape characters tests', () => {
   it.each([
     {
@@ -13,15 +12,15 @@ describe('Escape characters tests', () => {
       expected: 'space',
     },
     {
-      expression: '"foo\\nbar"', // NOSONAR - Compliance test requires literal escape sequences
+      expression: '"foo\\nbar"',
       expected: 'newline',
     },
     {
-      expression: '"foo\\"bar"', // NOSONAR - Compliance test requires literal escape sequences
+      expression: '"foo\\"bar"',
       expected: 'doublequote',
     },
     {
-      expression: '"c:\\\\\\\\windows\\\\path"', // NOSONAR - Compliance test requires literal escape sequences
+      expression: '"c:\\\\\\\\windows\\\\path"',
       expected: 'windows',
     },
     {
@@ -29,7 +28,7 @@ describe('Escape characters tests', () => {
       expected: 'unix',
     },
     {
-      expression: '"\\"\\"\\""', // NOSONAR - Compliance test requires literal escape sequences
+      expression: '"\\"\\"\\""',
       expected: 'threequotes',
     },
     {
@@ -46,7 +45,7 @@ describe('Escape characters tests', () => {
       'foo bar': 'space',
       'foo\nbar': 'newline',
       'foo"bar': 'doublequote',
-      'c:\\\\windows\\path': 'windows', // NOSONAR - Compliance test requires literal escape sequences
+      'c:\\\\windows\\path': 'windows',
       '/unix/path': 'unix',
       '"""': 'threequotes',
       bar: { baz: 'qux' },

--- a/packages/jmespath/tests/unit/compliance/identifiers.test.ts
+++ b/packages/jmespath/tests/unit/compliance/identifiers.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { search } from '../../../src/index.js';
 
-// NOSONAR - This file contains JMESPath compliance tests that intentionally use escape sequences
 describe('Identifiers tests', () => {
   it.each([
     {

--- a/packages/jmespath/tests/unit/compliance/literal.test.ts
+++ b/packages/jmespath/tests/unit/compliance/literal.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { search } from '../../../src/index.js';
 
-// NOSONAR - This file contains JMESPath compliance tests that intentionally use escape sequences
 describe('Literal expressions tests', () => {
   it.each([
     {

--- a/packages/jmespath/tests/unit/compliance/multiselect.test.ts
+++ b/packages/jmespath/tests/unit/compliance/multiselect.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { search } from '../../../src/index.js';
 
-// NOSONAR - This file contains JMESPath compliance tests that intentionally use escape sequences
 describe('Multiselect expressions tests', () => {
   it.each([
     {

--- a/packages/jmespath/tests/unit/compliance/syntax.test.ts
+++ b/packages/jmespath/tests/unit/compliance/syntax.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { search } from '../../../src/index.js';
 
-// NOSONAR - This file contains JMESPath compliance tests that intentionally use escape sequences
 describe('Syntax tests', () => {
   it.each([
     {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,0 @@
-# Exclude generated proto files from Sonar analysis
-sonar.exclusions=packages/kafka/tests/protos/*.generated.js,packages/kafka/tests/protos/*.generated.d.ts


### PR DESCRIPTION
## Summary

Removes the SonarCloud integration from the repository in favor of GitHub CodeQL, which now runs on every pull request via org-managed code scanning. We verified that all 30 most recent merged PRs carry a successful CodeQL check run independently of SonarCloud, so the OpenSSF Scorecard SAST check remains at full score (see #5467 for the full assessment). SonarCloud's remaining features are redundant for us: its maintainability findings have been noise, and CI already enforces a 100% coverage gate.

### Changes

- Remove SonarCloud Quality Gate and Security Rating badges from `README.md`
- Delete `sonar-project.properties`
- Replace "Quality checks (SonarCloud)" with "Static analysis (CodeQL)" in the CI journey diagram in `CONTRIBUTING.md`
- Remove `// NOSONAR` suppression comments from `packages/jmespath` and `packages/event-handler` (no behavior change; affected unit tests and lint pass)

**Issue number:** closes #5467

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
