### PR TITLE
docs: fix misspelled 'descrition' front-matter key and a typo

### DIFF
--- a/docs/features/event-handler/appsync-graphql.md
+++ b/docs/features/event-handler/appsync-graphql.md
@@ -89,7 +89,7 @@ If you prefer to use the decorator syntax, you can instead use the same methods 
 --8<-- "examples/snippets/event-handler/appsync-graphql/gettingStartedDecorators.ts"
 ```
 
-1. It's recommended to pass a refernce of `this` to ensure the correct class scope is propageted to the route handler functions.
+1. It's recommended to pass a reference of `this` to ensure the correct class scope is propageted to the route handler functions.
 
 ### Scalar functions
 

--- a/docs/features/parser.md
+++ b/docs/features/parser.md
@@ -1,6 +1,6 @@
 ---
 title: Parser (Standard Schema)
-descrition: Utility
+description: Utility
 ---
 
 <!-- markdownlint-disable MD043 --->

--- a/docs/features/signer.md
+++ b/docs/features/signer.md
@@ -1,6 +1,6 @@
 ---
 title: Signer
-descrition: Utility
+description: Utility
 ---
 
 <!-- markdownlint-disable MD043 --->

--- a/docs/features/validation.md
+++ b/docs/features/validation.md
@@ -1,6 +1,6 @@
 ---
 title: Validation
-descrition: Utility
+description: Utility
 ---
 
 <!-- markdownlint-disable MD043 --->


### PR DESCRIPTION
## Summary

### Changes

Three feature docs pages open with a misspelled front-matter **key**:

```yaml
---
title: Parser
descrition: Utility
---
```

`descrition` is not a key MkDocs recognises, and every other feature page uses `description:` — `logger.md`, `tracer.md` and `metrics.md` all read `description: Core utility`.

The effect is not cosmetic. Because the key never resolves, `docs/features/parser.md`, `docs/features/signer.md` and `docs/features/validation.md` are published with **no description metadata at all**, so `<meta name="description">` falls back to the site default. That is what search engines and link previews read, so those three pages are less discoverable than their siblings.

This corrects the key to `description:` on all three, leaving the values untouched.

It also fixes a plain prose typo in `docs/features/event-handler/appsync-graphql.md` line 92: "It's recommended to pass a refernce" → `reference`.

Docs only — no source, tests or public API are touched.

> Please add the issue number below, if no issue is present the PR might get blocked and not be reviewed

**Issue number:** closes #5583

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
