### PR TITLE
chore(maintenance): move dev tooling to devDependencies in private workspaces

### DIFF
--- a/examples/app/package.json
+++ b/examples/app/package.json
@@ -33,6 +33,7 @@
     "@types/node": "26.3.0",
     "aws-cdk-lib": "^2.266.0",
     "constructs": "^10.8.1",
+    "esbuild": "^0.28.2",
     "source-map-support": "^0.5.21",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"
@@ -47,11 +48,7 @@
     "@aws-sdk/client-ssm": "^3.1116.0",
     "@aws-sdk/lib-dynamodb": "^3.1116.0",
     "@middy/core": "^4.7.0",
-    "@types/aws-lambda": "^8.10.162",
-    "@types/node": "26.3.0",
     "aws-cdk": "^2.1138.0",
-    "constructs": "^10.8.1",
-    "esbuild": "^0.28.2",
-    "typescript": "^6.0.3"
+    "constructs": "^10.8.1"
   }
 }

--- a/layers/package.json
+++ b/layers/package.json
@@ -38,11 +38,11 @@
   "homepage": "https://github.com/aws-powertools/powertools-lambda-typescript#readme",
   "devDependencies": {
     "@aws-lambda-powertools/testing-utils": "file:../packages/testing",
+    "esbuild": "^0.28.2",
     "source-map-support": "^0.5.21"
   },
   "dependencies": {
     "aws-cdk": "^2.1138.0",
-    "aws-cdk-lib": "^2.266.0",
-    "esbuild": "^0.28.2"
+    "aws-cdk-lib": "^2.266.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,18 +64,15 @@
         "@aws-sdk/client-ssm": "^3.1116.0",
         "@aws-sdk/lib-dynamodb": "^3.1116.0",
         "@middy/core": "^4.7.0",
-        "@types/aws-lambda": "^8.10.162",
-        "@types/node": "26.3.0",
         "aws-cdk": "^2.1138.0",
-        "constructs": "^10.8.1",
-        "esbuild": "^0.28.2",
-        "typescript": "^6.0.3"
+        "constructs": "^10.8.1"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.162",
         "@types/node": "26.3.0",
         "aws-cdk-lib": "^2.266.0",
         "constructs": "^10.8.1",
+        "esbuild": "^0.28.2",
         "source-map-support": "^0.5.21",
         "typescript": "^6.0.3",
         "vitest": "^4.1.11"
@@ -118,14 +115,14 @@
       "license": "MIT-0",
       "dependencies": {
         "aws-cdk": "^2.1138.0",
-        "aws-cdk-lib": "^2.266.0",
-        "esbuild": "^0.28.2"
+        "aws-cdk-lib": "^2.266.0"
       },
       "bin": {
         "layer": "bin/layers.js"
       },
       "devDependencies": {
         "@aws-lambda-powertools/testing-utils": "file:../packages/testing",
+        "esbuild": "^0.28.2",
         "source-map-support": "^0.5.21"
       }
     },
@@ -2172,6 +2169,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2188,6 +2186,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2204,6 +2203,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,6 +2220,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2236,6 +2237,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2252,6 +2254,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2268,6 +2271,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,6 +2288,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2300,6 +2305,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2316,6 +2322,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2332,6 +2339,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2348,6 +2356,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,6 +2373,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2380,6 +2390,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2396,6 +2407,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2412,6 +2424,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2428,6 +2441,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2444,6 +2458,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,6 +2475,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2476,6 +2492,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2492,6 +2509,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2508,6 +2526,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2524,6 +2543,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2540,6 +2560,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2556,6 +2577,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2572,6 +2594,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5008,6 +5031,7 @@
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
       "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8741,12 +8765,12 @@
         "@aws/lambda-invoke-store": "0.3.0",
         "@smithy/util-utf8": "^4.5.2",
         "aws-cdk-lib": "^2.266.0",
-        "esbuild": "^0.28.2",
         "promise-retry": "^2.0.1"
       },
       "devDependencies": {
         "@types/promise-retry": "^1.1.6",
-        "aws-sdk-client-mock-vitest": "^7.1.0"
+        "aws-sdk-client-mock-vitest": "^7.1.0",
+        "esbuild": "^0.28.2"
       }
     },
     "packages/tracer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2169,7 +2169,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,7 +2185,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,7 +2201,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2220,7 +2217,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2237,7 +2233,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2254,7 +2249,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,7 +2265,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2288,7 +2281,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2305,7 +2297,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,7 +2313,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,7 +2329,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,7 +2345,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2373,7 +2361,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2390,7 +2377,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2407,7 +2393,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2424,7 +2409,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,7 +2425,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2458,7 +2441,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,7 +2457,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2492,7 +2473,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2509,7 +2489,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2526,7 +2505,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,7 +2521,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2560,7 +2537,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,7 +2553,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2594,7 +2569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5031,7 +5005,6 @@
       "version": "0.28.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
       "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8765,12 +8738,12 @@
         "@aws/lambda-invoke-store": "0.3.0",
         "@smithy/util-utf8": "^4.5.2",
         "aws-cdk-lib": "^2.266.0",
+        "esbuild": "^0.28.2",
         "promise-retry": "^2.0.1"
       },
       "devDependencies": {
         "@types/promise-retry": "^1.1.6",
-        "aws-sdk-client-mock-vitest": "^7.1.0",
-        "esbuild": "^0.28.2"
+        "aws-sdk-client-mock-vitest": "^7.1.0"
       }
     },
     "packages/tracer": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -105,11 +105,11 @@
     "@aws/lambda-invoke-store": "0.3.0",
     "@smithy/util-utf8": "^4.5.2",
     "aws-cdk-lib": "^2.266.0",
+    "esbuild": "^0.28.2",
     "promise-retry": "^2.0.1"
   },
   "devDependencies": {
     "@types/promise-retry": "^1.1.6",
-    "aws-sdk-client-mock-vitest": "^7.1.0",
-    "esbuild": "^0.28.2"
+    "aws-sdk-client-mock-vitest": "^7.1.0"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -105,11 +105,11 @@
     "@aws/lambda-invoke-store": "0.3.0",
     "@smithy/util-utf8": "^4.5.2",
     "aws-cdk-lib": "^2.266.0",
-    "esbuild": "^0.28.2",
     "promise-retry": "^2.0.1"
   },
   "devDependencies": {
     "@types/promise-retry": "^1.1.6",
-    "aws-sdk-client-mock-vitest": "^7.1.0"
+    "aws-sdk-client-mock-vitest": "^7.1.0",
+    "esbuild": "^0.28.2"
   }
 }


### PR DESCRIPTION
## Summary

A couple of private workspaces declared build/test tooling (`esbuild`, `typescript`, `@types/*`) under `dependencies` instead of `devDependencies`. Dependabot classifies updates as production or development based on where a package is declared across the repo, so these misplacements caused routine tooling bumps to be labelled as production dependencies and excluded from the dev-dependency auto-merge workflow. Both workspaces are private and never published to npm, so the change has no effect on anything we ship.

### Changes

- `examples/app`: remove `@types/node`, `@types/aws-lambda`, and `typescript` from `dependencies` (they were already duplicated in `devDependencies`), and move `esbuild` to `devDependencies`
- `layers`: move `esbuild` to `devDependencies`
- Update `package-lock.json` so the workspace declarations and `dev` flags reflect the moves; all resolved versions stay at main's pins

`packages/testing` keeps `esbuild` as a production dependency — it backs the `NodejsFunction` L3 construct the package provides, so it's production as far as this package is concerned (see review discussion).

**Issue number:** closes #5593

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.