### PR TITLE
chore(ci): group CodeQL Action Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
     labels: [ ]
     schedule:
       interval: daily
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: pip
     directories:


### PR DESCRIPTION
## Summary

Group CodeQL Action dependencies so Dependabot updates all sub-actions together and avoids init/analyze version mismatch failures.

### Changes

- Add a `codeql-action` group for `github/codeql-action/*` in `.github/dependabot.yml`

**Issue number:** closes #5520

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.