### PR TITLE
fix(event-handler): handle +json content types and bodyless responses

### DIFF
--- a/docs/features/event-handler/http.md
+++ b/docs/features/event-handler/http.md
@@ -204,7 +204,8 @@ If you prefer to use the decorator syntax, you can use the same methods on a cla
 Event Handler supports built-in request and response validation using [Standard Schema](https://standardschema.dev){target="_blank"}, a common specification supported by popular TypeScript validation libraries including [Zod](https://zod.dev){target="_blank"}, [Valibot](https://valibot.dev){target="_blank"}, and [ArkType](https://arktype.io){target="_blank"}.
 
 !!! note "Body validation is limited to JSON-serializable values"
-    Standard Schema validators operate on JavaScript values, not raw bytes. For body validation, Event Handler deserializes the body before passing it to your schema: `application/json` content is parsed as an object, all other content types are passed as a plain string. Binary data, streams, and other non-serializable response types cannot be validated.
+    Standard Schema validators operate on JavaScript values, not raw bytes. For body validation, Event Handler deserializes the body before passing it to your schema: `application/json` content, and any content type with a `+json` structured syntax suffix (e.g. `application/vnd.api+json`, `application/problem+json`), is parsed as an object.
+    All other content types are passed as a plain string. Binary data, streams, and other non-serializable response types cannot be validated.
 
 #### Validating requests
 

--- a/packages/event-handler/src/http/middleware/tracer.ts
+++ b/packages/event-handler/src/http/middleware/tracer.ts
@@ -6,6 +6,7 @@ import type {
   SegmentHttpData,
   TracerOptions,
 } from '../../types/http.js';
+import { isJsonContentType } from '../utils.js';
 import { getClientIp } from './commons.js';
 import type { compress } from './compress.js';
 
@@ -156,7 +157,7 @@ const tracer = (tracer: Tracer, options?: TracerOptions): Middleware => {
 
       if (
         captureResponse &&
-        reqCtx.res.headers.get('Content-Type') === 'application/json'
+        isJsonContentType(reqCtx.res.headers.get('Content-Type'))
       ) {
         const responseBody = await reqCtx.res.clone().json();
         tracer.addResponseAsMetadata(responseBody, segmentName);

--- a/packages/event-handler/src/http/middleware/tracer.ts
+++ b/packages/event-handler/src/http/middleware/tracer.ts
@@ -159,8 +159,16 @@ const tracer = (tracer: Tracer, options?: TracerOptions): Middleware => {
         captureResponse &&
         isJsonContentType(reqCtx.res.headers.get('Content-Type'))
       ) {
-        const responseBody = await reqCtx.res.clone().json();
-        tracer.addResponseAsMetadata(responseBody, segmentName);
+        try {
+          const responseBody = await reqCtx.res.clone().json();
+          tracer.addResponseAsMetadata(responseBody, segmentName);
+        } catch (error) {
+          logger.warn(
+            'Failed to parse response body as JSON for segment %s. Response metadata will not be captured.',
+            segmentName,
+            error
+          );
+        }
       }
     } catch (err) {
       tracer.addErrorAsMetadata(err as Error);

--- a/packages/event-handler/src/http/middleware/tracer.ts
+++ b/packages/event-handler/src/http/middleware/tracer.ts
@@ -157,6 +157,7 @@ const tracer = (tracer: Tracer, options?: TracerOptions): Middleware => {
 
       if (
         captureResponse &&
+        reqCtx.res.body &&
         isJsonContentType(reqCtx.res.headers.get('Content-Type'))
       ) {
         try {

--- a/packages/event-handler/src/http/middleware/validation.ts
+++ b/packages/event-handler/src/http/middleware/validation.ts
@@ -12,6 +12,7 @@ import type {
   ValidationConfig,
 } from '../../types/http.js';
 import { RequestValidationError, ResponseValidationError } from '../errors.js';
+import { isJsonContentType } from '../utils.js';
 
 /**
  * Creates a validation middleware from the provided validation configuration.
@@ -189,7 +190,7 @@ async function extractBody(source: Request | Response): Promise<unknown> {
   const cloned = source.clone();
   const contentType = source.headers.get('content-type');
 
-  if (contentType?.includes('application/json')) {
+  if (isJsonContentType(contentType)) {
     try {
       return await cloned.json();
     } catch {

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -438,10 +438,13 @@ export const getBase64EncodingFromHeaders = (headers: Headers): boolean => {
 };
 
 /**
- * Checks whether a `Content-Type` value is `application/json` or uses the RFC 6839
- * `+json` structured syntax suffix (e.g. `application/vnd.api+json`). Parameters are ignored.
+ * Determines whether a `Content-Type` header value is JSON, including RFC 6839
+ * structured syntax suffixes such as `application/vnd.api+json`.
+ * Reference: https://datatracker.ietf.org/doc/html/rfc6839#section-3.1
  *
- * @param contentType - The `Content-Type` header value to check
+ * Any parameters in the header value are ignored.
+ *
+ * @param contentType - The `Content-Type` header value to check.
  */
 export const isJsonContentType = (
   contentType: string | null | undefined

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -437,6 +437,20 @@ export const getBase64EncodingFromHeaders = (headers: Headers): boolean => {
   return false;
 };
 
+/**
+ * Checks whether a `Content-Type` value is `application/json` or uses the RFC 6839
+ * `+json` structured syntax suffix (e.g. `application/vnd.api+json`). Parameters are ignored.
+ *
+ * @param contentType - The `Content-Type` header value to check
+ */
+export const isJsonContentType = (
+  contentType: string | null | undefined
+): boolean => {
+  if (!contentType) return false;
+  const type = contentType.split(';')[0].trim().toLowerCase();
+  return type === 'application/json' || type.endsWith('+json');
+};
+
 export const getStatusCode = (
   result: HandlerResponse,
   fallback: HttpStatusCode = HttpStatusCodes.OK

--- a/packages/event-handler/tests/unit/http/middleware/tracer.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/tracer.test.ts
@@ -269,6 +269,35 @@ describe('Tracer Middleware', () => {
       );
     });
 
+    it('does not capture metadata or log a warning for bodyless responses', async () => {
+      // Prepare
+      const tracer = new Tracer();
+      vi.spyOn(tracer, 'setSegment').mockImplementation(() => null);
+      vi.spyOn(tracer, 'getSegment')
+        .mockImplementationOnce(() => new Segment('main'))
+        .mockImplementation(() => new Subsegment('DELETE /test'));
+      vi.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
+      vi.spyOn(tracer, 'addServiceNameAnnotation').mockImplementation(
+        () => ({})
+      );
+      const addResponseSpy = vi.spyOn(tracer, 'addResponseAsMetadata');
+      const logWarningSpy = vi.spyOn(console, 'warn');
+
+      app.use(tracerMiddleware(tracer));
+      app.delete('/test', () => ({ statusCode: 204 }));
+
+      // Act
+      const result = await app.resolve(
+        createTestEvent('/test', 'DELETE'),
+        context
+      );
+
+      // Assess
+      expect(result.statusCode).toBe(204);
+      expect(addResponseSpy).toHaveBeenCalledTimes(0);
+      expect(logWarningSpy).toHaveBeenCalledTimes(0);
+    });
+
     it('closes subsegment and restores parent segment after successful request', async () => {
       // Prepare
       const tracer = new Tracer();

--- a/packages/event-handler/tests/unit/http/middleware/tracer.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/tracer.test.ts
@@ -226,6 +226,49 @@ describe('Tracer Middleware', () => {
       expect(addResponseSpy).toHaveBeenCalledTimes(0);
     });
 
+    it('logs a warning and does not fail the request when the response body is not valid JSON', async () => {
+      // Prepare
+      const tracer = new Tracer();
+      vi.spyOn(tracer, 'setSegment').mockImplementation(() => null);
+      vi.spyOn(tracer, 'getSegment')
+        .mockImplementationOnce(() => new Segment('main'))
+        .mockImplementation(() => new Subsegment('GET /test'));
+      vi.spyOn(tracer, 'annotateColdStart').mockImplementation(() => ({}));
+      vi.spyOn(tracer, 'addServiceNameAnnotation').mockImplementation(
+        () => ({})
+      );
+      const addResponseSpy = vi.spyOn(tracer, 'addResponseAsMetadata');
+      const addErrorSpy = vi.spyOn(tracer, 'addErrorAsMetadata');
+      const logWarningSpy = vi.spyOn(console, 'warn');
+
+      app.use(tracerMiddleware(tracer));
+      app.get(
+        '/test',
+        () =>
+          new Response('not json', {
+            headers: { 'Content-Type': 'application/json' },
+          })
+      );
+
+      // Act
+      const result = await app.resolve(
+        createTestEvent('/test', 'GET'),
+        context
+      );
+
+      // Assess
+      expect(result.statusCode).toBe(200);
+      expect(result.body).toBe('not json');
+      expect(addResponseSpy).toHaveBeenCalledTimes(0);
+      expect(addErrorSpy).toHaveBeenCalledTimes(0);
+      expect(logWarningSpy).toHaveBeenNthCalledWith(
+        1,
+        'Failed to parse response body as JSON for segment %s. Response metadata will not be captured.',
+        'GET /test',
+        expect.any(Error)
+      );
+    });
+
     it('closes subsegment and restores parent segment after successful request', async () => {
       // Prepare
       const tracer = new Tracer();

--- a/packages/event-handler/tests/unit/http/middleware/tracer.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/tracer.test.ts
@@ -170,6 +170,37 @@ describe('Tracer Middleware', () => {
       expect(addResponseSpy).toHaveBeenCalledTimes(0);
     });
 
+    it('captures response as metadata when content-type has a +json suffix', async () => {
+      // Prepare
+      const tracer = new Tracer();
+      vi.spyOn(tracer, 'setSegment').mockImplementation(() => null);
+      vi.spyOn(tracer, 'getSegment')
+        .mockImplementationOnce(() => new Segment('main'))
+        .mockImplementation(() => new Subsegment('GET /test'));
+      const addResponseSpy = vi.spyOn(tracer, 'addResponseAsMetadata');
+
+      app.use(tracerMiddleware(tracer));
+      app.get(
+        '/test',
+        () =>
+          new Response(JSON.stringify({ foo: 'bar' }), {
+            headers: { 'Content-Type': 'application/vnd.api+json' },
+          })
+      );
+
+      // Act
+      await app.resolve(createTestEvent('/test', 'GET'), context);
+
+      // Assess
+      expect(addResponseSpy).toHaveBeenCalledTimes(1);
+      expect(addResponseSpy).toHaveBeenCalledWith(
+        {
+          foo: 'bar',
+        },
+        'GET /test'
+      );
+    });
+
     it('does not capture non-JSON responses', async () => {
       // Prepare
       const tracer = new Tracer();

--- a/packages/event-handler/tests/unit/http/middleware/validation.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/validation.test.ts
@@ -40,6 +40,33 @@ describe('Router Validation Integration', () => {
     expect(result.body).toBe('Created John');
   });
 
+  it('validates request body successfully when content-type has a +json suffix', async () => {
+    // Prepare
+    const requestBodySchema = z.object({ name: z.string() });
+
+    app.post(
+      '/users',
+      (reqCtx) => {
+        const { name } = reqCtx.valid.req.body;
+        return { statusCode: 201, body: `Created ${name}` };
+      },
+      {
+        validation: { req: { body: requestBodySchema } },
+      }
+    );
+
+    const event = createTestEvent('/users', 'POST', {
+      'content-type': 'application/vnd.api+json',
+    });
+    event.body = JSON.stringify({ name: 'John' });
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.statusCode).toBe(201);
+  });
+
   it('returns 422 on request body validation failure', async () => {
     // Prepare
     const requestBodySchema = z.object({ name: z.string() });
@@ -329,6 +356,31 @@ describe('Router Validation Integration', () => {
 
     const event = createTestEvent('/users/123', 'GET', {});
     event.pathParameters = { id: '123' };
+
+    // Act
+    const result = await app.resolve(event, context);
+
+    // Assess
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('validates response body successfully when content-type has a +json suffix', async () => {
+    // Prepare
+    const responseSchema = z.object({ id: z.string(), name: z.string() });
+
+    app.get(
+      '/users',
+      () => ({
+        statusCode: 200,
+        body: { id: '1', name: 'John' },
+        headers: { 'content-type': 'application/vnd.api+json' },
+      }),
+      {
+        validation: { res: { body: responseSchema } },
+      }
+    );
+
+    const event = createTestEvent('/users', 'GET');
 
     // Act
     const result = await app.resolve(event, context);

--- a/packages/event-handler/tests/unit/http/middleware/validation.test.ts
+++ b/packages/event-handler/tests/unit/http/middleware/validation.test.ts
@@ -65,6 +65,7 @@ describe('Router Validation Integration', () => {
 
     // Assess
     expect(result.statusCode).toBe(201);
+    expect(result.body).toBe('Created John');
   });
 
   it('returns 422 on request body validation failure', async () => {
@@ -366,13 +367,15 @@ describe('Router Validation Integration', () => {
 
   it('validates response body successfully when content-type has a +json suffix', async () => {
     // Prepare
-    const responseSchema = z.object({ id: z.string(), name: z.string() });
+    const responseSchema = z.array(
+      z.object({ id: z.string(), name: z.string() })
+    );
 
     app.get(
       '/users',
       () => ({
         statusCode: 200,
-        body: { id: '1', name: 'John' },
+        body: [{ id: '1', name: 'John' }],
         headers: { 'content-type': 'application/vnd.api+json' },
       }),
       {
@@ -387,6 +390,7 @@ describe('Router Validation Integration', () => {
 
     // Assess
     expect(result.statusCode).toBe(200);
+    expect(result.body).toBe(JSON.stringify([{ id: '1', name: 'John' }]));
   });
 
   it('returns 500 on response body validation failure', async () => {

--- a/packages/event-handler/tests/unit/http/utils.test.ts
+++ b/packages/event-handler/tests/unit/http/utils.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../src/http/index.js';
 import {
   compilePath,
+  isJsonContentType,
   resolvePrefixedPath,
   validatePathPattern,
 } from '../../../src/http/utils.js';
@@ -866,6 +867,32 @@ describe('Path Utilities', () => {
 
       // Assert
       expect(resolvedPath).toEqual(expected);
+    });
+  });
+
+  describe('isJsonContentType', () => {
+    it.each([
+      { contentType: 'application/json' },
+      { contentType: 'application/json; charset=utf-8' },
+      { contentType: 'Application/JSON' },
+      { contentType: 'application/vnd.api+json' },
+      { contentType: 'application/problem+json; charset=utf-8' },
+      { contentType: 'model/gltf+json' },
+    ])('returns true for "$contentType"', ({ contentType }) => {
+      // Act & Assess
+      expect(isJsonContentType(contentType)).toBe(true);
+    });
+
+    it.each([
+      { contentType: null },
+      { contentType: undefined },
+      { contentType: '' },
+      { contentType: 'text/plain' },
+      { contentType: 'application/json-ish' },
+      { contentType: 'application/json, text/plain' },
+    ])('returns false for "$contentType"', ({ contentType }) => {
+      // Act & Assess
+      expect(isJsonContentType(contentType)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
Body deserialization in the HTTP event handler only recognized `application/json`, so responses using RFC 6839 structured syntax suffixes (`application/vnd.api+json`, `application/problem+json`) were treated as plain strings and failed schema validation. This adds a shared `isJsonContentType` helper used by both the validation and tracer middleware, and hardens the tracer against bodyless or malformed-JSON responses.
### Changes
- Add `isJsonContentType` to `packages/event-handler/src/http/utils.ts`, matching `application/json` and any `+json` suffix, ignoring parameters and casing
- Use it in `validation.ts` `extractBody` in place of the `contentType?.includes('application/json')` check
- Use it in the tracer middleware's response-metadata capture in place of the strict `=== 'application/json'` equality check
- Skip response metadata capture when the response has no body, avoiding a spurious parse attempt
- Wrap `res.clone().json()` in the tracer with a try/catch that logs a warning instead of throwing when the body isn't valid JSON
- Update the body validation note in `docs/features/event-handler/http.md` to document `+json` support
- Add unit tests for `isJsonContentType`, the tracer's bodyless/invalid-JSON paths, and `+json` response validation 

**Issue number:** closes #5566 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-typescript/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.aws.amazon.com/powertools/typescript/latest/#tenets
- Add a PR title that follows the conventional commit semantics
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
