### PR TITLE
chore(deps): pin vitest and @vitest/coverage-v8 to exact versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@biomejs/biome": "^2.5.8",
         "@types/aws-lambda": "^8.10.162",
         "@types/node": "^26.2.0",
-        "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
         "esbuild": "^0.28.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.3.0",
@@ -44,7 +44,7 @@
         "typedoc-plugin-missing-exports": "^4.1.4",
         "typescript": "^6.0.3",
         "undici-types": "^8.10.0",
-        "vitest": "^4.1.2"
+        "vitest": "4.1.10"
       },
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@biomejs/biome": "^2.5.8",
     "@types/aws-lambda": "^8.10.162",
     "@types/node": "^26.2.0",
-    "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/coverage-v8": "4.1.10",
     "esbuild": "^0.28.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",
@@ -67,7 +67,7 @@
     "typedoc-plugin-missing-exports": "^4.1.4",
     "typescript": "^6.0.3",
     "undici-types": "^8.10.0",
-    "vitest": "^4.1.2"
+    "vitest": "4.1.10"
   },
   "lint-staged": {
     "*.{js,ts,json}": "biome check --write --no-errors-on-unmatched",


### PR DESCRIPTION
## Summary

`vitest` and `@vitest/coverage-v8` had drifted apart in the root `package.json` (`vitest` stuck at `^4.1.2`, `@vitest/coverage-v8` at `^4.1.10`). They last moved together in #5140 and split at #5171. The cause is the caret ranges: `@vitest/coverage-v8` pins `vitest` as an exact peer, so bumping coverage-v8 drags vitest forward in the lockfile without a manifest change, and dependabot's `increase` strategy never rewrites vitest's already-satisfied caret. Pinning both to an exact version forces dependabot to rewrite both requirements on every release, keeping them in lockstep in the manifest — not just the lockfile.

### Changes

- Pin `@vitest/coverage-v8` from `^4.1.10` to `4.1.10` in the root `package.json`
- Pin `vitest` from `^4.1.2` to `4.1.10` in the root `package.json`
- Sync `package-lock.json` to the exact requirements

**Issue number:** closes #5584

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.