### PR TITLE
chore: clean up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,7 @@
 name: Bug report
 description: Report a reproducible bug to help us improve
-title: "Bug: TITLE"
+title: "Bug: <TITLE>"
 labels: ["bug", "triage"]
-projects: ["aws-powertools/7"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation_improvements.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvements.yml
@@ -1,8 +1,7 @@
 name: Documentation improvements
 description: Suggest a documentation update to improve everyone's experience
-title: "Docs: TITLE"
+title: "Docs: <TITLE>"
 labels: ["documentation", "triage"]
-projects: ["aws-powertools/7"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,7 @@
 name: Feature request
 description: Suggest an idea for Powertools for AWS Lambda
-title: "Feature request: TITLE"
+title: "Feature request: <TITLE>"
 labels: ["feature-request", "triage"]
-projects: ["aws-powertools/7"]
 body:
   - type: markdown
     attributes:
@@ -27,7 +26,6 @@ body:
     attributes:
       label: Alternative solutions
       description: Please describe what alternative solutions to this use case, if any
-      render: Markdown
     validations:
       required: false
   - type: checkboxes
@@ -49,5 +47,5 @@ body:
     id: notes
     attributes:
       label: Future readers
-      description: Please not edit this field
+      description: Please do not edit this field
       value: "Please react with 👍 and your use case to help us understand customer demand."

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,8 +1,7 @@
 name: Maintenance
 description: Suggest an activity to help address tech debt, governance, and anything internal
-title: "Maintenance: TITLE"
+title: "Maintenance: <TITLE>"
 labels: ["internal", "triage"]
-projects: ["aws-powertools/7"]
 body:
   - type: markdown
     attributes:
@@ -43,6 +42,8 @@ body:
         - Batch Processing
         - Validation
         - Other
+    validations:
+      required: true
   - type: textarea
     id: suggestion
     attributes:
@@ -69,5 +70,5 @@ body:
     id: notes
     attributes:
       label: Future readers
-      description: Please not edit this field
+      description: Please do not edit this field
       value: "Please react with 👍 and your use case to help us understand customer demand."

--- a/.github/ISSUE_TEMPLATE/share_your_work.yml
+++ b/.github/ISSUE_TEMPLATE/share_your_work.yml
@@ -2,7 +2,6 @@ name: I Made This (showcase your work)
 description: Share what you did with Powertools for AWS Lambda (TypeScript) 💞💞. Blog post, workshops, presentation, sample apps, etc.
 title: "[I Made This]: <TITLE>"
 labels: ["community-content"]
-projects: ["aws-powertools/7"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/support_powertools.yml
+++ b/.github/ISSUE_TEMPLATE/support_powertools.yml
@@ -1,8 +1,7 @@
 name: Support Powertools for AWS Lambda (TypeScript) (become a reference)
 description: Add your organization's name or logo to the Powertools for AWS Lambda (TypeScript) documentation
-title: "[Support Powertools for AWS Lambda (TypeScript)]: <your organization name>"
+title: "[Support Powertools for AWS Lambda (TypeScript)]: <YOUR ORGANIZATION NAME>"
 labels: ["customer-reference"]
-projects: ["aws-powertools/7"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Stop automatically adding new issues to the GitHub Project and make the issue forms more consistent.

### Changes

- Remove GitHub Project assignment from all issue forms
- Standardize title placeholders
- Correct guidance for fields that should not be edited
- Preserve Markdown formatting in the feature request alternatives field
- Require an area for maintenance issues

**Issue number:** closes #5469

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.