### PR TITLE
feat(ci): auto-trigger make-release and docs rebuild on PR merge

### DIFF
--- a/.github/workflows/on_layer_docs_pr_merge.yml
+++ b/.github/workflows/on_layer_docs_pr_merge.yml
@@ -1,17 +1,11 @@
-name: Auto-trigger release pipeline on PR merge
+name: Auto-trigger docs rebuild on layer ARN docs PR merge
 
 # PROCESS
 #
-# Two manual triggers remain in an otherwise-automated release pipeline:
-# 1. After `make-version.yml`'s version-bump PR (branch `ci-bump-<run_id>`) is merged,
-#    a maintainer has to manually trigger `make-release.yml`.
-# 2. After `publish_layer.yml`'s ARN-doc PR (branch `ci-layer-docs-<run_id>`) is merged,
-#    a maintainer has to manually trigger `rebuild_latest_docs.yml` with the released version.
-#
-# This workflow watches for those two PRs merging to `main` and dispatches the next
-# workflow automatically, so the only human actions left are the ones that require
-# actual review: approving the version PR, approving npm publish, and approving the
-# final ARN-doc PR.
+# This workflow watches for `publish_layer.yml`'s `update_layer_arn_docs` job PR (branch
+# `ci-layer-docs-<run_id>`) merging to `main` so it can dispatch `rebuild_latest_docs.yml`
+# automatically, leaving only the human action that requires actual review: approving the
+# ARN-doc PR.
 #
 # SECURITY NOTE
 #
@@ -21,11 +15,11 @@ name: Auto-trigger release pipeline on PR merge
 #
 # `github.event.pull_request.user.login` is set by GitHub from the identity that actually
 # called the API to open the PR - it isn't spoofable via branch name, PR title, or body.
-# Both `ci-bump-*` and `ci-layer-docs-*` PRs are opened by aws-powertools/actions'
-# `create-pr` action using the default `GITHUB_TOKEN`, so `.user.login` is always
-# `github-actions[bot]` (confirmed against real PR history - this is NOT the same as
-# `aws-powertools-bot`, which is only the git commit-author identity `create-pr` sets
-# locally via `git config`, not what GitHub exposes as the PR's author).
+# `ci-layer-docs-*` PRs are opened by aws-powertools/actions' `create-pr` action using the
+# default `GITHUB_TOKEN`, so `.user.login` is always `github-actions[bot]` (confirmed
+# against real PR history - this is NOT the same as `aws-powertools-bot`, which is only
+# the git commit-author identity `create-pr` sets locally via `git config`, not what
+# GitHub exposes as the PR's author).
 #
 # Combined with `head.repo.full_name == github.repository` (rejects forks explicitly)
 # and `base.ref == 'main'`, only genuine automation-opened, same-repo, main-targeted
@@ -38,22 +32,6 @@ on:
 permissions: {}
 
 jobs:
-  trigger-make-release:
-    if: >
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
-      startsWith(github.event.pull_request.head.ref, 'ci-bump-')
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Dispatch Make Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run make-release.yml --repo ${{ github.repository }} --ref main
-
   trigger-rebuild-docs:
     if: >
       github.event.pull_request.merged == true &&

--- a/.github/workflows/on_release_pr_merge.yml
+++ b/.github/workflows/on_release_pr_merge.yml
@@ -1,0 +1,80 @@
+name: Auto-trigger release pipeline on PR merge
+
+# PROCESS
+#
+# Two manual triggers remain in an otherwise-automated release pipeline:
+# 1. After `make-version.yml`'s version-bump PR (branch `ci-bump-<run_id>`) is merged,
+#    a maintainer has to manually trigger `make-release.yml`.
+# 2. After `publish_layer.yml`'s ARN-doc PR (branch `ci-layer-docs-<run_id>`) is merged,
+#    a maintainer has to manually trigger `rebuild_latest_docs.yml` with the released version.
+#
+# This workflow watches for those two PRs merging to `main` and dispatches the next
+# workflow automatically, so the only human actions left are the ones that require
+# actual review: approving the version PR, approving npm publish, and approving the
+# final ARN-doc PR.
+#
+# SECURITY NOTE
+#
+# Deliberately uses `pull_request` (not `pull_request_target`), so PRs from forks keep
+# GitHub's default read-only token and no secrets - a forked PR could never reach the
+# `gh workflow run` step even if every other condition below matched.
+#
+# `github.event.pull_request.user.login` is set by GitHub from the identity that actually
+# called the API to open the PR - it isn't spoofable via branch name, PR title, or body.
+# Both `ci-bump-*` and `ci-layer-docs-*` PRs are opened by aws-powertools/actions'
+# `create-pr` action using the default `GITHUB_TOKEN`, so `.user.login` is always
+# `github-actions[bot]` (confirmed against real PR history - this is NOT the same as
+# `aws-powertools-bot`, which is only the git commit-author identity `create-pr` sets
+# locally via `git config`, not what GitHub exposes as the PR's author).
+#
+# Combined with `head.repo.full_name == github.repository` (rejects forks explicitly)
+# and `base.ref == 'main'`, only genuine automation-opened, same-repo, main-targeted
+# PRs can reach the dispatch step.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  trigger-make-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'ci-bump-')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch Make Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run make-release.yml --repo ${{ github.repository }} --ref main
+
+  trigger-rebuild-docs:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'ci-layer-docs-')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+      - name: Resolve latest published version
+        id: version
+        run: echo "version=$(cat packages/commons/package.json | jq .version -r)" >> "$GITHUB_OUTPUT"
+      - name: Dispatch Rebuild latest docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: gh workflow run rebuild_latest_docs.yml --repo ${{ github.repository }} --ref main --field latest_published_version="$VERSION"

--- a/.github/workflows/on_version_bump_pr_merge.yml
+++ b/.github/workflows/on_version_bump_pr_merge.yml
@@ -1,0 +1,49 @@
+name: Auto-trigger Make Release on version bump PR merge
+
+# PROCESS
+#
+# This workflow watches for `make-version.yml`'s version-bump PR (branch `ci-bump-<run_id>`)
+# merging to `main` so it can dispatch `make-release.yml` automatically, leaving only the
+# human actions that require actual review: approving the version PR and approving npm
+# publish.
+#
+# SECURITY NOTE
+#
+# Deliberately uses `pull_request` (not `pull_request_target`), so PRs from forks keep
+# GitHub's default read-only token and no secrets - a forked PR could never reach the
+# `gh workflow run` step even if every other condition below matched.
+#
+# `github.event.pull_request.user.login` is set by GitHub from the identity that actually
+# called the API to open the PR - it isn't spoofable via branch name, PR title, or body.
+# `ci-bump-*` PRs are opened by aws-powertools/actions' `create-pr` action using the
+# default `GITHUB_TOKEN`, so `.user.login` is always `github-actions[bot]` (confirmed
+# against real PR history - this is NOT the same as `aws-powertools-bot`, which is only
+# the git commit-author identity `create-pr` sets locally via `git config`, not what
+# GitHub exposes as the PR's author).
+#
+# Combined with `head.repo.full_name == github.repository` (rejects forks explicitly)
+# and `base.ref == 'main'`, only genuine automation-opened, same-repo, main-targeted
+# PRs can reach the dispatch step.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions: {}
+
+jobs:
+  trigger-make-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'ci-bump-')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch Make Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run make-release.yml --repo ${{ github.repository }} --ref main

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -228,16 +228,16 @@ Releasing a new version is a multi-step process that requires up to 3 hours to c
 
 1. **End to end tests**: Run the [e2e tests](#run-end-to-end-tests) and ensure they pass.
 2. **Version bump**: Run the `Make Version` workflow to bump the version. This will create a PR with the new version and
-a changelog. Visually inspect the diff and make sure the changelog and version are correct, then merge the PR.
-3. **Make Release**: Run the `Make Release` workflow. This will: 1/ run the unit tests again, 2/ build and publish to npmjs.com,
+a changelog. Visually inspect the diff and make sure the changelog and version are correct, then merge the PR. Merging
+this PR automatically triggers the `Make Release` workflow.
+3. **Make Release**: The `Make Release` workflow will: 1/ run the unit tests again, 2/ build and publish to npmjs.com,
 3/ build and deploy the Lambda layers to the `Beta` and `Prod` environments in all commercial Regions, 4/ run canary
 tests, 5/ deploy the Lambda layers to the `GovCloud` and `China` partitions (Gamma then Prod, both in parallel) once the
-commercial Prod deployment finishes, 6/ update the documentation with the new version once all three (commercial,
-GovCloud, China) Prod deployments are complete.
+commercial Prod deployment finishes, 6/ open a PR to update the documentation with the new layer ARNs once all three
+(commercial, GovCloud, China) Prod deployments are complete.
 4. **Review and merge docs PR**: Once the `Make Release` workflow is complete, a PR will be created to update the
-documentation with the new version. Review and merge this PR.
-5. **Update Docs**: Run the `Rebuild latest docs` workflow with the `main` branch using the package version from
-npm (i.e. `2.20.0`). This will update the documentation with the new version.
+documentation with the new version. Review and merge this PR. Merging this PR automatically triggers the
+`Rebuild latest docs` workflow, which updates the documentation with the new version.
 
 Once complete, you can start drafting the release notes to let customers know **what changed and what's in it for them (a.k.a why they should care)**. We have guidelines in the release notes section so you know what good looks like.
 


### PR DESCRIPTION
## Summary

Follow-up to #5451 (merged as #5462). Removes the last two manual triggers in the release pipeline by adding a new workflow that auto-dispatches the next step when the version-bump PR or the layer ARN-doc PR merges to `main`.

### Changes

- Add `.github/workflows/on_release_pr_merge.yml`:
  - `trigger-make-release`: dispatches `make-release.yml` when a merged PR's branch matches `ci-bump-*` (opened by `make-version.yml`)
  - `trigger-rebuild-docs`: dispatches `rebuild_latest_docs.yml` with the version resolved from `packages/commons/package.json` when a merged PR's branch matches `ci-layer-docs-*` (opened by `publish_layer.yml`'s `update_layer_arn_docs` job)
- Update `docs/maintainers.md`'s release checklist to describe `Make Release` and `Rebuild latest docs` as automatically triggered by PR merge, since manual dispatch is no longer needed

### Security considerations

This workflow can dispatch `make-release.yml` (real npm publish) and `rebuild_latest_docs.yml` (real writes to production docs), so the trigger conditions are deliberately strict and layered:

- **`pull_request`, not `pull_request_target`**: runs with the default read-only `GITHUB_TOKEN` and no secrets in context for the triggering event itself. A PR from a fork could never reach the `gh workflow run` step even if every other condition below happened to match.
- **`head.repo.full_name == github.repository`**: explicitly rejects PRs opened from forks, independent of the author check below.
- **`pull_request.user.login == 'github-actions[bot]'`**: this is the actual GitHub-assigned identity of whoever called the API to open the PR — not spoofable via branch name, PR title, or body. Verified against real PR history that both `ci-bump-*` and `ci-layer-docs-*` PRs are opened by `aws-powertools/actions`' `create-pr` action using the default `GITHUB_TOKEN`, so `.user.login` is always `github-actions[bot]`. This is deliberately *not* `aws-powertools-bot` — that name only shows up as the git **commit author**, set locally by `create-pr` via `git config`, and is unrelated to what GitHub exposes as the PR's author.
- **Exact branch-prefix match (`ci-bump-`/`ci-layer-docs-`)**: scopes each job to the one specific automation flow it should react to, so an unrelated PR merge (e.g. a dependabot bump) can't accidentally trigger a release step even if it somehow satisfied the other conditions.
- **Least-privilege job permissions**: `permissions: {}` at the workflow level, with each job granted only what it needs (`actions: write` to dispatch; `contents: read` added only for the job that checks out `main` to read the published version).

Design and end-to-end behavior — including the negative case, where an unrelated PR merge correctly leaves both jobs `skipped` — were verified on a private staging fork prior to this PR, since dispatching for real against this repo would trigger real npm publishes and AWS/S3 writes.

**Issue number:** closes #5455

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.