### PR TITLE
ci: replace CodeQL default setup with advanced setup for fork PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+name: CodeQL
+
+# PROCESS
+#
+# 1. Run CodeQL analysis on the Actions workflows and the JavaScript/TypeScript source
+# 2. Upload results to the code-scanning dashboard and report the `CodeQL` status check
+# 3. Fail the check if new alerts are found on changed code in a pull request
+
+# USAGE
+#
+# This is CodeQL "advanced setup": a checked-in workflow that replaces the previous
+# GitHub-managed "default setup". Unlike default setup, this workflow also runs on pull
+# requests opened from forks, so external contributions can satisfy the required `CodeQL`
+# status check instead of being permanently blocked (see #5506).
+#
+# Runs against forked pull requests are still gated behind the repository's
+# "require approval for all external contributors" Actions policy, so a maintainer must
+# approve the run before CodeQL executes against a fork's code.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly, matching the cadence of the previous default setup.
+    - cron: "27 4 * * 1"
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # checkout repository
+      security-events: write  # upload results to the code-scanning dashboard
+      actions: read  # read workflow run metadata (required to analyze the `actions` language)
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - javascript-typescript
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: ${{ matrix.language }}
+          # Match the previous default setup: default query suite (queries left unset) and
+          # the remote threat model.
+          config: |
+            threat-models:
+              - remote
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

CodeQL was configured via GitHub-managed default setup, which only analyzes branches in the base repository — so PRs from forks were permanently blocked by the required `CodeQL` status check, which sat in "Expected — waiting for status to be reported" forever. This replaces default setup with a checked-in advanced-setup workflow that also runs on `pull_request`, so fork PRs are analyzed and can satisfy the required check.

### Changes

- Added `.github/workflows/codeql.yml` (advanced setup) triggering on `push` to `main`, `pull_request` to `main`, and a weekly schedule
- Mirrored the previous default-setup configuration: languages `actions` and `javascript-typescript`, default query suite, remote threat model, weekly cadence
- Verified against the sibling .NET repo (same setup) that the `CodeQL` check reported by the GitHub Advanced Security app — the exact context required on `main` — is still produced, so branch protection needs no change
- All actions are SHA-pinned (satisfies the repo's `secure-workflows.yml` gate); `actionlint` passes
- Fork-PR runs remain gated behind the repository's external-contributor Actions approval policy, preserving the security gate — a maintainer still approves before CodeQL runs against a fork's code

**Note:** CodeQL *default setup* has already been disabled (repo Settings → Code security → Code scanning), because advanced and default setup can't both be active — with default setup on, the advanced workflow's SARIF upload is rejected and the required `CodeQL` check can't pass. This PR's own `CodeQL` check is now green, produced by this workflow. Until this PR merges, `main` itself has no CodeQL scanning (the workflow only takes effect on `main` once merged), so merging promptly closes that gap.

**Issue number:** closes #5506

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.