### PR TITLE
ci(maintenance): add aggregate unit-test check for branch protection

### DIFF
--- a/.github/workflows/pr-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/pr-run-linting-check-and-unit-tests.yml
@@ -2,7 +2,7 @@ name: On PR code update
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
@@ -147,3 +147,24 @@ jobs:
       - *setup_dependencies
       - name: Run linting
         run: npm run lint:markdown
+  unit-tests-complete:
+    # Single stable context (`run-unit-tests / unit-tests-complete`) that branch protection can
+    # require, so that adding a Node.js version or a workspace to the `code-quality` matrix
+    # doesn't silently change which checks are required.
+    #
+    # `if: always()` is required so this job still runs when a dependency fails - otherwise it
+    # would be skipped, and a skipped required check counts as satisfied. For the same reason
+    # `skipped` is treated as a failure below: none of the jobs above are conditional, so a skip
+    # means something upstream went wrong.
+    needs: [code-quality, check-examples, check-layer-publisher, check-docs-snippets, check-docs]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all unit test jobs succeeded
+        env:
+          FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          if [ "${FAILED}" = "true" ]; then
+            echo "::error::One or more unit test jobs did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Unit tests and `dependency-review` don't gate merges on `main` today, so a pull request can merge with failing tests. This adds a single aggregate context that branch protection can require, and makes sure it always reports.

Requiring the 30 individual `code-quality` matrix contexts instead would be brittle: adding a Node.js version or a workspace silently changes which checks are required.

### Changes

- Add a `unit-tests-complete` job to `reusable-run-linting-check-and-unit-tests.yml` that `needs` all five existing jobs and fails if any of them did not succeed
- Treat `skipped` as a failure alongside `failure` and `cancelled`, and run the job with `if: always()`. Both are load-bearing: a skipped job reports its check run as `skipped`, and GitHub counts a skipped required check as *satisfied*, so an aggregate job that skipped when a dependency failed would green-light a broken pull request
- Add `reopened` to `pr-run-linting-check-and-unit-tests.yml` triggers, so a reopened pull request re-reports instead of stranding the required context

`dependency-review.yml` needs no change: it triggers on bare `pull_request` and has no `paths:` filter, so it always reports.

Follow-up for a repo admin once this merges: add `run-unit-tests / unit-tests-complete` and `dependency-review` to the required status checks for `main`. A context must report at least once before it can be required, which is why this is a separate step.

**Issue number:** closes #5569

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
