### PR TITLE
chore(ci): remove greetings now handled by oss-automation

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -3,13 +3,3 @@ firstPRWelcomeComment: >
   Thanks a lot for your first contribution! Please check out our [contributing guidelines](https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md) and don't hesitate to ask whatever you need.
 
   In the meantime, check out our GitHub Discussions: [Join the conversation](https://github.com/aws-powertools/powertools-lambda-typescript/discussions)
-
-# Comment to be posted to congratulate user on their first merged PR
-firstPRMergeComment: >
-  Awesome work, congrats on your first merged pull request and thank you for helping improve everyone's experience!
-
-# Comment to be posted to on first time issues
-firstIssueWelcomeComment: >
-  Thanks for opening your first issue here! We'll come back to you as soon as we can.
-
-  In the meantime, check out our GitHub Discussions: [Join the conversation](https://github.com/aws-powertools/powertools-lambda-typescript/discussions)


### PR DESCRIPTION
## Summary

Remove Boring Cyborg's first-issue welcome and first-merge congratulation now that the organization's replacement automation is live and posting the same greetings, causing duplicate comments.

### Changes

- Remove the first-issue welcome greeting.
- Remove the first-merge congratulation.
- Keep the first-PR welcome greeting until the app is uninstalled.

**Issue number:** closes #5533

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/.github/semantic.yml#L2
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.