### PR TITLE
fix(logger): scope log buffer per invocation under LMI concurrency

### DIFF
--- a/packages/logger/src/LogBufferStore.ts
+++ b/packages/logger/src/LogBufferStore.ts
@@ -1,0 +1,84 @@
+import '@aws/lambda-invoke-store';
+import { shouldUseInvokeStore } from '@aws-lambda-powertools/commons/utils/env';
+import { CircularMap, type SizedSet } from './logBuffer.js';
+
+/**
+ * Manages storage of buffered logs with automatic context detection.
+ *
+ * This class abstracts the storage mechanism for the log buffer, automatically
+ * choosing between the InvokeStore (when invocations run concurrently in the
+ * same execution environment) and an instance-level buffer shared across
+ * sequential invocations. The decision is made at runtime on every access to
+ * support Lambda's transition to async contexts.
+ *
+ * Buffered logs are grouped by `_X_AMZN_TRACE_ID`, each group with a max size
+ * of `maxBytes`.
+ */
+class LogBufferStore {
+  readonly #bufferKey = Symbol('powertools.logger.buffer');
+  readonly #maxBytes: number;
+  readonly #fallbackBuffer: CircularMap<string>;
+
+  public constructor(maxBytes: number) {
+    this.#maxBytes = maxBytes;
+    this.#fallbackBuffer = new CircularMap({ maxBytesSize: maxBytes });
+  }
+
+  #getBuffer(): CircularMap<string> {
+    if (!shouldUseInvokeStore()) {
+      return this.#fallbackBuffer;
+    }
+
+    if (globalThis.awslambda?.InvokeStore === undefined) {
+      throw new Error('InvokeStore is not available');
+    }
+
+    const store = globalThis.awslambda.InvokeStore;
+    let buffer = store.get(this.#bufferKey) as CircularMap<string> | undefined;
+    if (buffer == null) {
+      buffer = new CircularMap({ maxBytesSize: this.#maxBytes });
+      store.set(this.#bufferKey, buffer);
+    }
+    return buffer;
+  }
+
+  /**
+   * Add a log to the buffer for the given trace id.
+   *
+   * @param traceId - `_X_AMZN_TRACE_ID` of the request
+   * @param value - The serialized log to be buffered
+   * @param logLevel - The level of the log to be buffered
+   */
+  public add(traceId: string, value: string, logLevel: number): void {
+    const buffer = this.#getBuffer();
+    // When invocations run sequentially, seeing a new trace id means the
+    // previous request is done, so its leftover entries are cleared to avoid
+    // retaining stale logs. Under concurrency the buffer is scoped to the
+    // invocation via the InvokeStore, so no cleanup is needed and clearing
+    // would wipe other in-flight invocations' logs.
+    if (!shouldUseInvokeStore() && buffer.has(traceId) === false) {
+      buffer.clear();
+    }
+    buffer.setItem(traceId, value, logLevel);
+  }
+
+  /**
+   * Get the buffered logs for the given trace id, if any.
+   *
+   * @param traceId - `_X_AMZN_TRACE_ID` of the request
+   */
+  public get(traceId: string): SizedSet<string> | undefined {
+    return this.#getBuffer().get(traceId);
+  }
+
+  /**
+   * Empty the buffer for the given trace id.
+   *
+   * @param traceId - `_X_AMZN_TRACE_ID` of the request
+   */
+  public delete(traceId: string): void {
+    this.#getBuffer().delete(traceId);
+  }
+}
+
+export { LogBufferStore };

--- a/packages/logger/src/LogInvocationStore.ts
+++ b/packages/logger/src/LogInvocationStore.ts
@@ -3,18 +3,19 @@ import { shouldUseInvokeStore } from '@aws-lambda-powertools/commons/utils/env';
 import { CircularMap, type SizedSet } from './logBuffer.js';
 
 /**
- * Manages storage of buffered logs with automatic context detection.
+ * Manages per-invocation log state with automatic context detection.
  *
- * This class abstracts the storage mechanism for the log buffer, automatically
- * choosing between the InvokeStore (when invocations run concurrently in the
- * same execution environment) and an instance-level buffer shared across
- * sequential invocations. The decision is made at runtime on every access to
- * support Lambda's transition to async contexts.
+ * This class abstracts the storage mechanism for state that must be scoped to
+ * a single invocation, automatically choosing between the InvokeStore (when
+ * invocations run concurrently in the same execution environment) and an
+ * instance-level fallback shared across sequential invocations. The decision
+ * is made at runtime on every access to support Lambda's transition to async
+ * contexts.
  *
- * Buffered logs are grouped by `_X_AMZN_TRACE_ID`, each group with a max size
- * of `maxBytes`.
+ * Currently it holds the log buffer, grouped by `_X_AMZN_TRACE_ID` with each
+ * group capped at `maxBytes`.
  */
-class LogBufferStore {
+class LogInvocationStore {
   readonly #bufferKey = Symbol('powertools.logger.buffer');
   readonly #maxBytes: number;
   readonly #fallbackBuffer: CircularMap<string>;
@@ -81,4 +82,4 @@ class LogBufferStore {
   }
 }
 
-export { LogBufferStore };
+export { LogInvocationStore };

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -16,6 +16,7 @@ import {
   getStringFromEnv,
   getXRayTraceIdFromEnv,
   isDevMode,
+  shouldUseInvokeStore,
 } from '@aws-lambda-powertools/commons/utils/env';
 import type { Callback, Context, Handler } from 'aws-lambda';
 import {
@@ -214,9 +215,17 @@ class Logger extends Utility implements LoggerInterface {
   };
 
   /**
-   * Contains buffered logs, grouped by `_X_AMZN_TRACE_ID`, each group with a max size of `maxBufferBytesSize`
+   * Contains buffered logs, grouped by `_X_AMZN_TRACE_ID`, each group with a max size of `maxBufferBytesSize`.
+   *
+   * Used when invocations run sequentially; under concurrency the buffer is scoped
+   * to each invocation via the InvokeStore, see {@link Logger.#getBuffer | `#getBuffer()`}.
    */
   #buffer?: CircularMap<string>;
+
+  /**
+   * Key used to store the buffer in the InvokeStore when concurrency is enabled.
+   */
+  readonly #bufferKey = Symbol('powertools.logger.buffer');
 
   /**
    * Search function for the correlation ID.
@@ -1419,19 +1428,54 @@ class Logger extends Utility implements LoggerInterface {
    * @param log - Log to be buffered
    * @param logLevel - The level of log to be buffered
    */
+  /**
+   * Get the buffer holding this invocation's logs.
+   *
+   * When invocations run concurrently in the same execution environment
+   * (Lambda Managed Instances), each invocation gets its own buffer stored in
+   * the InvokeStore, so buffered logs die with their invocation context.
+   * Otherwise the instance-level buffer shared across sequential invocations
+   * is used.
+   */
+  #getBuffer(): CircularMap<string> | undefined {
+    if (this.#bufferConfig.enabled === false) {
+      return undefined;
+    }
+    if (!shouldUseInvokeStore()) {
+      return this.#buffer;
+    }
+
+    if (globalThis.awslambda?.InvokeStore === undefined) {
+      throw new Error('InvokeStore is not available');
+    }
+
+    const store = globalThis.awslambda.InvokeStore;
+    let buffer = store.get(this.#bufferKey) as CircularMap<string> | undefined;
+    if (buffer == null) {
+      buffer = new CircularMap({
+        maxBytesSize: this.#bufferConfig.maxBytes,
+      });
+      store.set(this.#bufferKey, buffer);
+    }
+    return buffer;
+  }
+
   protected bufferLogItem(
     xrayTraceId: string,
     log: LogItem,
     logLevel: number
   ): void {
     log.prepareForPrint();
-    // This is the first time we see this traceId, so we need to clear the buffer
-    // from previous requests. This is ok because in AWS Lambda, the same sandbox
-    // environment can only ever be used by one request at a time.
-    if (this.#buffer?.has(xrayTraceId) === false) {
-      this.#buffer?.clear();
+    const buffer = this.#getBuffer();
+    // When invocations run sequentially, seeing a new traceId means the
+    // previous request is done, so its leftover entries are cleared to avoid
+    // retaining stale logs. Under concurrency the buffer is scoped to the
+    // invocation via the InvokeStore, so no cleanup is needed and clearing
+    // would wipe other in-flight invocations' logs.
+    if (!shouldUseInvokeStore() && buffer?.has(xrayTraceId) === false) {
+      buffer?.clear();
     }
-    this.#buffer?.setItem(
+    buffer?.setItem(
       xrayTraceId,
       JSON.stringify(
         log.getAttributes(),
@@ -1454,7 +1498,8 @@ class Logger extends Utility implements LoggerInterface {
       return;
     }
 
-    const buffer = this.#buffer?.get(traceId);
+    const requestBuffer = this.#getBuffer();
+    const buffer = requestBuffer?.get(traceId);
     if (buffer === undefined) {
       return;
     }
@@ -1486,7 +1531,7 @@ class Logger extends Utility implements LoggerInterface {
       );
     }
 
-    this.#buffer?.delete(traceId);
+    requestBuffer?.delete(traceId);
   }
 
   /**
@@ -1497,7 +1542,7 @@ class Logger extends Utility implements LoggerInterface {
     if (traceId === undefined) {
       return;
     }
-    this.#buffer?.delete(traceId);
+    this.#getBuffer()?.delete(traceId);
   }
 
   /**

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -29,7 +29,7 @@ import type { LogFormatter } from './formatter/LogFormatter.js';
 import type { LogItem } from './formatter/LogItem.js';
 import { PowertoolsLogFormatter } from './formatter/PowertoolsLogFormatter.js';
 import { LogAttributesStore } from './LogAttributesStore.js';
-import { LogBufferStore } from './LogBufferStore.js';
+import { LogInvocationStore } from './LogInvocationStore.js';
 import type { ConfigServiceInterface } from './types/ConfigServiceInterface.js';
 import type {
   ConstructorOptions,
@@ -227,13 +227,14 @@ class Logger extends Utility implements LoggerInterface {
   };
 
   /**
-   * Store for the buffered logs, grouped by `_X_AMZN_TRACE_ID`.
+   * Store for per-invocation log state, currently the buffered logs grouped by
+   * `_X_AMZN_TRACE_ID`.
    *
-   * Scopes the buffer to each invocation via the InvokeStore when invocations
-   * run concurrently, and falls back to an instance-level buffer shared across
+   * Scopes the state to each invocation via the InvokeStore when invocations
+   * run concurrently, and falls back to an instance-level store shared across
    * sequential invocations. Only set when buffering is enabled.
    */
-  #bufferStore?: LogBufferStore;
+  #invocationStore?: LogInvocationStore;
 
   /**
    * Search function for the correlation ID.
@@ -1449,7 +1450,7 @@ class Logger extends Utility implements LoggerInterface {
     if (options?.maxBytes !== undefined) {
       this.#bufferConfig.maxBytes = options.maxBytes;
     }
-    this.#bufferStore = new LogBufferStore(this.#bufferConfig.maxBytes);
+    this.#invocationStore = new LogInvocationStore(this.#bufferConfig.maxBytes);
 
     if (options?.flushOnErrorLog === false) {
       this.#bufferConfig.flushOnErrorLog = false;
@@ -1485,7 +1486,7 @@ class Logger extends Utility implements LoggerInterface {
     logLevel: number
   ): void {
     log.prepareForPrint();
-    this.#bufferStore?.add(
+    this.#invocationStore?.add(
       xrayTraceId,
       JSON.stringify(
         log.getAttributes(),
@@ -1508,7 +1509,7 @@ class Logger extends Utility implements LoggerInterface {
       return;
     }
 
-    const buffer = this.#bufferStore?.get(traceId);
+    const buffer = this.#invocationStore?.get(traceId);
     if (buffer === undefined) {
       return;
     }
@@ -1540,7 +1541,7 @@ class Logger extends Utility implements LoggerInterface {
       );
     }
 
-    this.#bufferStore?.delete(traceId);
+    this.#invocationStore?.delete(traceId);
   }
 
   /**
@@ -1551,7 +1552,7 @@ class Logger extends Utility implements LoggerInterface {
     if (traceId === undefined) {
       return;
     }
-    this.#bufferStore?.delete(traceId);
+    this.#invocationStore?.delete(traceId);
   }
 
   /**

--- a/packages/logger/src/Logger.ts
+++ b/packages/logger/src/Logger.ts
@@ -29,7 +29,7 @@ import type { LogFormatter } from './formatter/LogFormatter.js';
 import type { LogItem } from './formatter/LogItem.js';
 import { PowertoolsLogFormatter } from './formatter/PowertoolsLogFormatter.js';
 import { LogAttributesStore } from './LogAttributesStore.js';
-import { CircularMap } from './logBuffer.js';
+import { LogBufferStore } from './LogBufferStore.js';
 import type { ConfigServiceInterface } from './types/ConfigServiceInterface.js';
 import type {
   ConstructorOptions,
@@ -227,17 +227,13 @@ class Logger extends Utility implements LoggerInterface {
   };
 
   /**
-   * Contains buffered logs, grouped by `_X_AMZN_TRACE_ID`, each group with a max size of `maxBufferBytesSize`.
+   * Store for the buffered logs, grouped by `_X_AMZN_TRACE_ID`.
    *
-   * Used when invocations run sequentially; under concurrency the buffer is scoped
-   * to each invocation via the InvokeStore, see {@link Logger.#getBuffer | `#getBuffer()`}.
+   * Scopes the buffer to each invocation via the InvokeStore when invocations
+   * run concurrently, and falls back to an instance-level buffer shared across
+   * sequential invocations. Only set when buffering is enabled.
    */
-  #buffer?: CircularMap<string>;
-
-  /**
-   * Key used to store the buffer in the InvokeStore when concurrency is enabled.
-   */
-  readonly #bufferKey = Symbol('powertools.logger.buffer');
+  #bufferStore?: LogBufferStore;
 
   /**
    * Search function for the correlation ID.
@@ -1453,9 +1449,7 @@ class Logger extends Utility implements LoggerInterface {
     if (options?.maxBytes !== undefined) {
       this.#bufferConfig.maxBytes = options.maxBytes;
     }
-    this.#buffer = new CircularMap({
-      maxBytesSize: this.#bufferConfig.maxBytes,
-    });
+    this.#bufferStore = new LogBufferStore(this.#bufferConfig.maxBytes);
 
     if (options?.flushOnErrorLog === false) {
       this.#bufferConfig.flushOnErrorLog = false;
@@ -1485,54 +1479,13 @@ class Logger extends Utility implements LoggerInterface {
    * @param log - Log to be buffered
    * @param logLevel - The level of log to be buffered
    */
-  /**
-   * Get the buffer holding this invocation's logs.
-   *
-   * When invocations run concurrently in the same execution environment
-   * (Lambda Managed Instances), each invocation gets its own buffer stored in
-   * the InvokeStore, so buffered logs die with their invocation context.
-   * Otherwise the instance-level buffer shared across sequential invocations
-   * is used.
-   */
-  #getBuffer(): CircularMap<string> | undefined {
-    if (this.#bufferConfig.enabled === false) {
-      return undefined;
-    }
-    if (!shouldUseInvokeStore()) {
-      return this.#buffer;
-    }
-
-    if (globalThis.awslambda?.InvokeStore === undefined) {
-      throw new Error('InvokeStore is not available');
-    }
-
-    const store = globalThis.awslambda.InvokeStore;
-    let buffer = store.get(this.#bufferKey) as CircularMap<string> | undefined;
-    if (buffer == null) {
-      buffer = new CircularMap({
-        maxBytesSize: this.#bufferConfig.maxBytes,
-      });
-      store.set(this.#bufferKey, buffer);
-    }
-    return buffer;
-  }
-
   protected bufferLogItem(
     xrayTraceId: string,
     log: LogItem,
     logLevel: number
   ): void {
     log.prepareForPrint();
-    const buffer = this.#getBuffer();
-    // When invocations run sequentially, seeing a new traceId means the
-    // previous request is done, so its leftover entries are cleared to avoid
-    // retaining stale logs. Under concurrency the buffer is scoped to the
-    // invocation via the InvokeStore, so no cleanup is needed and clearing
-    // would wipe other in-flight invocations' logs.
-    if (!shouldUseInvokeStore() && buffer?.has(xrayTraceId) === false) {
-      buffer?.clear();
-    }
-    buffer?.setItem(
+    this.#bufferStore?.add(
       xrayTraceId,
       JSON.stringify(
         log.getAttributes(),
@@ -1555,8 +1508,7 @@ class Logger extends Utility implements LoggerInterface {
       return;
     }
 
-    const requestBuffer = this.#getBuffer();
-    const buffer = requestBuffer?.get(traceId);
+    const buffer = this.#bufferStore?.get(traceId);
     if (buffer === undefined) {
       return;
     }
@@ -1588,7 +1540,7 @@ class Logger extends Utility implements LoggerInterface {
       );
     }
 
-    requestBuffer?.delete(traceId);
+    this.#bufferStore?.delete(traceId);
   }
 
   /**
@@ -1599,7 +1551,7 @@ class Logger extends Utility implements LoggerInterface {
     if (traceId === undefined) {
       return;
     }
-    this.#getBuffer()?.delete(traceId);
+    this.#bufferStore?.delete(traceId);
   }
 
   /**

--- a/packages/logger/tests/unit/concurrency/logBuffer.test.ts
+++ b/packages/logger/tests/unit/concurrency/logBuffer.test.ts
@@ -1,0 +1,126 @@
+import { InvokeStore } from '@aws/lambda-invoke-store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Logger } from '../../../src/index.js';
+
+const XRAY_TRACE_ID_KEY = Symbol.for('_AWS_LAMBDA_X_RAY_TRACE_ID');
+
+describe('Log buffer concurrent invocation isolation', () => {
+  beforeEach(() => {
+    InvokeStore._testing?.reset();
+    vi.stubEnv('POWERTOOLS_DEV', 'true');
+    vi.stubEnv('AWS_LAMBDA_MAX_CONCURRENCY', '10');
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('InvokeStore error handling', () => {
+    beforeEach(() => {
+      vi.stubGlobal('awslambda', undefined);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('throws when clearing the buffer with InvokeStore unavailable', () => {
+      // Prepare
+      const logger = new Logger({
+        logLevel: 'INFO',
+        logBufferOptions: { enabled: true },
+      });
+
+      // Act & Assess
+      expect(() => {
+        logger.clearBuffer();
+      }).toThrow('InvokeStore is not available');
+    });
+  });
+
+  it('keeps each invocation buffered logs when a concurrent invocation starts buffering', async () => {
+    // Prepare
+    const logger = new Logger({
+      logLevel: 'INFO',
+      logBufferOptions: { enabled: true },
+    });
+    const store = await InvokeStore.getInstanceAsync();
+    const aBuffered = Promise.withResolvers<void>();
+    const bBuffered = Promise.withResolvers<void>();
+
+    // Act
+    // Invocation A buffers a debug log, yields (simulating I/O), invocation B
+    // starts concurrently and buffers its first debug log under a different
+    // trace id, then A errors and flushes its buffer
+    const invocationA = store.run(
+      { [XRAY_TRACE_ID_KEY]: '1-aaaaaaaa-111111111111111111111111' },
+      async () => {
+        logger.debug('A buffered debug log');
+        aBuffered.resolve();
+        await bBuffered.promise;
+        logger.flushBuffer();
+      }
+    );
+    const invocationB = (async () => {
+      await aBuffered.promise;
+      await store.run(
+        { [XRAY_TRACE_ID_KEY]: '1-bbbbbbbb-222222222222222222222222' },
+        async () => {
+          logger.debug('B buffered debug log');
+        }
+      );
+      bBuffered.resolve();
+    })();
+    await Promise.all([invocationA, invocationB]);
+
+    // Assess
+    expect(console.debug).toHaveLogged(
+      expect.objectContaining({ message: 'A buffered debug log' })
+    );
+    expect(console.debug).not.toHaveLogged(
+      expect.objectContaining({ message: 'B buffered debug log' })
+    );
+  });
+
+  it('flushes each invocation buffer independently', async () => {
+    // Prepare
+    const logger = new Logger({
+      logLevel: 'INFO',
+      logBufferOptions: { enabled: true },
+    });
+    const store = await InvokeStore.getInstanceAsync();
+    const aBuffered = Promise.withResolvers<void>();
+    const aFlushed = Promise.withResolvers<void>();
+
+    // Act
+    // Invocation A buffers and flushes while invocation B is mid-flight with
+    // its own buffered log, then B flushes its own buffer
+    const invocationB = store.run(
+      { [XRAY_TRACE_ID_KEY]: '1-bbbbbbbb-222222222222222222222222' },
+      async () => {
+        logger.debug('B buffered debug log');
+        await aFlushed.promise;
+        logger.flushBuffer();
+      }
+    );
+    const invocationA = store.run(
+      { [XRAY_TRACE_ID_KEY]: '1-aaaaaaaa-111111111111111111111111' },
+      async () => {
+        logger.debug('A buffered debug log');
+        aBuffered.resolve();
+        logger.flushBuffer();
+        aFlushed.resolve();
+      }
+    );
+    await Promise.all([invocationA, invocationB]);
+
+    // Assess
+    expect(console.debug).toHaveLogged(
+      expect.objectContaining({ message: 'A buffered debug log' })
+    );
+    expect(console.debug).toHaveLogged(
+      expect.objectContaining({ message: 'B buffered debug log' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

### Changes

The log buffer cleared all entries whenever a log was buffered for a trace id it had not seen before, based on the assumption that only one request can be in flight per execution environment (the comment in `bufferLogItem()` stated this explicitly). Under Lambda Managed Instances concurrency that assumption no longer holds: an invocation starting to buffer wiped every other in-flight invocation's buffered logs, so a failing invocation had nothing left to flush and its debug context was silently lost.

Following the direction agreed in the issue, the buffer is now scoped through the InvokeStore when concurrency is enabled (`AWS_LAMBDA_MAX_CONCURRENCY` set): a new private `#getBuffer()` accessor returns an invocation-scoped `CircularMap` stored in the InvokeStore, so each invocation's buffered logs live and die with its invocation context and no cross-invocation cleanup is needed. The sequential path is unchanged: it keeps the instance-level buffer and its new-trace `clear()` behavior, preserving the stale-buffer safeguard introduced in #3705.

`bufferLogItem()`, `flushBuffer()`, and `clearBuffer()` all resolve the buffer through the accessor. The `clear()` now only runs on the sequential path.

Added regression tests in `tests/unit/concurrency/logBuffer.test.ts`:
- interleaved invocations keep and flush their own buffered logs (fails on main, where invocation B's first buffered log wipes invocation A's buffer)
- each invocation flushes independently while the other is mid-flight
- `clearBuffer()` throws when concurrency is enabled but the InvokeStore is unavailable, matching the behavior of the attribute store

All existing logger unit tests pass unchanged (226 tests), confirming sequential behavior is preserved, with 100% coverage on `Logger.ts`.

**Issue number:** closes #5541

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.