### PR TITLE
feat(parser): add schema for Amazon Connect Outbound Campaigns

### DIFF
--- a/docs/features/parser.md
+++ b/docs/features/parser.md
@@ -82,6 +82,7 @@ When using the decorator or middleware, you can specify a schema to parse the ev
 | **VerifyAuthChallengeResponseTriggerSchema** | Lambda Event Source payload for Amazon Cognito Verify Auth Challenge Response trigger |
 | **PreTokenGenerationTriggerSchemaV1**        | Lambda Event Source payload for Amazon Cognito Pre Token Generation trigger v1        |
 | **PreTokenGenerationTriggerSchemaV2AndV3**   | Lambda Event Source payload for Amazon Cognito Pre Token Generation trigger v2 and v3 |
+| **ConnectOutboundCampaignsSchema**           | Lambda Event Source payload for Amazon Connect Outbound Campaigns custom actions      |
 | **DynamoDBStreamSchema**                     | Lambda Event Source payload for Amazon DynamoDB Streams                               |
 | **EventBridgeSchema**                        | Lambda Event Source payload for Amazon EventBridge                                    |
 | **KafkaMskEventSchema**                      | Lambda Event Source payload for AWS MSK payload                                       |

--- a/packages/parser/src/schemas/connect-outbound-campaigns.ts
+++ b/packages/parser/src/schemas/connect-outbound-campaigns.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod';
+import type {
+  ConnectOutboundCampaignsCustomerProfile,
+  ConnectOutboundCampaignsEvent,
+} from '../types/schema.js';
+
+/**
+ * Zod schema for Amazon Connect Outbound Campaigns customer profile records.
+ *
+ * `CustomerData` is a JSON string with campaign-defined key-value pairs. You can
+ * parse it by extending this schema with `JSONStringified` from
+ * `@aws-lambda-powertools/parser/helpers`.
+ *
+ * @see {@link ConnectOutboundCampaignsCustomerProfile | `ConnectOutboundCampaignsCustomerProfile`}
+ * @see {@link https://docs.aws.amazon.com/connect/latest/adminguide/lambda-invoke-functions.html}
+ */
+const ConnectOutboundCampaignsCustomerProfileSchema = z.object({
+  ProfileId: z.string(),
+  CustomerData: z.string(),
+  IdempotencyToken: z.string(),
+});
+
+/**
+ * Zod schema for Amazon Connect Outbound Campaigns custom action events.
+ *
+ * @example
+ * ```json
+ * {
+ *   "InvocationMetadata": {
+ *     "CampaignContext": {
+ *       "CampaignId": "campaign-12345",
+ *       "RunId": "run-67890",
+ *       "ActionId": "activity-abc123",
+ *       "CampaignName": "Welcome Campaign"
+ *     }
+ *   },
+ *   "Items": {
+ *     "CustomerProfiles": [
+ *       {
+ *         "ProfileId": "customer-001",
+ *         "CustomerData": "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"email\":\"john.doe@example.com\"}",
+ *         "IdempotencyToken": "token-xyz789"
+ *       }
+ *     ]
+ *   }
+ * }
+ * ```
+ *
+ * @see {@link ConnectOutboundCampaignsEvent | `ConnectOutboundCampaignsEvent`}
+ * @see {@link https://docs.aws.amazon.com/connect/latest/adminguide/lambda-invoke-functions.html}
+ */
+const ConnectOutboundCampaignsSchema = z.object({
+  InvocationMetadata: z.object({
+    CampaignContext: z.object({
+      CampaignId: z.string(),
+      RunId: z.string(),
+      ActionId: z.string(),
+      CampaignName: z.string(),
+    }),
+  }),
+  Items: z.object({
+    CustomerProfiles: z.array(ConnectOutboundCampaignsCustomerProfileSchema),
+  }),
+});
+
+export {
+  ConnectOutboundCampaignsCustomerProfileSchema,
+  ConnectOutboundCampaignsSchema,
+};

--- a/packages/parser/src/schemas/index.ts
+++ b/packages/parser/src/schemas/index.ts
@@ -49,6 +49,10 @@ export {
   VerifyAuthChallengeTriggerSchema,
 } from './cognito.js';
 export {
+  ConnectOutboundCampaignsCustomerProfileSchema,
+  ConnectOutboundCampaignsSchema,
+} from './connect-outbound-campaigns.js';
+export {
   DynamoDBStreamRecord,
   DynamoDBStreamSchema,
   DynamoDBStreamToKinesisRecord,

--- a/packages/parser/src/types/index.ts
+++ b/packages/parser/src/types/index.ts
@@ -33,6 +33,8 @@ export type {
   CloudWatchLogEvent,
   CloudWatchLogsDecode,
   CloudWatchLogsEvent,
+  ConnectOutboundCampaignsCustomerProfile,
+  ConnectOutboundCampaignsEvent,
   DynamoDBStreamEvent,
   DynamoDBStreamRecord,
   DynamoDBStreamToKinesisRecordEvent,

--- a/packages/parser/src/types/schema.ts
+++ b/packages/parser/src/types/schema.ts
@@ -18,6 +18,8 @@ import type {
   CloudWatchLogEventSchema,
   CloudWatchLogsDecodeSchema,
   CloudWatchLogsSchema,
+  ConnectOutboundCampaignsCustomerProfileSchema,
+  ConnectOutboundCampaignsSchema,
   DynamoDBStreamRecord as DynamoDBStreamRecordSchema,
   DynamoDBStreamSchema,
   DynamoDBStreamToKinesisRecord,
@@ -102,6 +104,14 @@ type CloudFormationCustomResourceUpdateEvent = z.infer<
 
 type CloudWatchLogsEvent = z.infer<typeof CloudWatchLogsSchema>;
 
+type ConnectOutboundCampaignsCustomerProfile = z.infer<
+  typeof ConnectOutboundCampaignsCustomerProfileSchema
+>;
+
+type ConnectOutboundCampaignsEvent = z.infer<
+  typeof ConnectOutboundCampaignsSchema
+>;
+
 type DynamoDBStreamEvent = z.infer<typeof DynamoDBStreamSchema>;
 
 type DynamoDBStreamRecord = z.infer<typeof DynamoDBStreamRecordSchema>;
@@ -185,6 +195,8 @@ export type {
   CloudWatchLogEvent,
   CloudWatchLogsDecode,
   CloudWatchLogsEvent,
+  ConnectOutboundCampaignsCustomerProfile,
+  ConnectOutboundCampaignsEvent,
   DynamoDBStreamEvent,
   DynamoDBStreamRecord,
   DynamoDBStreamToKinesisRecordEvent,

--- a/packages/parser/tests/events/connect-outbound-campaigns/base.json
+++ b/packages/parser/tests/events/connect-outbound-campaigns/base.json
@@ -1,0 +1,24 @@
+{
+  "InvocationMetadata": {
+    "CampaignContext": {
+      "CampaignId": "campaign-12345",
+      "RunId": "run-67890",
+      "ActionId": "activity-abc123",
+      "CampaignName": "Welcome Campaign"
+    }
+  },
+  "Items": {
+    "CustomerProfiles": [
+      {
+        "ProfileId": "customer-001",
+        "CustomerData": "{\"firstName\":\"John\",\"lastName\":\"Doe\",\"email\":\"john.doe@example.com\"}",
+        "IdempotencyToken": "token-xyz789"
+      },
+      {
+        "ProfileId": "customer-002",
+        "CustomerData": "{\"firstName\":\"Jane\",\"lastName\":\"Smith\",\"email\":\"jane.smith@example.com\"}",
+        "IdempotencyToken": "token-abc456"
+      }
+    ]
+  }
+}

--- a/packages/parser/tests/unit/schema/connect-outbound-campaigns.test.ts
+++ b/packages/parser/tests/unit/schema/connect-outbound-campaigns.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { JSONStringified } from '../../../src/helpers/index.js';
+import {
+  ConnectOutboundCampaignsCustomerProfileSchema,
+  ConnectOutboundCampaignsSchema,
+} from '../../../src/schemas/connect-outbound-campaigns.js';
+import type { ConnectOutboundCampaignsEvent } from '../../../src/types/schema.js';
+import { getTestEvent } from '../helpers/utils.js';
+
+describe('Schema: ConnectOutboundCampaigns', () => {
+  const baseEvent = getTestEvent<ConnectOutboundCampaignsEvent>({
+    eventsPath: 'connect-outbound-campaigns',
+    filename: 'base',
+  });
+
+  it('parses a valid ConnectOutboundCampaigns event', () => {
+    // Prepare
+    const event = structuredClone(baseEvent);
+
+    // Act
+    const result = ConnectOutboundCampaignsSchema.parse(event);
+
+    // Assess
+    expect(result).toStrictEqual(event);
+  });
+
+  it('throws if the event is missing required fields', () => {
+    // Prepare
+    const event = structuredClone(
+      baseEvent
+    ) as Partial<ConnectOutboundCampaignsEvent>;
+    delete event.InvocationMetadata;
+
+    // Act & Assess
+    expect(() => ConnectOutboundCampaignsSchema.parse(event)).toThrow();
+  });
+
+  it('parses CustomerData when extending the customer profile schema with JSONStringified', () => {
+    // Prepare
+    const customerDataSchema = z.object({
+      firstName: z.string(),
+      lastName: z.string(),
+      email: z.email(),
+    });
+    const customerProfileSchema =
+      ConnectOutboundCampaignsCustomerProfileSchema.extend({
+        CustomerData: JSONStringified(customerDataSchema),
+      });
+    const eventSchema = ConnectOutboundCampaignsSchema.extend({
+      Items: z.object({
+        CustomerProfiles: z.array(customerProfileSchema),
+      }),
+    });
+    const event = structuredClone(baseEvent);
+
+    // Act
+    const result = eventSchema.parse(event);
+
+    // Assess
+    expect(result.Items.CustomerProfiles[0]).toStrictEqual({
+      ProfileId: 'customer-001',
+      CustomerData: {
+        firstName: 'John',
+        lastName: 'Doe',
+        email: 'john.doe@example.com',
+      },
+      IdempotencyToken: 'token-xyz789',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a built-in Zod schema to the `parser` package for the payload sent by Amazon Connect Outbound Campaigns when invoking a Lambda function through a custom action block in a journey flow. The schema is based on the request structure published in the [official AWS documentation](https://docs.aws.amazon.com/connect/latest/adminguide/lambda-invoke-functions.html).

### Changes

- Add `ConnectOutboundCampaignsSchema` and `ConnectOutboundCampaignsCustomerProfileSchema` in `packages/parser/src/schemas/connect-outbound-campaigns.ts`
- Keep `CustomerData` typed as a JSON string since its contents are campaign-defined; the per-profile schema is exported separately so customers can parse it by extending it with the `JSONStringified` helper
- Add inferred types `ConnectOutboundCampaignsEvent` and `ConnectOutboundCampaignsCustomerProfile`
- Add test fixture taken from the documented example payload and unit tests covering valid parse, missing required fields, and the `JSONStringified` extension path
- Add the new schema to the built-in schemas table in `docs/features/parser.md`

**Issue number:** closes #5501 (refs aws-powertools/powertools-lambda-python#7976)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.