### PR TITLE
fix(kafka): lazily import Avro and Protobuf codecs so JSON-only consumers bundle

### DIFF
--- a/docs/features/kafka.md
+++ b/docs/features/kafka.md
@@ -66,6 +66,10 @@ Depending on the schema types you want to use, install the library and the corre
 	npm install @aws-lambda-powertools/kafka protobufjs
 	```
 
+`avro-js` and `protobufjs` are declared as optional peer dependencies (`avro-js@^1.12.1`, `protobufjs@^8.7.2`).
+They are only imported when you configure an Avro or Protobuf schema, so a JSON-only consumer bundles without them installed.
+If you already have one of these installed at an incompatible version you may see a peer-dependency warning; align it with the supported range to clear it.
+
 Additionally, if you want to use output parsing with [Standard Schema](https://github.com/standard-schema/standard-schema), you can install [any of the supported libraries](https://standardschema.dev/#what-schema-libraries-implement-the-spec), for example: Zod, Valibot, or ArkType.
 
 ### Required resources

--- a/packages/kafka/package.json
+++ b/packages/kafka/package.json
@@ -53,6 +53,8 @@
   },
   "peerDependencies": {
     "arktype": "^2.2.3",
+    "avro-js": "^1.12.1",
+    "protobufjs": "^8.7.2",
     "valibot": "^1.4.2",
     "zod": "^3.25.0 || ^4.0.0"
   },
@@ -64,6 +66,12 @@
       "optional": true
     },
     "arktype": {
+      "optional": true
+    },
+    "avro-js": {
+      "optional": true
+    },
+    "protobufjs": {
       "optional": true
     }
   },

--- a/packages/kafka/src/consumer.ts
+++ b/packages/kafka/src/consumer.ts
@@ -120,12 +120,12 @@ const getDeserializer = async (type?: string) => {
     return deserializeJson as Deserializer;
   }
   if (type === 'protobuf') {
-    const deserializer = await import('./deserializer/protobuf.js');
-    return deserializer.deserialize as Deserializer;
+    const { createDeserializer } = await import('./deserializer/protobuf.js');
+    return (await createDeserializer()) as Deserializer;
   }
   if (type === 'avro') {
-    const deserializer = await import('./deserializer/avro.js');
-    return deserializer.deserialize as Deserializer;
+    const { createDeserializer } = await import('./deserializer/avro.js');
+    return (await createDeserializer()) as Deserializer;
   }
   throw new KafkaConsumerDeserializationError(
     `Unsupported deserialization type: ${type}. Supported types are: json, avro, protobuf.`

--- a/packages/kafka/src/deserializer/avro.ts
+++ b/packages/kafka/src/deserializer/avro.ts
@@ -1,22 +1,43 @@
-import avro from 'avro-js';
 import { KafkaConsumerDeserializationError } from '../errors.js';
+import type { AvroDeserializer } from '../types/types.js';
+
+let deserializer: AvroDeserializer | undefined;
 
 /**
- * Deserialize an Avro message from a base64-encoded string using the provided Avro schema.
+ * Create an Avro deserializer, importing `avro-js` on first use.
  *
- * @param data - The base64-encoded string representing the Avro binary data.
- * @param schema - The Avro schema as a JSON string.
+ * The `avro-js` dependency is only required when deserializing Avro messages,
+ * so it's resolved at runtime through a non-literal specifier. This keeps
+ * bundlers (e.g. esbuild) from eagerly including `avro-js` - and failing when
+ * it isn't installed - in builds that never use Avro.
  */
-const deserialize = (data: string, schema: string) => {
-  try {
-    const type = avro.parse(schema);
-    const buffer = Buffer.from(data, 'base64');
-    return type.fromBuffer(buffer);
-  } catch (error) {
-    throw new KafkaConsumerDeserializationError(
-      `Failed to deserialize Avro message: ${error}, message: ${data}, schema: ${schema}`
-    );
+const createDeserializer = async (): Promise<AvroDeserializer> => {
+  if (deserializer !== undefined) {
+    return deserializer;
   }
+
+  const moduleName = 'avro-js';
+  const { default: avro }: typeof import('avro-js') = await import(moduleName);
+
+  /**
+   * Deserialize an Avro message from a base64-encoded string using the provided Avro schema.
+   *
+   * @param data - The base64-encoded string representing the Avro binary data.
+   * @param schema - The Avro schema as a JSON string.
+   */
+  deserializer = (data: string, schema: string) => {
+    try {
+      const type = avro.parse(schema);
+      const buffer = Buffer.from(data, 'base64');
+      return type.fromBuffer(buffer);
+    } catch (error) {
+      throw new KafkaConsumerDeserializationError(
+        `Failed to deserialize Avro message: ${error}, message: ${data}, schema: ${schema}`
+      );
+    }
+  };
+
+  return deserializer;
 };
 
-export { deserialize };
+export { createDeserializer };

--- a/packages/kafka/src/deserializer/protobuf.ts
+++ b/packages/kafka/src/deserializer/protobuf.ts
@@ -1,94 +1,124 @@
-import { BufferReader, type Message } from 'protobufjs';
 import { KafkaConsumerDeserializationError } from '../errors.js';
-import type { ProtobufMessage, SchemaMetadata } from '../types/types.js';
+import type {
+  ProtobufDeserializer,
+  ProtobufMessage,
+  SchemaMetadata,
+} from '../types/types.js';
+
+let deserializer: ProtobufDeserializer | undefined;
 
 /**
- * Default order of varint types used in Protobuf to attempt deserializing Confluent Schema Registry messages.
- */
-const varintOrder: Array<'int32' | 'sint32'> = ['int32', 'sint32'];
-
-/**
- * Deserialize a Protobuf message from a base64-encoded string.
+ * Create a Protobuf deserializer, importing `protobufjs` on first use.
  *
- * @template T - The type of the deserialized message object.
- *
- * @param data - The base64-encoded string representing the Protobuf binary data.
- * @param messageType - The Protobuf message type definition - see {@link Message | `Message`} from {@link https://www.npmjs.com/package/protobufjs | `protobufjs`}.
+ * The `protobufjs` dependency is only required when deserializing Protobuf
+ * messages, so it's resolved at runtime through a non-literal specifier. This
+ * keeps bundlers (e.g. esbuild) from eagerly including `protobufjs` - and
+ * failing when it isn't installed - in builds that never use Protobuf. See
+ * {@link https://www.npmjs.com/package/protobufjs | `protobufjs`}.
  */
-const deserialize = <T>(
-  data: string,
-  messageType: ProtobufMessage<T>,
-  schemaMetadata: SchemaMetadata
-): T => {
-  const buffer = Buffer.from(data, 'base64');
-  try {
-    if (schemaMetadata.schemaId === undefined) {
-      return messageType.decode(buffer, buffer.length);
-    }
-    /**
-     * If `schemaId` is longer than 10 chars, it's an UUID, otherwise it's a numeric ID.
-     *
-     * When this is the case, we know the schema is coming from Glue Schema Registry,
-     * and the first byte of the buffer is a magic byte that we need to remove before
-     * decoding the message.
-     */
-    if (schemaMetadata.schemaId.length > 10) {
-      // remove the first byte from the buffer
-      const reader = new BufferReader(buffer);
-      reader.uint32();
-      return messageType.decode(reader);
-    }
-  } catch (error) {
-    throw new KafkaConsumerDeserializationError(
-      `Failed to deserialize Protobuf message: ${error}, message: ${data}, messageType: ${JSON.stringify(messageType)}`
-    );
+const createDeserializer = async (): Promise<ProtobufDeserializer> => {
+  if (deserializer !== undefined) {
+    return deserializer;
   }
 
+  const moduleName = 'protobufjs';
+  const { BufferReader }: typeof import('protobufjs') = await import(
+    moduleName
+  );
+
   /**
-   * If schemaId is numeric, inferred from its length, we know it's coming from Confluent Schema Registry,
-   * so we need to remove the MessageIndex bytes.
-   * We don't know the type of the index, so we try both `int32` and `sint32`. If both fail, we throw an error.
+   * Default order of varint types used in Protobuf to attempt deserializing Confluent Schema Registry messages.
    */
-  try {
-    const newBuffer = clipConfluentSchemaRegistryBuffer(buffer, varintOrder[0]);
-    return messageType.decode(newBuffer);
-  } catch (error) {
+  const varintOrder: Array<'int32' | 'sint32'> = ['int32', 'sint32'];
+
+  /**
+   * Clip the Confluent Schema Registry buffer to remove the index bytes.
+   *
+   * @param buffer - The buffer to clip.
+   * @param intType - The type of the integer to read from the buffer, either 'int32' or 'sint32'.
+   */
+  const clipConfluentSchemaRegistryBuffer = (
+    buffer: Buffer,
+    intType: 'int32' | 'sint32'
+  ) => {
+    const reader = new BufferReader(buffer);
+    /**
+     * Read the first varint byte to get the index count or 0.
+     * Doing so, also advances the reader position to the next byte after the index count.
+     */
+    const indexCount = intType === 'int32' ? reader.int32() : reader.sint32();
+    // Skip the index bytes
+    reader.skip(indexCount);
+    return reader;
+  };
+
+  /**
+   * Deserialize a Protobuf message from a base64-encoded string.
+   *
+   * @template T - The type of the deserialized message object.
+   *
+   * @param data - The base64-encoded string representing the Protobuf binary data.
+   * @param messageType - The Protobuf message type definition - see the `Message` type from {@link https://www.npmjs.com/package/protobufjs | `protobufjs`}.
+   */
+  deserializer = <T>(
+    data: string,
+    messageType: ProtobufMessage<T>,
+    schemaMetadata: SchemaMetadata
+  ): T => {
+    const buffer = Buffer.from(data, 'base64');
     try {
-      const newBuffer = clipConfluentSchemaRegistryBuffer(
-        buffer,
-        varintOrder[1]
-      );
-      const decoded = messageType.decode(newBuffer);
-      // swap varint order if the first attempt failed so we can use the correct one for subsequent messages
-      varintOrder.reverse();
-      return decoded;
-    } catch {
+      if (schemaMetadata.schemaId === undefined) {
+        return messageType.decode(buffer, buffer.length);
+      }
+      /**
+       * If `schemaId` is longer than 10 chars, it's an UUID, otherwise it's a numeric ID.
+       *
+       * When this is the case, we know the schema is coming from Glue Schema Registry,
+       * and the first byte of the buffer is a magic byte that we need to remove before
+       * decoding the message.
+       */
+      if (schemaMetadata.schemaId.length > 10) {
+        // remove the first byte from the buffer
+        const reader = new BufferReader(buffer);
+        reader.uint32();
+        return messageType.decode(reader);
+      }
+    } catch (error) {
       throw new KafkaConsumerDeserializationError(
         `Failed to deserialize Protobuf message: ${error}, message: ${data}, messageType: ${JSON.stringify(messageType)}`
       );
     }
-  }
+
+    /**
+     * If schemaId is numeric, inferred from its length, we know it's coming from Confluent Schema Registry,
+     * so we need to remove the MessageIndex bytes.
+     * We don't know the type of the index, so we try both `int32` and `sint32`. If both fail, we throw an error.
+     */
+    try {
+      const newBuffer = clipConfluentSchemaRegistryBuffer(
+        buffer,
+        varintOrder[0]
+      );
+      return messageType.decode(newBuffer);
+    } catch (error) {
+      try {
+        const newBuffer = clipConfluentSchemaRegistryBuffer(
+          buffer,
+          varintOrder[1]
+        );
+        const decoded = messageType.decode(newBuffer);
+        // swap varint order if the first attempt failed so we can use the correct one for subsequent messages
+        varintOrder.reverse();
+        return decoded;
+      } catch {
+        throw new KafkaConsumerDeserializationError(
+          `Failed to deserialize Protobuf message: ${error}, message: ${data}, messageType: ${JSON.stringify(messageType)}`
+        );
+      }
+    }
+  };
+
+  return deserializer;
 };
 
-/**
- * Clip the Confluent Schema Registry buffer to remove the index bytes.
- *
- * @param buffer - The buffer to clip.
- * @param intType - The type of the integer to read from the buffer, either 'int32' or 'sint32'.
- */
-const clipConfluentSchemaRegistryBuffer = (
-  buffer: Buffer,
-  intType: 'int32' | 'sint32'
-) => {
-  const reader = new BufferReader(buffer);
-  /**
-   * Read the first varint byte to get the index count or 0.
-   * Doing so, also advances the reader position to the next byte after the index count.
-   */
-  const indexCount = intType === 'int32' ? reader.int32() : reader.sint32();
-  // Skip the index bytes
-  reader.skip(indexCount);
-  return reader;
-};
-
-export { deserialize };
+export { createDeserializer };

--- a/packages/kafka/src/types/types.ts
+++ b/packages/kafka/src/types/types.ts
@@ -251,6 +251,14 @@ type Deserializer = (
   schemaMetadata?: SchemaMetadata
 ) => unknown;
 
+type AvroDeserializer = (data: string, schema: string) => unknown;
+
+type ProtobufDeserializer = <T>(
+  data: string,
+  messageType: ProtobufMessage<T>,
+  schemaMetadata: SchemaMetadata
+) => T;
+
 type DeserializeOptions = {
   value: string | null;
   deserializer: Deserializer;
@@ -259,11 +267,13 @@ type DeserializeOptions = {
 };
 
 export type {
+  AvroDeserializer,
   ConsumerRecord,
   ConsumerRecords,
   DeserializeOptions,
   Deserializer,
   MSKEvent,
+  ProtobufDeserializer,
   ProtobufMessage,
   Record,
   RecordHeader,

--- a/packages/kafka/tests/unit/deserializer.avro.test.ts
+++ b/packages/kafka/tests/unit/deserializer.avro.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest';
-import { deserialize } from '../../src/deserializer/avro.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createDeserializer } from '../../src/deserializer/avro.js';
 import { KafkaConsumerDeserializationError } from '../../src/errors.js';
 
 describe('Avro Deserializer: ', () => {
+  let deserialize: Awaited<ReturnType<typeof createDeserializer>>;
+
+  beforeAll(async () => {
+    deserialize = await createDeserializer();
+  });
+
   it('returns avro deserialised value', async () => {
     // Prepare
     const message = '0g8MTGFwdG9wUrgehes/j0A=';

--- a/packages/kafka/tests/unit/deserializer.protobuf.test.ts
+++ b/packages/kafka/tests/unit/deserializer.protobuf.test.ts
@@ -1,11 +1,17 @@
 import type { Message } from 'protobufjs';
-import { describe, expect, it } from 'vitest';
-import { deserialize } from '../../src/deserializer/protobuf.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { createDeserializer } from '../../src/deserializer/protobuf.js';
 import { KafkaConsumerDeserializationError } from '../../src/errors.js';
 import type { ProtobufMessage } from '../../src/types/types.js';
 import { Product } from '../protos/product.generated.js';
 
 describe('Protobuf deserialiser: ', () => {
+  let deserialize: Awaited<ReturnType<typeof createDeserializer>>;
+
+  beforeAll(async () => {
+    deserialize = await createDeserializer();
+  });
+
   it('throws when protobuf serialise fails', () => {
     // Prepare
     const data = 'COkHEgZMYXB0b3AZUrgehes/j0A=';


### PR DESCRIPTION
## Summary

The Kafka consumer used string-literal dynamic imports for the Avro and Protobuf deserializers. Bundlers such as esbuild statically resolve literal dynamic imports and follow their transitive `avro-js`/`protobufjs` imports, so a primitive/JSON-only handler failed to bundle unless both packages were installed — and always shipped both codecs. This change loads each codec lazily through a non-literal specifier so bundlers leave it as a runtime import that only resolves when the format is actually used.

### Changes

- Load `avro-js` and `protobufjs` via a non-literal specifier inside an async `createDeserializer` factory in `src/deserializer/avro.ts` and `src/deserializer/protobuf.ts`, so bundlers don't eagerly resolve them.
- Keep `deserialize` synchronous (it runs inside record getters) and avoid top-level `await`, so the CommonJS build remains valid.
- Update `getDeserializer` in `src/consumer.ts` to await the new factory.
- Add `AvroDeserializer` and `ProtobufDeserializer` type aliases to `src/types/types.ts`.
- Declare `avro-js` (`^1.12.1`) and `protobufjs` (`^8.7.2`) as optional peer dependencies, matching the existing parser peer-dependency pattern; they are not auto-installed, so JSON-only consumers are unaffected.
- Update the Avro/Protobuf deserializer unit tests to obtain `deserialize` from the factory.
- Document the optional peer dependencies and supported versions in `docs/features/kafka.md`.

### Testing

Verified against the `npm pack` tarball (published form, with the optional peer deps), not just the source tree:

- A JSON-only handler now bundles with esbuild when neither `avro-js` nor `protobufjs` is installed — the exact failure from #5557.
- Deployed that bundle to a real `nodejs22.x` Lambda (via a throwaway CloudFormation stack) and invoked it with the sample MSK event: `200`, no error, correctly deserialized `{"name":"Powertools","age":5}`.
- An Avro handler bundles with only `avro-js` installed (not `protobufjs`) and deserializes correctly at runtime via the lazy import; confirmed on Node 24.
- `npm install <tarball>` pulls in neither codec, confirming the optional peer dependencies don't change the install footprint for existing consumers.

**Issue number:** closes #5557

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.