### PR TITLE
chore(tests): add scheduled sweeper for leaked e2e infrastructure

### DIFF
--- a/.github/scripts/report_e2e_sweep.js
+++ b/.github/scripts/report_e2e_sweep.js
@@ -1,0 +1,122 @@
+const INCIDENT_LABEL = 'e2e-sweeper';
+const AUTOMATION_LABEL = 'automation';
+const INCIDENT_TITLE = 'E2E stale stack cleanup failing';
+
+const ensureLabel = async ({ github, owner, repo, name, color }) => {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name });
+  } catch (error) {
+    if (error.status !== 404) throw error;
+    await github.rest.issues.createLabel({ owner, repo, name, color });
+  }
+};
+
+const findIncident = async ({ github, owner, repo }) => {
+  const { data: issues } = await github.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: 'open',
+    labels: INCIDENT_LABEL,
+    per_page: 100,
+  });
+
+  return issues.find(
+    (issue) =>
+      issue.title === INCIDENT_TITLE && issue.pull_request === undefined
+  );
+};
+
+const formatSection = (title, items, format) => {
+  if (items.length === 0) return `### ${title}\n\n_None_`;
+  return `### ${title}\n\n${items.map((item) => `- ${format(item)}`).join('\n')}`;
+};
+
+const formatReport = ({ report, runUrl }) =>
+  [
+    `Automated E2E stale stack cleanup reported a problem at ${report.timestamp}.`,
+    formatSection(
+      'Candidates',
+      report.candidates,
+      (item) =>
+        `\`${item.stackName}\` — ${item.status}; ${item.ageHours} hours old; reason: ${item.reason}`
+    ),
+    formatSection('Deleted', report.deleted, (name) => `\`${name}\``),
+    formatSection(
+      'Skipped in progress',
+      report.skippedInProgress,
+      (item) => `\`${item.stackName}\` — ${item.status}`
+    ),
+    formatSection(
+      'Unresolved',
+      report.unresolved,
+      (item) => `\`${item.stackName}\` — ${item.status}; reason: ${item.reason}`
+    ),
+    `Discovery failed: **${report.discoveryFailed ? 'yes' : 'no'}**`,
+    `[View workflow run](${runUrl})`,
+  ].join('\n\n');
+
+module.exports = async ({ github, context, core, report }) => {
+  const { owner, repo } = context.repo;
+  const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+  const isOk =
+    report.unresolved.length === 0 &&
+    report.skippedInProgress.length === 0 &&
+    report.discoveryFailed === false;
+
+  await ensureLabel({
+    github,
+    owner,
+    repo,
+    name: INCIDENT_LABEL,
+    color: 'b60205',
+  });
+  await ensureLabel({
+    github,
+    owner,
+    repo,
+    name: AUTOMATION_LABEL,
+    color: '0e8a16',
+  });
+
+  const incident = await findIncident({ github, owner, repo });
+
+  if (!isOk) {
+    const body = formatReport({ report, runUrl });
+    if (incident === undefined) {
+      const { data: issue } = await github.rest.issues.create({
+        owner,
+        repo,
+        title: INCIDENT_TITLE,
+        body,
+        labels: [INCIDENT_LABEL, AUTOMATION_LABEL],
+      });
+      core.info(`Created incident issue #${issue.number}`);
+      return;
+    }
+
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: incident.number,
+      body,
+    });
+    core.info(`Updated incident issue #${incident.number}`);
+    return;
+  }
+
+  if (incident !== undefined) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: incident.number,
+      body: `The E2E test account is clean. [View workflow run](${runUrl}).`,
+    });
+    await github.rest.issues.update({
+      owner,
+      repo,
+      issue_number: incident.number,
+      state: 'closed',
+    });
+    core.info(`Closed incident issue #${incident.number}`);
+  }
+};

--- a/.github/scripts/report_e2e_sweep.js
+++ b/.github/scripts/report_e2e_sweep.js
@@ -1,35 +1,13 @@
-const INCIDENT_LABEL = 'e2e-sweeper';
-const AUTOMATION_LABEL = 'automation';
 const INCIDENT_TITLE = 'E2E stale stack cleanup failing';
 const MAX_SECTION_ENTRIES = 50;
 const MAX_BODY_LENGTH = 60_000;
 
-/** Ensure an issue label exists, tolerating concurrent creation. */
-const ensureLabel = async ({ github, owner, repo, name, color }) => {
-  try {
-    await github.rest.issues.getLabel({ owner, repo, name });
-  } catch (error) {
-    if (error.status !== 404) throw error;
-    try {
-      await github.rest.issues.createLabel({ owner, repo, name, color });
-    } catch (createError) {
-      const alreadyExists =
-        createError.status === 422 ||
-        createError.response?.data?.errors?.some(
-          (labelError) => labelError.code === 'already_exists'
-        );
-      if (!alreadyExists) throw createError;
-    }
-  }
-};
-
-/** Find the open incident issue managed by the sweeper. */
+/** Find the open incident issue by its exact title. */
 const findIncident = async ({ github, owner, repo }) => {
   const { data: issues } = await github.rest.issues.listForRepo({
     owner,
     repo,
     state: 'open',
-    labels: INCIDENT_LABEL,
     per_page: 100,
   });
 
@@ -87,68 +65,35 @@ const formatReport = ({ report, runUrl }) => {
   return `${body.slice(0, MAX_BODY_LENGTH - suffix.length)}${suffix}`;
 };
 
-/** Create, update, or close the stale-stack incident issue. */
+/** Create or update the stale-stack incident issue after a failed sweep. */
 const reportE2eSweep = async ({ github, context, core, report }) => {
   const { owner, repo } = context.repo;
   const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-  const isOk = report.ok === true;
-
-  await ensureLabel({
-    github,
-    owner,
-    repo,
-    name: INCIDENT_LABEL,
-    color: 'b60205',
-  });
-  await ensureLabel({
-    github,
-    owner,
-    repo,
-    name: AUTOMATION_LABEL,
-    color: '0e8a16',
-  });
-
-  const incident = await findIncident({ github, owner, repo });
-
-  if (!isOk) {
-    const body = formatReport({ report, runUrl });
-    if (incident === undefined) {
-      const { data: issue } = await github.rest.issues.create({
-        owner,
-        repo,
-        title: INCIDENT_TITLE,
-        body,
-        labels: [INCIDENT_LABEL, AUTOMATION_LABEL],
-      });
-      core.info(`Created incident issue #${issue.number}`);
-      return;
-    }
-
-    await github.rest.issues.createComment({
-      owner,
-      repo,
-      issue_number: incident.number,
-      body,
-    });
-    core.info(`Updated incident issue #${incident.number}`);
+  if (report.ok === true) {
+    core.info('Sweep completed without an incident');
     return;
   }
 
-  if (incident !== undefined) {
-    await github.rest.issues.createComment({
+  const incident = await findIncident({ github, owner, repo });
+  const body = formatReport({ report, runUrl });
+  if (incident === undefined) {
+    const { data: issue } = await github.rest.issues.create({
       owner,
       repo,
-      issue_number: incident.number,
-      body: `The E2E test account is clean. [View workflow run](${runUrl}).`,
+      title: INCIDENT_TITLE,
+      body,
     });
-    await github.rest.issues.update({
-      owner,
-      repo,
-      issue_number: incident.number,
-      state: 'closed',
-    });
-    core.info(`Closed incident issue #${incident.number}`);
+    core.info(`Created incident issue #${issue.number}`);
+    return;
   }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: incident.number,
+    body,
+  });
+  core.info(`Updated incident issue #${incident.number}`);
 };
 
 module.exports = reportE2eSweep;

--- a/.github/scripts/report_e2e_sweep.js
+++ b/.github/scripts/report_e2e_sweep.js
@@ -1,16 +1,29 @@
 const INCIDENT_LABEL = 'e2e-sweeper';
 const AUTOMATION_LABEL = 'automation';
 const INCIDENT_TITLE = 'E2E stale stack cleanup failing';
+const MAX_SECTION_ENTRIES = 50;
+const MAX_BODY_LENGTH = 60_000;
 
+/** Ensure an issue label exists, tolerating concurrent creation. */
 const ensureLabel = async ({ github, owner, repo, name, color }) => {
   try {
     await github.rest.issues.getLabel({ owner, repo, name });
   } catch (error) {
     if (error.status !== 404) throw error;
-    await github.rest.issues.createLabel({ owner, repo, name, color });
+    try {
+      await github.rest.issues.createLabel({ owner, repo, name, color });
+    } catch (createError) {
+      const alreadyExists =
+        createError.status === 422 ||
+        createError.response?.data?.errors?.some(
+          (labelError) => labelError.code === 'already_exists'
+        );
+      if (!alreadyExists) throw createError;
+    }
   }
 };
 
+/** Find the open incident issue managed by the sweeper. */
 const findIncident = async ({ github, owner, repo }) => {
   const { data: issues } = await github.rest.issues.listForRepo({
     owner,
@@ -26,42 +39,59 @@ const findIncident = async ({ github, owner, repo }) => {
   );
 };
 
-const formatSection = (title, items, format) => {
+/** Render one bounded report section as Markdown. */
+const formatSection = (title, items, format, runUrl) => {
   if (items.length === 0) return `### ${title}\n\n_None_`;
-  return `### ${title}\n\n${items.map((item) => `- ${format(item)}`).join('\n')}`;
+  const visibleItems = items.slice(0, MAX_SECTION_ENTRIES);
+  const lines = visibleItems.map((item) => `- ${format(item)}`);
+  const hiddenCount = items.length - visibleItems.length;
+  if (hiddenCount > 0) {
+    lines.push(
+      `- …and ${hiddenCount} more — see the [workflow run](${runUrl})`
+    );
+  }
+  return `### ${title}\n\n${lines.join('\n')}`;
 };
 
-const formatReport = ({ report, runUrl }) =>
-  [
-    `Automated E2E stale stack cleanup reported a problem at ${report.timestamp}.`,
+/** Render a bounded sweep report for job summaries and incident issues. */
+const formatReport = ({ report, runUrl }) => {
+  const body = [
+    '# E2E stale stack sweep',
+    `- Mode: **${report.dryRun ? 'dry run' : 'cleanup'}**\n- Timestamp: ${report.timestamp}\n- Discovery failed: ${report.discoveryFailed ? 'yes' : 'no'}`,
     formatSection(
       'Candidates',
       report.candidates,
       (item) =>
-        `\`${item.stackName}\` — ${item.status}; ${item.ageHours} hours old; reason: ${item.reason}`
+        `\`${item.stackName}\` — ${item.status}; ${item.ageHours} hours old; reason: ${item.reason}`,
+      runUrl
     ),
-    formatSection('Deleted', report.deleted, (name) => `\`${name}\``),
+    formatSection('Deleted', report.deleted, (name) => `\`${name}\``, runUrl),
     formatSection(
       'Skipped in progress',
       report.skippedInProgress,
-      (item) => `\`${item.stackName}\` — ${item.status}`
+      (item) => `\`${item.stackName}\` — ${item.status}`,
+      runUrl
     ),
     formatSection(
       'Unresolved',
       report.unresolved,
-      (item) => `\`${item.stackName}\` — ${item.status}; reason: ${item.reason}`
+      (item) =>
+        `\`${item.stackName}\` — ${item.status}; reason: ${item.reason}`,
+      runUrl
     ),
-    `Discovery failed: **${report.discoveryFailed ? 'yes' : 'no'}**`,
     `[View workflow run](${runUrl})`,
   ].join('\n\n');
 
-module.exports = async ({ github, context, core, report }) => {
+  if (body.length <= MAX_BODY_LENGTH) return body;
+  const suffix = `\n\n_Report truncated — see the [workflow run](${runUrl})._`;
+  return `${body.slice(0, MAX_BODY_LENGTH - suffix.length)}${suffix}`;
+};
+
+/** Create, update, or close the stale-stack incident issue. */
+const reportE2eSweep = async ({ github, context, core, report }) => {
   const { owner, repo } = context.repo;
   const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
-  const isOk =
-    report.unresolved.length === 0 &&
-    report.skippedInProgress.length === 0 &&
-    report.discoveryFailed === false;
+  const isOk = report.ok === true;
 
   await ensureLabel({
     github,
@@ -120,3 +150,6 @@ module.exports = async ({ github, context, core, report }) => {
     core.info(`Closed incident issue #${incident.number}`);
   }
 };
+
+module.exports = reportE2eSweep;
+module.exports.formatReport = formatReport;

--- a/.github/workflows/sweep-stale-e2e-stacks.yml
+++ b/.github/workflows/sweep-stale-e2e-stacks.yml
@@ -1,5 +1,27 @@
 name: Sweep stale e2e stacks
 
+# STALE E2E STACK SWEEPER
+#
+# Nightly safety net for issue #5519. Deletes leaked e2e CloudFormation stacks
+# older than 12 hours when selected by either:
+# - the exact `Service=Powertools-for-AWS-e2e-tests` tag
+# - an `LmiShared-*` stack name
+#
+# Triggers:
+# - Nightly cron at 02:00 UTC; always performs a real cleanup run.
+# - Manual `workflow_dispatch`; `dry_run` defaults to true. Dry runs only
+#   discover stacks and write a job summary, deleting nothing and creating no issue.
+#
+# Failure behavior:
+# - When stacks remain unresolved after two dependency-ordered passes, the notify
+#   job creates or comments on a single incident issue, deduplicated by exact title,
+#   and the run fails.
+# - The incident stays open until a maintainer closes it.
+#
+# Authentication:
+# - Assumes the E2E OIDC role via the `e2e-tests` environment in eu-west-1;
+#   requires no standing infrastructure.
+
 on:
   schedule:
     - cron: '0 2 * * *'

--- a/.github/workflows/sweep-stale-e2e-stacks.yml
+++ b/.github/workflows/sweep-stale-e2e-stacks.yml
@@ -1,0 +1,142 @@
+name: Sweep stale e2e stacks
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Discover stale stacks without deleting them
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: e2e-tests
+    permissions:
+      id-token: write # needed to interact with GitHub's OIDC Token endpoint.
+      contents: read
+    outputs:
+      dry_run: ${{ steps.mode.outputs.dry_run }}
+      report: ${{ steps.report.outputs.report }}
+      sweep_outcome: ${{ steps.sweep.outcome }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+      - name: Setup dependencies
+        uses: aws-powertools/actions/.github/actions/cached-node-modules@3b5b8e2e58b7af07994be982e83584a94e8c76c5 # v1.5.0
+        with:
+          node-version: 24
+      - name: Setup AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.E2E_IAM_ROLE_ARN }}
+          aws-region: eu-west-1
+          mask-aws-account-id: true
+      - name: Build
+        run: npm run build
+      - name: Select sweep mode
+        id: mode
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs['dry-run'] == true }}
+        run: echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
+      - name: Sweep stale stacks
+        id: sweep
+        continue-on-error: true
+        env:
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+        run: npm run --silent e2e:sweep -w packages/testing > "$RUNNER_TEMP/report.json"
+      - name: Record report
+        id: report
+        if: always()
+        run: |
+          report=$(node -e '
+            const fs = require("node:fs");
+            const path = process.env.REPORT_PATH;
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync(path, "utf8"));
+            } catch {
+              report = {
+                dryRun: process.env.DRY_RUN === "true",
+                timestamp: new Date().toISOString(),
+                candidates: [],
+                deleted: [],
+                skippedInProgress: [],
+                unresolved: [],
+                discoveryFailed: true,
+                ok: false,
+              };
+            }
+            process.stdout.write(JSON.stringify(report));
+          ')
+          echo "report=$report" >> "$GITHUB_OUTPUT"
+        env:
+          REPORT_PATH: ${{ runner.temp }}/report.json
+          DRY_RUN: ${{ steps.mode.outputs.dry_run }}
+      - name: Add sweep summary
+        if: always()
+        env:
+          REPORT_JSON: ${{ steps.report.outputs.report }}
+        run: |
+          node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const report = JSON.parse(process.env.REPORT_JSON);
+          const section = (title, items, format) => {
+            console.log(`## ${title} (${items.length})\n`);
+            if (items.length === 0) {
+              console.log('_None_\n');
+              return;
+            }
+            for (const item of items) console.log(`- ${format(item)}`);
+            console.log();
+          };
+
+          console.log('# E2E stale stack sweep');
+          console.log(`\n- Mode: **${report.dryRun ? 'dry run' : 'cleanup'}**`);
+          console.log(`- Timestamp: ${report.timestamp}`);
+          console.log(`- Discovery failed: ${report.discoveryFailed ? 'yes' : 'no'}\n`);
+          section('Candidates', report.candidates, (item) =>
+            `\`${item.stackName}\` — ${item.status}, ${item.ageHours} hours old (${item.reason})`
+          );
+          section('Deleted', report.deleted, (name) => `\`${name}\``);
+          section('Skipped in progress', report.skippedInProgress, (item) =>
+            `\`${item.stackName}\` — ${item.status}`
+          );
+          section('Unresolved', report.unresolved, (item) =>
+            `\`${item.stackName}\` — ${item.status}: ${item.reason}`
+          );
+          NODE
+
+  notify:
+    needs: sweep
+    if: always() && needs.sweep.outputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Report sweep status
+        id: notification
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPORT_JSON: ${{ needs.sweep.outputs.report }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const report_e2e_sweep = require('./.github/scripts/report_e2e_sweep.js')
+            await report_e2e_sweep({github, context, core, report: JSON.parse(process.env.REPORT_JSON)})
+      - name: Fail after unsuccessful cleanup
+        if: always() && (needs.sweep.outputs.sweep_outcome != 'success' || steps.notification.outcome != 'success')
+        run: exit 1

--- a/.github/workflows/sweep-stale-e2e-stacks.yml
+++ b/.github/workflows/sweep-stale-e2e-stacks.yml
@@ -5,13 +5,17 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
-      dry-run:
+      dry_run:
         description: Discover stale stacks without deleting them
         type: boolean
         default: true
 
 permissions:
   contents: read
+
+concurrency:
+  group: sweep-stale-e2e-stacks
+  cancel-in-progress: false
 
 jobs:
   sweep:
@@ -42,12 +46,10 @@ jobs:
           role-to-assume: ${{ secrets.E2E_IAM_ROLE_ARN }}
           aws-region: eu-west-1
           mask-aws-account-id: true
-      - name: Build
-        run: npm run build
       - name: Select sweep mode
         id: mode
         env:
-          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs['dry-run'] == true }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run != false }}
         run: echo "dry_run=$DRY_RUN" >> "$GITHUB_OUTPUT"
       - name: Sweep stale stacks
         id: sweep
@@ -89,32 +91,14 @@ jobs:
           REPORT_JSON: ${{ steps.report.outputs.report }}
         run: |
           node <<'NODE' >> "$GITHUB_STEP_SUMMARY"
+          const { formatReport } = require('./.github/scripts/report_e2e_sweep.js');
           const report = JSON.parse(process.env.REPORT_JSON);
-          const section = (title, items, format) => {
-            console.log(`## ${title} (${items.length})\n`);
-            if (items.length === 0) {
-              console.log('_None_\n');
-              return;
-            }
-            for (const item of items) console.log(`- ${format(item)}`);
-            console.log();
-          };
-
-          console.log('# E2E stale stack sweep');
-          console.log(`\n- Mode: **${report.dryRun ? 'dry run' : 'cleanup'}**`);
-          console.log(`- Timestamp: ${report.timestamp}`);
-          console.log(`- Discovery failed: ${report.discoveryFailed ? 'yes' : 'no'}\n`);
-          section('Candidates', report.candidates, (item) =>
-            `\`${item.stackName}\` — ${item.status}, ${item.ageHours} hours old (${item.reason})`
-          );
-          section('Deleted', report.deleted, (name) => `\`${name}\``);
-          section('Skipped in progress', report.skippedInProgress, (item) =>
-            `\`${item.stackName}\` — ${item.status}`
-          );
-          section('Unresolved', report.unresolved, (item) =>
-            `\`${item.stackName}\` — ${item.status}: ${item.reason}`
-          );
+          const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+          console.log(formatReport({ report, runUrl }));
           NODE
+      - name: Fail after unsuccessful dry run
+        if: always() && steps.mode.outputs.dry_run == 'true' && steps.sweep.outcome != 'success'
+        run: exit 1
 
   notify:
     needs: sweep

--- a/package-lock.json
+++ b/package-lock.json
@@ -8747,6 +8747,7 @@
       },
       "devDependencies": {
         "@types/promise-retry": "^1.1.6",
+        "aws-sdk-client-mock": "^4.1.0",
         "aws-sdk-client-mock-vitest": "^7.1.0"
       }
     },

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -130,6 +130,7 @@
   },
   "devDependencies": {
     "@types/promise-retry": "^1.1.6",
+    "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-vitest": "^7.1.0"
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "echo 'Not implemented'",
     "lmi:deploy": "node lib/esm/lmi/deploySharedCapacityProvider.js",
     "lmi:destroy": "node lib/esm/lmi/destroySharedCapacityProvider.js",
+    "e2e:sweep": "node lib/esm/e2e/sweepStaleStacksCli.js",
     "build:cjs": "tsc --build tsconfig.cjs.json && echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
     "build:esm": "tsc --build tsconfig.json && echo '{ \"type\": \"module\" }' > lib/esm/package.json",
     "build:tests": "tsc --noEmit -p tests/tsconfig.json",

--- a/packages/testing/src/TestStack.ts
+++ b/packages/testing/src/TestStack.ts
@@ -7,7 +7,7 @@ import {
   StackSelectionStrategy,
   Toolkit,
 } from '@aws-cdk/toolkit-lib';
-import { App, Stack } from 'aws-cdk-lib';
+import { App, Stack, Tags } from 'aws-cdk-lib';
 import { generateTestUniqueName } from './helpers.js';
 import type { TestStackProps } from './types.js';
 
@@ -68,13 +68,8 @@ class TestStack {
       testPrefix: stackNameProps.stackNamePrefix,
     });
     this.app = app ?? new App();
-    this.stack =
-      stack ??
-      new Stack(this.app, this.testName, {
-        tags: {
-          Service: 'Powertools-for-AWS-e2e-tests',
-        },
-      });
+    this.stack = stack ?? new Stack(this.app, this.testName);
+    Tags.of(this.stack).add('Service', 'Powertools-for-AWS-e2e-tests');
     let lastCreateLog = 0;
     let lastDestroyLog = 0;
     const creationDeleteLogFrequency = 10000; // 10 seconds

--- a/packages/testing/src/e2e/sweepStaleStacks.ts
+++ b/packages/testing/src/e2e/sweepStaleStacks.ts
@@ -2,6 +2,7 @@ import {
   CloudFormationClient,
   DeleteStackCommand,
   DescribeStacksCommand,
+  paginateDescribeStacks,
   type Stack,
   type StackStatus,
   waitUntilStackDeleteComplete,
@@ -339,7 +340,8 @@ const selectCandidate = (
  * `DescribeStacks` is used rather than `ListStacks` because it returns `Tags`,
  * `CreationTime`, `RootId` and `StackId` in the same response, so selection
  * needs no per-stack follow-up call — which both halves the API calls and
- * removes the window in which a stack could change underneath us.
+ * removes the window in which a stack could change underneath us. The SDK
+ * paginator walks the pages, so no token bookkeeping is needed here.
  *
  * Any error propagates: discovery is all-or-nothing, because deleting from a
  * half-built candidate list could delete a shared stack while the function
@@ -354,19 +356,14 @@ const discoverStaleStacks = async (
   now: number
 ): Promise<StaleStackCandidate[]> => {
   const candidates: StaleStackCandidate[] = [];
-  let nextToken: string | undefined;
-  do {
-    const page = await client.send(
-      new DescribeStacksCommand({ NextToken: nextToken })
-    );
+  for await (const page of paginateDescribeStacks({ client }, {})) {
     for (const stack of page.Stacks ?? []) {
       const candidate = selectCandidate(stack, now);
       if (candidate) {
         candidates.push(candidate);
       }
     }
-    nextToken = page.NextToken;
-  } while (nextToken);
+  }
 
   // Sorted so the report reads the same way for the same account state.
   return candidates.sort((a, b) => a.stackName.localeCompare(b.stackName));
@@ -735,42 +732,38 @@ const sweepStaleStacks = async ({
 
   const deleted = new Set<string>();
   const unresolved = new Map<string, SweepReport['unresolved'][number]>();
-  const markUnresolved = (
-    { stackName, status }: StaleStackCandidate,
-    reason: string
-  ): void => {
-    unresolved.set(stackName, { stackName, status, reason });
-  };
 
   const failed: StaleStackCandidate[] = [];
-  for (const outcome of await runDeletionPass(
+  for (const { candidate, state, failureReason } of await runDeletionPass(
     client,
     deletable,
     waiter,
     budget,
     log
   )) {
-    if (outcome.state === 'deleted') {
-      deleted.add(outcome.candidate.stackName);
+    if (state === 'deleted') {
+      deleted.add(candidate.stackName);
       continue;
     }
-    if (outcome.state === 'out-of-time') {
-      markUnresolved(
-        outcome.candidate,
-        outcome.failureReason ?? TIME_BUDGET_REASON
-      );
+    if (state === 'out-of-time') {
+      unresolved.set(candidate.stackName, {
+        stackName: candidate.stackName,
+        status: candidate.status,
+        reason: failureReason ?? TIME_BUDGET_REASON,
+      });
       continue;
     }
-    failed.push(outcome.candidate);
+    failed.push(candidate);
   }
 
   if (failed.length > 0 && budget.isExhausted()) {
     log(`${TIME_BUDGET_REASON}, not retrying ${failed.length} stack(s)`);
-    for (const candidate of failed) {
-      markUnresolved(
-        candidate,
-        `${TIME_BUDGET_REASON} before the delete could be retried`
-      );
+    for (const { stackName, status } of failed) {
+      unresolved.set(stackName, {
+        stackName,
+        status,
+        reason: `${TIME_BUDGET_REASON} before the delete could be retried`,
+      });
     }
   } else if (failed.length > 0) {
     log(`Retrying ${failed.length} stack(s) that did not delete`);
@@ -781,27 +774,29 @@ const sweepStaleStacks = async ({
     for (const candidate of gone) {
       deleted.add(candidate.stackName);
     }
-    for (const candidate of untouchable) {
-      markUnresolved(
-        candidate,
-        `CloudFormation is busy with the stack (${candidate.status}), it was not deleted again`
-      );
+    for (const { stackName, status } of untouchable) {
+      unresolved.set(stackName, {
+        stackName,
+        status,
+        reason: `CloudFormation is busy with the stack (${status}), it was not deleted again`,
+      });
     }
-    for (const outcome of await runDeletionPass(
+    for (const { candidate, state, failureReason } of await runDeletionPass(
       client,
       retryable,
       waiter,
       budget,
       log
     )) {
-      if (outcome.state === 'deleted') {
-        deleted.add(outcome.candidate.stackName);
+      if (state === 'deleted') {
+        deleted.add(candidate.stackName);
         continue;
       }
-      markUnresolved(
-        outcome.candidate,
-        outcome.failureReason ?? 'Unknown failure'
-      );
+      unresolved.set(candidate.stackName, {
+        stackName: candidate.stackName,
+        status: candidate.status,
+        reason: failureReason ?? 'Unknown failure',
+      });
     }
   }
 

--- a/packages/testing/src/e2e/sweepStaleStacks.ts
+++ b/packages/testing/src/e2e/sweepStaleStacks.ts
@@ -1,0 +1,585 @@
+import {
+  CloudFormationClient,
+  DeleteStackCommand,
+  DescribeStacksCommand,
+  type Stack,
+  waitUntilStackDeleteComplete,
+} from '@aws-sdk/client-cloudformation';
+
+/**
+ * The tag every stack deployed by `TestStack` carries. An exact key/value match
+ * is the primary signal that a stack belongs to the e2e test suite and can be
+ * swept; anything else in the account is left alone.
+ */
+const E2E_TAG_KEY = 'Service';
+const E2E_TAG_VALUE = 'Powertools-for-AWS-e2e-tests';
+
+/**
+ * The run-scoped LMI shared capacity provider stacks (`LmiShared-<runId>-...`)
+ * are matched by name as well as by tag: they are the only stacks other stacks
+ * depend on, so they must be recognisable even if a future change stops tagging
+ * them, and they must always be deleted *after* the function stacks that attach
+ * to them by ARN (a relationship CloudFormation cannot see).
+ */
+const LMI_SHARED_STACK_NAME_PREFIX = 'LmiShared-';
+
+/**
+ * A stack must be at least this old to be considered abandoned. E2E jobs finish
+ * well within a couple of hours, so 12h is far outside any legitimate run and
+ * guarantees the sweeper can never race a live workflow. There are no
+ * exemptions: a stack younger than this is never deleted, even when it is what
+ * keeps an older stack from being deleted.
+ */
+const MIN_STACK_AGE_HOURS = 12;
+
+/**
+ * How many stack deletions may be in flight within a single phase. Deletions
+ * are cheap to issue but each one polls `DescribeStacks` until it completes, so
+ * the cap keeps the sweep from tripping the account-wide CloudFormation read
+ * rate limit (which surfaces as `Throttling: Rate exceeded`).
+ */
+const MAX_CONCURRENT_DELETIONS = 5;
+
+/**
+ * How long to wait for a single stack delete to reach `DELETE_COMPLETE`.
+ * Stacks holding VPC-attached Lambda functions can take ~15 minutes to release
+ * their ENIs, so anything below 20 minutes would report healthy deletions as
+ * failures.
+ */
+const STACK_DELETE_MAX_WAIT_SECONDS = 20 * 60;
+
+/**
+ * Statuses that mean CloudFormation is mid-operation on the stack. These are
+ * never deleted: a `DeleteStack` call would either fail or fight an operation
+ * that may still be a live workflow's, so they are reported for a human to look
+ * at instead.
+ */
+const isInProgress = (status: string): boolean =>
+  status.endsWith('_IN_PROGRESS');
+
+/**
+ * A candidate stack, as selected by {@link discoverStaleStacks | discovery}.
+ *
+ * `stackId` is kept alongside the name because the delete waiter must poll by
+ * id: `DescribeStacks` by *name* stops resolving once the stack is gone, so a
+ * name-based waiter never observes `DELETE_COMPLETE`.
+ */
+type StaleStackCandidate = {
+  stackName: string;
+  stackId: string;
+  status: string;
+  ageHours: number;
+  reason: 'tag' | 'lmi-shared-name';
+};
+
+/**
+ * The machine-readable report the sweeper writes to stdout. The e2e sweeper
+ * workflow parses it to build its job summary, so the shape is a contract:
+ * fields are only ever added, never renamed or removed.
+ */
+type SweepReport = {
+  dryRun: boolean;
+  timestamp: string;
+  candidates: {
+    stackName: string;
+    status: string;
+    ageHours: number;
+    reason: StaleStackCandidate['reason'];
+  }[];
+  deleted: string[];
+  skippedInProgress: { stackName: string; status: string }[];
+  unresolved: { stackName: string; status: string; reason: string }[];
+  discoveryFailed: boolean;
+  ok: boolean;
+};
+
+/**
+ * Waits for a stack delete to complete. Injectable so unit tests don't have to
+ * poll a real (or mocked) `DescribeStacks` on a timer.
+ */
+type StackDeleteWaiter = (
+  client: CloudFormationClient,
+  stackId: string
+) => Promise<void>;
+
+type SweepStaleStacksOptions = {
+  /**
+   * The CloudFormation client to use. By default the region and credentials
+   * come from the AWS SDK default provider chain, i.e. from the environment the
+   * workflow sets up.
+   */
+  client?: CloudFormationClient;
+  /**
+   * The instant the sweep is anchored to, as epoch milliseconds. Injectable so
+   * the age gate is deterministic in tests.
+   */
+  now?: number;
+  /**
+   * When `true`, discover and select candidates but issue no `DeleteStack`
+   * call.
+   */
+  dryRun?: boolean;
+  waiter?: StackDeleteWaiter;
+  /**
+   * Where human-readable progress goes. Defaults to `console.error` so stdout
+   * stays reserved for the JSON report.
+   */
+  log?: (message: string) => void;
+};
+
+const defaultWaiter: StackDeleteWaiter = async (client, stackId) => {
+  await waitUntilStackDeleteComplete(
+    { client, maxWaitTime: STACK_DELETE_MAX_WAIT_SECONDS },
+    { StackName: stackId }
+  );
+};
+
+/**
+ * Strip anything that identifies the AWS account from text that ends up in the
+ * report, which is published to a public workflow run: ARNs first (they embed
+ * the account id), then any bare 12-digit number.
+ */
+const sanitize = (value: string): string =>
+  value
+    .replaceAll(/arn:[^\s"']+/g, '[REDACTED]')
+    .replaceAll(/\d{12}/g, '[REDACTED]');
+
+const describeError = (error: unknown): string =>
+  sanitize(error instanceof Error ? error.message : String(error));
+
+const isLmiSharedStack = (stackName: string): boolean =>
+  stackName.startsWith(LMI_SHARED_STACK_NAME_PREFIX);
+
+const hasE2eTag = (stack: Stack): boolean =>
+  (stack.Tags ?? []).some(
+    (tag) => tag.Key === E2E_TAG_KEY && tag.Value === E2E_TAG_VALUE
+  );
+
+/**
+ * Decide whether a described stack is a sweep candidate, and why.
+ *
+ * All of the following must hold:
+ * - it is a root stack: nested stacks are deleted by their parent, and deleting
+ *   one directly fails;
+ * - it was created more than {@link MIN_STACK_AGE_HOURS} ago, computed from
+ *   `CreationTime` (a stack without one is never swept, because its age cannot
+ *   be proven);
+ * - it carries the exact e2e `Service` tag, or its name marks it as a shared
+ *   LMI stack.
+ *
+ * `DELETE_COMPLETE` stacks are dropped as well; `DescribeStacks` without a
+ * stack name does not return them, but a re-check by id does.
+ */
+const selectCandidate = (
+  stack: Stack,
+  now: number
+): StaleStackCandidate | undefined => {
+  const { StackName: stackName, StackId: stackId, StackStatus: status } = stack;
+  if (!stackName || !stackId || !status || status === 'DELETE_COMPLETE') {
+    return undefined;
+  }
+  if (stack.RootId || stack.ParentId) {
+    return undefined;
+  }
+  if (!stack.CreationTime) {
+    return undefined;
+  }
+
+  const ageHours = (now - stack.CreationTime.getTime()) / 3_600_000;
+  if (ageHours <= MIN_STACK_AGE_HOURS) {
+    return undefined;
+  }
+
+  const reason = hasE2eTag(stack)
+    ? 'tag'
+    : isLmiSharedStack(stackName)
+      ? 'lmi-shared-name'
+      : undefined;
+  if (!reason) {
+    return undefined;
+  }
+
+  return {
+    stackName,
+    stackId,
+    status,
+    // Rounded for the report only; the age gate above uses the exact value.
+    ageHours: Math.round(ageHours * 10) / 10,
+    reason,
+  };
+};
+
+/**
+ * Page through every stack in the account and return the stale ones.
+ *
+ * `DescribeStacks` is used rather than `ListStacks` because it returns `Tags`,
+ * `CreationTime`, `RootId` and `StackId` in the same response, so selection
+ * needs no per-stack follow-up call — which both halves the API calls and
+ * removes the window in which a stack could change underneath us.
+ *
+ * Any error propagates: discovery is all-or-nothing, because deleting from a
+ * half-built candidate list could delete a shared stack while the function
+ * stacks depending on it are still unknown.
+ */
+const discoverStaleStacks = async (
+  client: CloudFormationClient,
+  now: number
+): Promise<StaleStackCandidate[]> => {
+  const candidates: StaleStackCandidate[] = [];
+  let nextToken: string | undefined;
+  do {
+    const page = await client.send(
+      new DescribeStacksCommand({ NextToken: nextToken })
+    );
+    for (const stack of page.Stacks ?? []) {
+      const candidate = selectCandidate(stack, now);
+      if (candidate) {
+        candidates.push(candidate);
+      }
+    }
+    nextToken = page.NextToken;
+  } while (nextToken);
+
+  // Sorted so the report reads the same way for the same account state.
+  return candidates.sort((a, b) => a.stackName.localeCompare(b.stackName));
+};
+
+/**
+ * Run `worker` over `items` with at most `limit` calls in flight, preserving
+ * the input order in the results.
+ *
+ * A handful of long-lived promises pulling from a shared cursor is all the
+ * limiter this needs, and it keeps the package free of another dependency.
+ */
+const mapWithConcurrency = async <TItem, TResult>(
+  items: TItem[],
+  limit: number,
+  worker: (item: TItem) => Promise<TResult>
+): Promise<TResult[]> => {
+  const results = new Array<TResult>(items.length);
+  let cursor = 0;
+  const runners = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      let index = cursor++;
+      while (index < items.length) {
+        results[index] = await worker(items[index]);
+        index = cursor++;
+      }
+    }
+  );
+  await Promise.all(runners);
+
+  return results;
+};
+
+type DeletionOutcome = {
+  candidate: StaleStackCandidate;
+  deleted: boolean;
+  failureReason?: string;
+};
+
+/**
+ * Delete a single stack and wait for it to be gone.
+ *
+ * The stack *id* is used for both the delete and the wait: it pins the
+ * operation to the exact stack discovery selected (a name could in principle
+ * have been reused since), and it is the only form `DescribeStacks` keeps
+ * resolving after the stack is gone, which the waiter needs to ever see
+ * `DELETE_COMPLETE`.
+ *
+ * Deletion is never forced (`DeletionMode: FORCE_DELETE_STACK`): retaining
+ * resources that CloudFormation cannot delete would leave the account dirtier
+ * than the stack itself, so a stack that will not delete is reported instead.
+ *
+ * Failures are captured rather than thrown so one stuck stack cannot stop the
+ * rest of the sweep.
+ */
+const deleteStack = async (
+  client: CloudFormationClient,
+  candidate: StaleStackCandidate,
+  waiter: StackDeleteWaiter,
+  log: (message: string) => void
+): Promise<DeletionOutcome> => {
+  log(`Deleting ${candidate.stackName} (${candidate.status})`);
+  try {
+    await client.send(new DeleteStackCommand({ StackName: candidate.stackId }));
+    await waiter(client, candidate.stackId);
+    log(`Deleted ${candidate.stackName}`);
+
+    return { candidate, deleted: true };
+  } catch (error) {
+    const failureReason = describeError(error);
+    log(`Failed to delete ${candidate.stackName}: ${failureReason}`);
+
+    return { candidate, deleted: false, failureReason };
+  }
+};
+
+/**
+ * One dependency-ordered deletion pass: every stack that is not a shared LMI
+ * stack first, then — once those are all gone — the shared ones.
+ *
+ * The ordering exists because a function stack's function attaches to a shared
+ * capacity provider by ARN. CloudFormation does not know about that link, so
+ * deleting the provider stack first fails on ENIs still in use.
+ */
+const runDeletionPass = async (
+  client: CloudFormationClient,
+  candidates: StaleStackCandidate[],
+  waiter: StackDeleteWaiter,
+  log: (message: string) => void
+): Promise<DeletionOutcome[]> => {
+  const phases = [
+    candidates.filter(({ stackName }) => !isLmiSharedStack(stackName)),
+    candidates.filter(({ stackName }) => isLmiSharedStack(stackName)),
+  ];
+
+  const outcomes: DeletionOutcome[] = [];
+  for (const phase of phases) {
+    if (phase.length === 0) {
+      continue;
+    }
+    outcomes.push(
+      ...(await mapWithConcurrency(
+        phase,
+        MAX_CONCURRENT_DELETIONS,
+        async (candidate) => deleteStack(client, candidate, waiter, log)
+      ))
+    );
+  }
+
+  return outcomes;
+};
+
+type RecheckResult = {
+  /** Stacks that are gone after all, despite the first pass reporting them as failed. */
+  gone: StaleStackCandidate[];
+  /** Stacks that still exist and can be deleted again. */
+  retryable: StaleStackCandidate[];
+  /** Stacks that exist but must not be touched, with their current status. */
+  untouchable: StaleStackCandidate[];
+};
+
+/**
+ * Re-read the state of the stacks the first pass could not delete.
+ *
+ * The most common first-pass failure is a stack that depends on another one in
+ * the same batch, so by the time the batch is over it is either already gone or
+ * finally deletable. Re-checking before retrying avoids reporting a stack that
+ * did delete, and avoids calling `DeleteStack` on a stack that has since entered
+ * an operation of its own.
+ *
+ * A stack that no longer resolves is treated as deleted. Any other describe
+ * error (a throttle, say) leaves the stack in the retry list: retrying costs
+ * one call and the retry's own failure is reported if it doesn't help.
+ */
+const recheckFailedStacks = async (
+  client: CloudFormationClient,
+  candidates: StaleStackCandidate[]
+): Promise<RecheckResult> => {
+  const result: RecheckResult = { gone: [], retryable: [], untouchable: [] };
+  for (const candidate of candidates) {
+    let current: Stack | undefined;
+    try {
+      const { Stacks: stacks } = await client.send(
+        new DescribeStacksCommand({ StackName: candidate.stackId })
+      );
+      current = stacks?.at(0);
+      if (!current) {
+        result.gone.push(candidate);
+        continue;
+      }
+    } catch (error) {
+      if (describeError(error).includes('does not exist')) {
+        result.gone.push(candidate);
+      } else {
+        result.retryable.push(candidate);
+      }
+      continue;
+    }
+
+    const status = current.StackStatus ?? candidate.status;
+    if (status === 'DELETE_COMPLETE') {
+      result.gone.push(candidate);
+      continue;
+    }
+    // `DELETE_IN_PROGRESS` is retryable: the delete we issued is simply still
+    // running, and re-issuing it is a no-op that lets us wait again. Any other
+    // in-progress status belongs to an operation we did not start.
+    if (isInProgress(status) && status !== 'DELETE_IN_PROGRESS') {
+      result.untouchable.push({ ...candidate, status });
+      continue;
+    }
+    result.retryable.push({ ...candidate, status });
+  }
+
+  return result;
+};
+
+const toReportCandidate = ({
+  stackName,
+  status,
+  ageHours,
+  reason,
+}: StaleStackCandidate): SweepReport['candidates'][number] => ({
+  stackName,
+  status,
+  ageHours,
+  reason,
+});
+
+/**
+ * An empty report: nothing found, nothing done, not `ok`. Every sweep starts
+ * from this and fills it in, and the CLI falls back to it when the sweep itself
+ * blows up, so the workflow always gets a report in the agreed shape.
+ */
+const createEmptyReport = (dryRun: boolean, now = Date.now()): SweepReport => ({
+  dryRun,
+  timestamp: new Date(now).toISOString(),
+  candidates: [],
+  deleted: [],
+  skippedInProgress: [],
+  unresolved: [],
+  discoveryFailed: false,
+  ok: false,
+});
+
+/**
+ * Delete the CloudFormation stacks left behind by e2e test runs, and report
+ * what happened.
+ *
+ * A cancelled or timed-out e2e job never runs its own teardown, so its stacks
+ * stay in the account forever and eventually collide with account limits. This
+ * sweep is the safety net: it deletes stacks that are provably abandoned — root
+ * stacks, older than {@link MIN_STACK_AGE_HOURS}, tagged as e2e test stacks (or
+ * named as shared LMI stacks) — and nothing else.
+ *
+ * The sweep is deliberately staged:
+ * 1. discovery runs to completion before anything is deleted, so a partial
+ *    listing can never cause a partial (and out-of-order) deletion;
+ * 2. deletion runs as two {@link runDeletionPass | dependency-ordered passes},
+ *    because cross-stack dependencies that CloudFormation cannot see make some
+ *    first-pass failures expected;
+ * 3. whatever is still there afterwards is reported as `unresolved` for a human
+ *    to deal with, never force-deleted.
+ *
+ * The returned report is the workflow's contract. `ok` is `false` whenever the
+ * account was left in a state a human should look at: a discovery failure,
+ * anything unresolved, or a candidate skipped because CloudFormation was busy
+ * with it. A dry run is `ok` unless discovery itself failed — it changes
+ * nothing, so there is nothing to fail.
+ */
+const sweepStaleStacks = async ({
+  client = new CloudFormationClient({}),
+  now = Date.now(),
+  dryRun = false,
+  waiter = defaultWaiter,
+  log = (message: string) => {
+    console.error(message);
+  },
+}: SweepStaleStacksOptions = {}): Promise<SweepReport> => {
+  const report: SweepReport = createEmptyReport(dryRun, now);
+
+  let candidates: StaleStackCandidate[];
+  try {
+    candidates = await discoverStaleStacks(client, now);
+  } catch (error) {
+    log(`Discovery failed, no stack was deleted: ${describeError(error)}`);
+    report.discoveryFailed = true;
+
+    return report;
+  }
+
+  report.candidates = candidates.map(toReportCandidate);
+  log(`Found ${candidates.length} stale stack(s)`);
+
+  const deletable: StaleStackCandidate[] = [];
+  for (const candidate of candidates) {
+    if (isInProgress(candidate.status)) {
+      log(
+        `Skipping ${candidate.stackName}: CloudFormation is busy with it (${candidate.status})`
+      );
+      report.skippedInProgress.push({
+        stackName: candidate.stackName,
+        status: candidate.status,
+      });
+      continue;
+    }
+    deletable.push(candidate);
+  }
+
+  if (dryRun) {
+    log(
+      `Dry run: would delete ${deletable.length} stack(s): ${deletable.map(({ stackName }) => stackName).join(', ')}`
+    );
+    report.ok = true;
+
+    return report;
+  }
+
+  const deleted = new Set<string>();
+  const firstPass = await runDeletionPass(client, deletable, waiter, log);
+  const failed: StaleStackCandidate[] = [];
+  for (const outcome of firstPass) {
+    if (outcome.deleted) {
+      deleted.add(outcome.candidate.stackName);
+      continue;
+    }
+    failed.push(outcome.candidate);
+  }
+
+  const unresolved = new Map<string, SweepReport['unresolved'][number]>();
+  if (failed.length > 0) {
+    log(`Retrying ${failed.length} stack(s) that did not delete`);
+    const { gone, retryable, untouchable } = await recheckFailedStacks(
+      client,
+      failed
+    );
+    for (const candidate of gone) {
+      deleted.add(candidate.stackName);
+    }
+    for (const candidate of untouchable) {
+      unresolved.set(candidate.stackName, {
+        stackName: candidate.stackName,
+        status: candidate.status,
+        reason: `CloudFormation is busy with the stack (${candidate.status}), it was not deleted again`,
+      });
+    }
+    for (const outcome of await runDeletionPass(
+      client,
+      retryable,
+      waiter,
+      log
+    )) {
+      if (outcome.deleted) {
+        deleted.add(outcome.candidate.stackName);
+        continue;
+      }
+      unresolved.set(outcome.candidate.stackName, {
+        stackName: outcome.candidate.stackName,
+        status: outcome.candidate.status,
+        reason: outcome.failureReason ?? 'Unknown failure',
+      });
+    }
+  }
+
+  report.deleted = [...deleted].sort((a, b) => a.localeCompare(b));
+  report.unresolved = [...unresolved.values()].sort((a, b) =>
+    a.stackName.localeCompare(b.stackName)
+  );
+  report.ok =
+    report.unresolved.length === 0 && report.skippedInProgress.length === 0;
+
+  return report;
+};
+
+export {
+  createEmptyReport,
+  MAX_CONCURRENT_DELETIONS,
+  MIN_STACK_AGE_HOURS,
+  type StackDeleteWaiter,
+  type SweepReport,
+  type SweepStaleStacksOptions,
+  sweepStaleStacks,
+};

--- a/packages/testing/src/e2e/sweepStaleStacks.ts
+++ b/packages/testing/src/e2e/sweepStaleStacks.ts
@@ -3,6 +3,7 @@ import {
   DeleteStackCommand,
   DescribeStacksCommand,
   type Stack,
+  type StackStatus,
   waitUntilStackDeleteComplete,
 } from '@aws-sdk/client-cloudformation';
 
@@ -10,6 +11,8 @@ import {
  * The tag every stack deployed by `TestStack` carries. An exact key/value match
  * is the primary signal that a stack belongs to the e2e test suite and can be
  * swept; anything else in the account is left alone.
+ *
+ * @internal
  */
 const E2E_TAG_KEY = 'Service';
 const E2E_TAG_VALUE = 'Powertools-for-AWS-e2e-tests';
@@ -20,6 +23,8 @@ const E2E_TAG_VALUE = 'Powertools-for-AWS-e2e-tests';
  * depend on, so they must be recognisable even if a future change stops tagging
  * them, and they must always be deleted *after* the function stacks that attach
  * to them by ARN (a relationship CloudFormation cannot see).
+ *
+ * @internal
  */
 const LMI_SHARED_STACK_NAME_PREFIX = 'LmiShared-';
 
@@ -29,6 +34,8 @@ const LMI_SHARED_STACK_NAME_PREFIX = 'LmiShared-';
  * guarantees the sweeper can never race a live workflow. There are no
  * exemptions: a stack younger than this is never deleted, even when it is what
  * keeps an older stack from being deleted.
+ *
+ * @internal
  */
 const MIN_STACK_AGE_HOURS = 12;
 
@@ -37,6 +44,8 @@ const MIN_STACK_AGE_HOURS = 12;
  * are cheap to issue but each one polls `DescribeStacks` until it completes, so
  * the cap keeps the sweep from tripping the account-wide CloudFormation read
  * rate limit (which surfaces as `Throttling: Rate exceeded`).
+ *
+ * @internal
  */
 const MAX_CONCURRENT_DELETIONS = 5;
 
@@ -45,29 +54,65 @@ const MAX_CONCURRENT_DELETIONS = 5;
  * Stacks holding VPC-attached Lambda functions can take ~15 minutes to release
  * their ENIs, so anything below 20 minutes would report healthy deletions as
  * failures.
+ *
+ * @internal
  */
 const STACK_DELETE_MAX_WAIT_SECONDS = 20 * 60;
 
 /**
- * Statuses that mean CloudFormation is mid-operation on the stack. These are
- * never deleted: a `DeleteStack` call would either fail or fight an operation
- * that may still be a live workflow's, so they are reported for a human to look
- * at instead.
+ * How long the whole sweep may take before it stops starting work and reports
+ * what it did not get to.
+ *
+ * The workflow job that runs the sweep is capped at 60 minutes, and a job the
+ * runner kills never gets to print its report — which the workflow can only
+ * read as a discovery failure, hiding whatever the sweep actually achieved. The
+ * budget is therefore comfortably below the job timeout, leaving room for the
+ * checkout, build and reporting steps around it.
+ *
+ * @internal
  */
-const isInProgress = (status: string): boolean =>
-  status.endsWith('_IN_PROGRESS');
+const DEFAULT_TIME_BUDGET_MS = 50 * 60 * 1_000;
 
 /**
- * A candidate stack, as selected by {@link discoverStaleStacks | discovery}.
+ * Prefix shared by every `unresolved` reason caused by the time budget, so a
+ * reader (and a test) can tell "we ran out of time" apart from "CloudFormation
+ * refused".
+ *
+ * @internal
+ */
+const TIME_BUDGET_REASON = 'Time budget exhausted';
+
+/**
+ * Tells whether CloudFormation is mid-operation on a stack in this status.
+ *
+ * Such stacks are never deleted: a `DeleteStack` call would either fail or
+ * fight an operation that may still be a live workflow's, so they are reported
+ * for a human to look at instead.
+ *
+ * `REVIEW_IN_PROGRESS` is the exception. Despite the name it is a terminal
+ * status: it means a stack was created from a change set that was never
+ * executed, so it holds no resources, nothing is running, and `DeleteStack`
+ * removes it cleanly.
+ *
+ * @param status - the CloudFormation status of the stack
+ * @internal
+ */
+const isInProgress = (status: string): boolean =>
+  status.endsWith('_IN_PROGRESS') && status !== 'REVIEW_IN_PROGRESS';
+
+/**
+ * A candidate stack, as selected by {@link discoverStaleStacks | `discoverStaleStacks`}.
  *
  * `stackId` is kept alongside the name because the delete waiter must poll by
  * id: `DescribeStacks` by *name* stops resolving once the stack is gone, so a
  * name-based waiter never observes `DELETE_COMPLETE`.
+ *
+ * @internal
  */
 type StaleStackCandidate = {
   stackName: string;
   stackId: string;
-  status: string;
+  status: StackStatus;
   ageHours: number;
   reason: 'tag' | 'lmi-shared-name';
 };
@@ -82,13 +127,13 @@ type SweepReport = {
   timestamp: string;
   candidates: {
     stackName: string;
-    status: string;
+    status: StackStatus;
     ageHours: number;
     reason: StaleStackCandidate['reason'];
   }[];
   deleted: string[];
-  skippedInProgress: { stackName: string; status: string }[];
-  unresolved: { stackName: string; status: string; reason: string }[];
+  skippedInProgress: { stackName: string; status: StackStatus }[];
+  unresolved: { stackName: string; status: StackStatus; reason: string }[];
   discoveryFailed: boolean;
   ok: boolean;
 };
@@ -99,7 +144,8 @@ type SweepReport = {
  */
 type StackDeleteWaiter = (
   client: CloudFormationClient,
-  stackId: string
+  stackId: string,
+  maxWaitTimeSeconds: number
 ) => Promise<void>;
 
 type SweepStaleStacksOptions = {
@@ -110,10 +156,21 @@ type SweepStaleStacksOptions = {
    */
   client?: CloudFormationClient;
   /**
-   * The instant the sweep is anchored to, as epoch milliseconds. Injectable so
-   * the age gate is deterministic in tests.
+   * Reads the current time, in epoch milliseconds. Only used to tell how much
+   * of the {@link SweepStaleStacksOptions.timeBudgetMs | `timeBudgetMs`} is
+   * left, and injectable so tests can make time pass without waiting.
+   */
+  clock?: () => number;
+  /**
+   * The instant the sweep is anchored to, as epoch milliseconds: the age gate,
+   * the report timestamp and the time budget are all measured from it.
    */
   now?: number;
+  /**
+   * How long the sweep may keep working, measured from
+   * {@link SweepStaleStacksOptions.now | `now`}.
+   */
+  timeBudgetMs?: number;
   /**
    * When `true`, discover and select candidates but issue no `DeleteStack`
    * call.
@@ -127,48 +184,115 @@ type SweepStaleStacksOptions = {
   log?: (message: string) => void;
 };
 
-const defaultWaiter: StackDeleteWaiter = async (client, stackId) => {
+/**
+ * Waits for a stack to reach `DELETE_COMPLETE`, using the CloudFormation
+ * waiter.
+ *
+ * @param client - the CloudFormation client to poll with
+ * @param stackId - the id of the stack being deleted
+ * @param maxWaitTimeSeconds - how long to keep polling before giving up
+ * @internal
+ */
+const defaultWaiter: StackDeleteWaiter = async (
+  client,
+  stackId,
+  maxWaitTimeSeconds
+) => {
   await waitUntilStackDeleteComplete(
-    { client, maxWaitTime: STACK_DELETE_MAX_WAIT_SECONDS },
+    { client, maxWaitTime: maxWaitTimeSeconds },
     { StackName: stackId }
   );
 };
 
 /**
- * Strip anything that identifies the AWS account from text that ends up in the
- * report, which is published to a public workflow run: ARNs first (they embed
- * the account id), then any bare 12-digit number.
+ * Tracks how much of the sweep's wall-clock budget is left.
+ *
+ * @internal
+ */
+type TimeBudget = {
+  /** Whether the budget is spent, i.e. no new deletion may be started. */
+  isExhausted: () => boolean;
+  /** How many whole seconds are left, never less than one. */
+  remainingSeconds: () => number;
+};
+
+/**
+ * Creates the time budget the sweep checks before it starts any new work.
+ *
+ * @param deadline - the instant the sweep must stop working, in epoch milliseconds
+ * @param clock - reads the current time, in epoch milliseconds
+ * @internal
+ */
+const createTimeBudget = (
+  deadline: number,
+  clock: () => number
+): TimeBudget => ({
+  isExhausted: () => clock() >= deadline,
+  remainingSeconds: () => Math.max(1, Math.ceil((deadline - clock()) / 1_000)),
+});
+
+/**
+ * Strips anything that identifies the AWS account from text that ends up in the
+ * report, which is published to a public workflow run.
+ *
+ * ARNs go first because they embed the account id, then any bare 12-digit
+ * number.
+ *
+ * @param value - the text to redact
+ * @internal
  */
 const sanitize = (value: string): string =>
   value
     .replaceAll(/arn:[^\s"']+/g, '[REDACTED]')
     .replaceAll(/\d{12}/g, '[REDACTED]');
 
+/**
+ * Turns an error into a message that is safe to publish.
+ *
+ * @param error - the error to describe
+ * @internal
+ */
 const describeError = (error: unknown): string =>
   sanitize(error instanceof Error ? error.message : String(error));
 
+/**
+ * Tells whether a stack is one of the shared LMI capacity provider stacks.
+ *
+ * @param stackName - the name of the stack
+ * @internal
+ */
 const isLmiSharedStack = (stackName: string): boolean =>
   stackName.startsWith(LMI_SHARED_STACK_NAME_PREFIX);
 
+/**
+ * Tells whether a stack carries the exact tag the e2e suite applies.
+ *
+ * @param stack - the stack as returned by `DescribeStacks`
+ * @internal
+ */
 const hasE2eTag = (stack: Stack): boolean =>
   (stack.Tags ?? []).some(
     (tag) => tag.Key === E2E_TAG_KEY && tag.Value === E2E_TAG_VALUE
   );
 
 /**
- * Decide whether a described stack is a sweep candidate, and why.
+ * Decides whether a described stack is a sweep candidate, and why.
  *
  * All of the following must hold:
  * - it is a root stack: nested stacks are deleted by their parent, and deleting
  *   one directly fails;
- * - it was created more than {@link MIN_STACK_AGE_HOURS} ago, computed from
- *   `CreationTime` (a stack without one is never swept, because its age cannot
- *   be proven);
+ * - it was created more than {@link MIN_STACK_AGE_HOURS | `MIN_STACK_AGE_HOURS`}
+ *   ago, computed from `CreationTime` (a stack without one is never swept,
+ *   because its age cannot be proven);
  * - it carries the exact e2e `Service` tag, or its name marks it as a shared
  *   LMI stack.
  *
  * `DELETE_COMPLETE` stacks are dropped as well; `DescribeStacks` without a
  * stack name does not return them, but a re-check by id does.
+ *
+ * @param stack - the stack as returned by `DescribeStacks`
+ * @param now - the instant the stack's age is measured against, in epoch milliseconds
+ * @internal
  */
 const selectCandidate = (
   stack: Stack,
@@ -210,7 +334,7 @@ const selectCandidate = (
 };
 
 /**
- * Page through every stack in the account and return the stale ones.
+ * Pages through every stack in the account and returns the stale ones.
  *
  * `DescribeStacks` is used rather than `ListStacks` because it returns `Tags`,
  * `CreationTime`, `RootId` and `StackId` in the same response, so selection
@@ -220,6 +344,10 @@ const selectCandidate = (
  * Any error propagates: discovery is all-or-nothing, because deleting from a
  * half-built candidate list could delete a shared stack while the function
  * stacks depending on it are still unknown.
+ *
+ * @param client - the CloudFormation client to list stacks with
+ * @param now - the instant stack ages are measured against, in epoch milliseconds
+ * @internal
  */
 const discoverStaleStacks = async (
   client: CloudFormationClient,
@@ -245,11 +373,16 @@ const discoverStaleStacks = async (
 };
 
 /**
- * Run `worker` over `items` with at most `limit` calls in flight, preserving
- * the input order in the results.
+ * Runs a worker over every item with a bounded number of calls in flight,
+ * preserving the input order in the results.
  *
  * A handful of long-lived promises pulling from a shared cursor is all the
  * limiter this needs, and it keeps the package free of another dependency.
+ *
+ * @param items - the items to work through
+ * @param limit - how many workers may run at the same time
+ * @param worker - handles a single item
+ * @internal
  */
 const mapWithConcurrency = async <TItem, TResult>(
   items: TItem[],
@@ -273,14 +406,19 @@ const mapWithConcurrency = async <TItem, TResult>(
   return results;
 };
 
+/**
+ * What became of one attempt to delete one stack.
+ *
+ * @internal
+ */
 type DeletionOutcome = {
   candidate: StaleStackCandidate;
-  deleted: boolean;
+  state: 'deleted' | 'failed' | 'out-of-time';
   failureReason?: string;
 };
 
 /**
- * Delete a single stack and wait for it to be gone.
+ * Deletes a single stack and waits for it to be gone.
  *
  * The stack *id* is used for both the delete and the wait: it pins the
  * operation to the exact stack discovery selected (a name could in principle
@@ -293,41 +431,80 @@ type DeletionOutcome = {
  * than the stack itself, so a stack that will not delete is reported instead.
  *
  * Failures are captured rather than thrown so one stuck stack cannot stop the
- * rest of the sweep.
+ * rest of the sweep. Nothing is started once the budget is spent, and the wait
+ * itself is capped by whatever is left of it, so the sweep always gets to
+ * report instead of being killed mid-wait by the job timeout.
+ *
+ * @param client - the CloudFormation client to delete with
+ * @param candidate - the stack to delete
+ * @param waiter - waits for the delete to complete
+ * @param budget - tells how much sweeping time is left
+ * @param log - writes human-readable progress
+ * @internal
  */
 const deleteStack = async (
   client: CloudFormationClient,
   candidate: StaleStackCandidate,
   waiter: StackDeleteWaiter,
+  budget: TimeBudget,
   log: (message: string) => void
 ): Promise<DeletionOutcome> => {
+  if (budget.isExhausted()) {
+    log(`Not deleting ${candidate.stackName}: ${TIME_BUDGET_REASON}`);
+
+    return {
+      candidate,
+      state: 'out-of-time',
+      failureReason: `${TIME_BUDGET_REASON}, the delete was never attempted`,
+    };
+  }
+
   log(`Deleting ${candidate.stackName} (${candidate.status})`);
   try {
     await client.send(new DeleteStackCommand({ StackName: candidate.stackId }));
-    await waiter(client, candidate.stackId);
+    await waiter(
+      client,
+      candidate.stackId,
+      Math.min(STACK_DELETE_MAX_WAIT_SECONDS, budget.remainingSeconds())
+    );
     log(`Deleted ${candidate.stackName}`);
 
-    return { candidate, deleted: true };
+    return { candidate, state: 'deleted' };
   } catch (error) {
     const failureReason = describeError(error);
     log(`Failed to delete ${candidate.stackName}: ${failureReason}`);
+    if (budget.isExhausted()) {
+      return {
+        candidate,
+        state: 'out-of-time',
+        failureReason: `${TIME_BUDGET_REASON} while waiting for the delete to complete`,
+      };
+    }
 
-    return { candidate, deleted: false, failureReason };
+    return { candidate, state: 'failed', failureReason };
   }
 };
 
 /**
- * One dependency-ordered deletion pass: every stack that is not a shared LMI
- * stack first, then — once those are all gone — the shared ones.
+ * Runs one dependency-ordered deletion pass: every stack that is not a shared
+ * LMI stack first, then — once those are all gone — the shared ones.
  *
  * The ordering exists because a function stack's function attaches to a shared
  * capacity provider by ARN. CloudFormation does not know about that link, so
  * deleting the provider stack first fails on ENIs still in use.
+ *
+ * @param client - the CloudFormation client to delete with
+ * @param candidates - the stacks to delete in this pass
+ * @param waiter - waits for each delete to complete
+ * @param budget - tells how much sweeping time is left
+ * @param log - writes human-readable progress
+ * @internal
  */
 const runDeletionPass = async (
   client: CloudFormationClient,
   candidates: StaleStackCandidate[],
   waiter: StackDeleteWaiter,
+  budget: TimeBudget,
   log: (message: string) => void
 ): Promise<DeletionOutcome[]> => {
   const phases = [
@@ -344,7 +521,7 @@ const runDeletionPass = async (
       ...(await mapWithConcurrency(
         phase,
         MAX_CONCURRENT_DELETIONS,
-        async (candidate) => deleteStack(client, candidate, waiter, log)
+        async (candidate) => deleteStack(client, candidate, waiter, budget, log)
       ))
     );
   }
@@ -352,6 +529,11 @@ const runDeletionPass = async (
   return outcomes;
 };
 
+/**
+ * How the stacks a pass could not delete look on a second look.
+ *
+ * @internal
+ */
 type RecheckResult = {
   /** Stacks that are gone after all, despite the first pass reporting them as failed. */
   gone: StaleStackCandidate[];
@@ -362,7 +544,7 @@ type RecheckResult = {
 };
 
 /**
- * Re-read the state of the stacks the first pass could not delete.
+ * Re-reads the state of the stacks the first pass could not delete.
  *
  * The most common first-pass failure is a stack that depends on another one in
  * the same batch, so by the time the batch is over it is either already gone or
@@ -373,6 +555,10 @@ type RecheckResult = {
  * A stack that no longer resolves is treated as deleted. Any other describe
  * error (a throttle, say) leaves the stack in the retry list: retrying costs
  * one call and the retry's own failure is reported if it doesn't help.
+ *
+ * @param client - the CloudFormation client to describe stacks with
+ * @param candidates - the stacks whose delete did not complete
+ * @internal
  */
 const recheckFailedStacks = async (
   client: CloudFormationClient,
@@ -417,6 +603,12 @@ const recheckFailedStacks = async (
   return result;
 };
 
+/**
+ * Reduces a candidate to the fields the report publishes.
+ *
+ * @param candidate - the candidate to report on
+ * @internal
+ */
 const toReportCandidate = ({
   stackName,
   status,
@@ -430,9 +622,14 @@ const toReportCandidate = ({
 });
 
 /**
- * An empty report: nothing found, nothing done, not `ok`. Every sweep starts
- * from this and fills it in, and the CLI falls back to it when the sweep itself
- * blows up, so the workflow always gets a report in the agreed shape.
+ * Creates an empty report: nothing found, nothing done, not `ok`.
+ *
+ * Every sweep starts from this and fills it in, and the CLI falls back to it
+ * when the sweep itself blows up, so the workflow always gets a report in the
+ * agreed shape.
+ *
+ * @param dryRun - whether the sweep is only reporting what it would delete
+ * @param now - the instant to timestamp the report with, in epoch milliseconds
  */
 const createEmptyReport = (dryRun: boolean, now = Date.now()): SweepReport => ({
   dryRun,
@@ -446,33 +643,50 @@ const createEmptyReport = (dryRun: boolean, now = Date.now()): SweepReport => ({
 });
 
 /**
- * Delete the CloudFormation stacks left behind by e2e test runs, and report
+ * Deletes the CloudFormation stacks left behind by e2e test runs, and reports
  * what happened.
  *
  * A cancelled or timed-out e2e job never runs its own teardown, so its stacks
  * stay in the account forever and eventually collide with account limits. This
  * sweep is the safety net: it deletes stacks that are provably abandoned — root
- * stacks, older than {@link MIN_STACK_AGE_HOURS}, tagged as e2e test stacks (or
- * named as shared LMI stacks) — and nothing else.
+ * stacks, older than {@link MIN_STACK_AGE_HOURS | `MIN_STACK_AGE_HOURS`},
+ * tagged as e2e test stacks (or named as shared LMI stacks) — and nothing else.
  *
  * The sweep is deliberately staged:
  * 1. discovery runs to completion before anything is deleted, so a partial
  *    listing can never cause a partial (and out-of-order) deletion;
- * 2. deletion runs as two {@link runDeletionPass | dependency-ordered passes},
+ * 2. deletion runs as two {@link runDeletionPass | `runDeletionPass`} calls,
  *    because cross-stack dependencies that CloudFormation cannot see make some
  *    first-pass failures expected;
  * 3. whatever is still there afterwards is reported as `unresolved` for a human
  *    to deal with, never force-deleted.
+ *
+ * Every stage is bounded by
+ * {@link SweepStaleStacksOptions.timeBudgetMs | `timeBudgetMs`}: once it is
+ * spent no new delete is started, and whatever was left is reported as
+ * `unresolved`. Reporting late but completely beats being killed by the job
+ * timeout, which would leave the workflow with no report at all.
  *
  * The returned report is the workflow's contract. `ok` is `false` whenever the
  * account was left in a state a human should look at: a discovery failure,
  * anything unresolved, or a candidate skipped because CloudFormation was busy
  * with it. A dry run is `ok` unless discovery itself failed — it changes
  * nothing, so there is nothing to fail.
+ *
+ * @param {Object} options - the options to run the sweep with
+ * @param options.client - the CloudFormation client to sweep with
+ * @param options.clock - reads the current time, in epoch milliseconds
+ * @param options.now - the instant the sweep is anchored to, in epoch milliseconds
+ * @param options.timeBudgetMs - how long the sweep may keep working
+ * @param options.dryRun - whether to report the candidates instead of deleting them
+ * @param options.waiter - waits for each delete to complete
+ * @param options.log - writes human-readable progress
  */
 const sweepStaleStacks = async ({
   client = new CloudFormationClient({}),
-  now = Date.now(),
+  clock = Date.now,
+  now = clock(),
+  timeBudgetMs = DEFAULT_TIME_BUDGET_MS,
   dryRun = false,
   waiter = defaultWaiter,
   log = (message: string) => {
@@ -480,6 +694,7 @@ const sweepStaleStacks = async ({
   },
 }: SweepStaleStacksOptions = {}): Promise<SweepReport> => {
   const report: SweepReport = createEmptyReport(dryRun, now);
+  const budget = createTimeBudget(now + timeBudgetMs, clock);
 
   let candidates: StaleStackCandidate[];
   try {
@@ -519,18 +734,45 @@ const sweepStaleStacks = async ({
   }
 
   const deleted = new Set<string>();
-  const firstPass = await runDeletionPass(client, deletable, waiter, log);
+  const unresolved = new Map<string, SweepReport['unresolved'][number]>();
+  const markUnresolved = (
+    { stackName, status }: StaleStackCandidate,
+    reason: string
+  ): void => {
+    unresolved.set(stackName, { stackName, status, reason });
+  };
+
   const failed: StaleStackCandidate[] = [];
-  for (const outcome of firstPass) {
-    if (outcome.deleted) {
+  for (const outcome of await runDeletionPass(
+    client,
+    deletable,
+    waiter,
+    budget,
+    log
+  )) {
+    if (outcome.state === 'deleted') {
       deleted.add(outcome.candidate.stackName);
+      continue;
+    }
+    if (outcome.state === 'out-of-time') {
+      markUnresolved(
+        outcome.candidate,
+        outcome.failureReason ?? TIME_BUDGET_REASON
+      );
       continue;
     }
     failed.push(outcome.candidate);
   }
 
-  const unresolved = new Map<string, SweepReport['unresolved'][number]>();
-  if (failed.length > 0) {
+  if (failed.length > 0 && budget.isExhausted()) {
+    log(`${TIME_BUDGET_REASON}, not retrying ${failed.length} stack(s)`);
+    for (const candidate of failed) {
+      markUnresolved(
+        candidate,
+        `${TIME_BUDGET_REASON} before the delete could be retried`
+      );
+    }
+  } else if (failed.length > 0) {
     log(`Retrying ${failed.length} stack(s) that did not delete`);
     const { gone, retryable, untouchable } = await recheckFailedStacks(
       client,
@@ -540,27 +782,26 @@ const sweepStaleStacks = async ({
       deleted.add(candidate.stackName);
     }
     for (const candidate of untouchable) {
-      unresolved.set(candidate.stackName, {
-        stackName: candidate.stackName,
-        status: candidate.status,
-        reason: `CloudFormation is busy with the stack (${candidate.status}), it was not deleted again`,
-      });
+      markUnresolved(
+        candidate,
+        `CloudFormation is busy with the stack (${candidate.status}), it was not deleted again`
+      );
     }
     for (const outcome of await runDeletionPass(
       client,
       retryable,
       waiter,
+      budget,
       log
     )) {
-      if (outcome.deleted) {
+      if (outcome.state === 'deleted') {
         deleted.add(outcome.candidate.stackName);
         continue;
       }
-      unresolved.set(outcome.candidate.stackName, {
-        stackName: outcome.candidate.stackName,
-        status: outcome.candidate.status,
-        reason: outcome.failureReason ?? 'Unknown failure',
-      });
+      markUnresolved(
+        outcome.candidate,
+        outcome.failureReason ?? 'Unknown failure'
+      );
     }
   }
 
@@ -576,7 +817,6 @@ const sweepStaleStacks = async ({
 
 export {
   createEmptyReport,
-  MAX_CONCURRENT_DELETIONS,
   MIN_STACK_AGE_HOURS,
   type StackDeleteWaiter,
   type SweepReport,

--- a/packages/testing/src/e2e/sweepStaleStacksCli.ts
+++ b/packages/testing/src/e2e/sweepStaleStacksCli.ts
@@ -2,7 +2,7 @@ import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
 import { createEmptyReport, sweepStaleStacks } from './sweepStaleStacks.js';
 
 /**
- * Entry point for the scheduled e2e stale stack sweeper.
+ * Runs the scheduled e2e stale stack sweeper.
  *
  * Run it from the workflow (or locally, against whatever account the AWS SDK
  * default provider chain resolves to) with:
@@ -14,10 +14,11 @@ import { createEmptyReport, sweepStaleStacks } from './sweepStaleStacks.js';
  * ```
  *
  * The two output streams are strictly separated so the workflow can consume
- * both: **stdout carries exactly one line**, the JSON
- * {@link sweepStaleStacks | sweep report}, while all human-readable progress
- * goes to stderr. The report is always printed, including when the sweep did
- * not go well and the process exits non-zero.
+ * both: **stdout carries exactly one line**, the JSON report of
+ * {@link sweepStaleStacks | `sweepStaleStacks`}, while all human-readable
+ * progress goes to stderr. The report is always printed, including when the
+ * sweep did not go well and the process exits non-zero — the sweep's own time
+ * budget makes sure it gets that far before the job timeout.
  *
  * No region is configured here on purpose: the client picks it up from the
  * environment, so the same script sweeps whichever region the caller points it

--- a/packages/testing/src/e2e/sweepStaleStacksCli.ts
+++ b/packages/testing/src/e2e/sweepStaleStacksCli.ts
@@ -1,0 +1,47 @@
+import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { createEmptyReport, sweepStaleStacks } from './sweepStaleStacks.js';
+
+/**
+ * Entry point for the scheduled e2e stale stack sweeper.
+ *
+ * Run it from the workflow (or locally, against whatever account the AWS SDK
+ * default provider chain resolves to) with:
+ * ```yaml
+ * - run: npm run e2e:sweep -w packages/testing
+ *   env:
+ *     AWS_REGION: eu-west-1
+ *     DRY_RUN: 'true' # anything other than the exact string 'true' is a real run
+ * ```
+ *
+ * The two output streams are strictly separated so the workflow can consume
+ * both: **stdout carries exactly one line**, the JSON
+ * {@link sweepStaleStacks | sweep report}, while all human-readable progress
+ * goes to stderr. The report is always printed, including when the sweep did
+ * not go well and the process exits non-zero.
+ *
+ * No region is configured here on purpose: the client picks it up from the
+ * environment, so the same script sweeps whichever region the caller points it
+ * at.
+ */
+const main = async (): Promise<void> => {
+  const dryRun = process.env.DRY_RUN === 'true';
+  const report = await sweepStaleStacks({
+    client: new CloudFormationClient({}),
+    dryRun,
+  });
+
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  process.exitCode = report.ok ? 0 : 1;
+};
+
+main().catch((error) => {
+  // Everything the sweep expects to go wrong is already in the report, so
+  // getting here means the sweeper itself broke. The workflow still needs a
+  // report to parse, so emit an empty failed one and let the logs carry the
+  // detail.
+  console.error(error);
+  const report = createEmptyReport(process.env.DRY_RUN === 'true');
+  report.discoveryFailed = true;
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/testing/src/lmi/sharedCapacityProviderStack.ts
+++ b/packages/testing/src/lmi/sharedCapacityProviderStack.ts
@@ -29,11 +29,7 @@ const buildSharedCapacityProviderStack = (
   const stackName = `LmiShared-${getRunId()}-${architecture.replace('_', '-')}`;
 
   const app = new App();
-  const stack = new Stack(app, stackName, {
-    tags: {
-      Service: 'Powertools-for-AWS-e2e-tests',
-    },
-  });
+  const stack = new Stack(app, stackName);
   const testStack = new TestStack({
     stackNameProps: {
       stackNamePrefix: 'LmiShared',

--- a/packages/testing/tests/unit/TestStack.test.ts
+++ b/packages/testing/tests/unit/TestStack.test.ts
@@ -7,35 +7,35 @@ const serviceTag = {
 };
 
 describe('TestStack', () => {
-  it('tags an internally created stack', () => {
+  it.each([
+    {
+      stackType: 'an internally created stack',
+      prepareStack: () => ({}),
+    },
+    {
+      stackType: 'a caller-supplied stack',
+      prepareStack: () => {
+        const app = new App();
+        return { app, stack: new Stack(app, 'CallerSuppliedStack') };
+      },
+    },
+  ])('tags $stackType', ({ prepareStack }) => {
+    // Prepare
+    const stack = prepareStack();
+
+    // Act
     const testStack = new TestStack({
+      ...stack,
       stackNameProps: {
         stackNamePrefix: 'TEST',
-        testName: 'internal-stack',
+        testName: 'tagged-stack',
       },
     });
-
     const artifact = testStack.app
       .synth()
       .getStackArtifact(testStack.stack.artifactId);
 
-    expect(artifact.tags).toMatchObject(serviceTag);
-  });
-
-  it('tags a caller-supplied stack', () => {
-    const app = new App();
-    const stack = new Stack(app, 'CallerSuppliedStack');
-    const testStack = new TestStack({
-      app,
-      stack,
-      stackNameProps: {
-        stackNamePrefix: 'TEST',
-        testName: 'supplied-stack',
-      },
-    });
-
-    const artifact = app.synth().getStackArtifact(testStack.stack.artifactId);
-
+    // Assess
     expect(artifact.tags).toMatchObject(serviceTag);
   });
 });

--- a/packages/testing/tests/unit/TestStack.test.ts
+++ b/packages/testing/tests/unit/TestStack.test.ts
@@ -1,0 +1,41 @@
+import { App, Stack } from 'aws-cdk-lib';
+import { describe, expect, it } from 'vitest';
+import { TestStack } from '../../src/TestStack.js';
+
+const serviceTag = {
+  Service: 'Powertools-for-AWS-e2e-tests',
+};
+
+describe('TestStack', () => {
+  it('tags an internally created stack', () => {
+    const testStack = new TestStack({
+      stackNameProps: {
+        stackNamePrefix: 'TEST',
+        testName: 'internal-stack',
+      },
+    });
+
+    const artifact = testStack.app
+      .synth()
+      .getStackArtifact(testStack.stack.artifactId);
+
+    expect(artifact.tags).toMatchObject(serviceTag);
+  });
+
+  it('tags a caller-supplied stack', () => {
+    const app = new App();
+    const stack = new Stack(app, 'CallerSuppliedStack');
+    const testStack = new TestStack({
+      app,
+      stack,
+      stackNameProps: {
+        stackNamePrefix: 'TEST',
+        testName: 'supplied-stack',
+      },
+    });
+
+    const artifact = app.synth().getStackArtifact(testStack.stack.artifactId);
+
+    expect(artifact.tags).toMatchObject(serviceTag);
+  });
+});

--- a/packages/testing/tests/unit/sweepStaleStacks.test.ts
+++ b/packages/testing/tests/unit/sweepStaleStacks.test.ts
@@ -8,14 +8,15 @@ import {
 } from '@aws-sdk/client-cloudformation';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  MAX_CONCURRENT_DELETIONS,
   MIN_STACK_AGE_HOURS,
   type StackDeleteWaiter,
+  type SweepStaleStacksOptions,
   sweepStaleStacks,
 } from '../../src/e2e/sweepStaleStacks.js';
 
 const NOW = new Date('2026-08-31T12:00:00.000Z').getTime();
 const HOUR_IN_MS = 3_600_000;
+const MINUTE_IN_MS = 60_000;
 const ACCOUNT_ID = '123456789012';
 const E2E_TAGS = [{ Key: 'Service', Value: 'Powertools-for-AWS-e2e-tests' }];
 
@@ -23,6 +24,9 @@ const stackIdOf = (stackName: string): string =>
   `arn:aws:cloudformation:eu-west-1:${ACCOUNT_ID}:stack/${stackName}/11111111-2222-3333-4444-555555555555`;
 
 const stackNameOf = (stackId: string): string => stackId.split('/')[1];
+
+const createdHoursAgo = (hours: number): Date =>
+  new Date(NOW - hours * HOUR_IN_MS);
 
 /**
  * A `DescribeStacks` entry that is a valid sweep candidate by default: a tagged
@@ -36,7 +40,7 @@ const makeStack = (
   StackName: stackName,
   StackId: stackIdOf(stackName),
   StackStatus: 'CREATE_COMPLETE',
-  CreationTime: new Date(NOW - 24 * HOUR_IN_MS),
+  CreationTime: createdHoursAgo(24),
   Tags: E2E_TAGS,
   ...overrides,
 });
@@ -52,7 +56,7 @@ type StubOptions = {
   /**
    * Responses returned by `DescribeStacks` for a single stack id, i.e. the
    * second-pass re-check, keyed by stack name. `null` stands for an empty
-   * `Stacks` array.
+   * `Stacks` array, a missing entry for a stack CloudFormation no longer knows.
    */
   recheck?: Record<string, Stack | Error | null>;
 };
@@ -131,17 +135,22 @@ const createWaiter = (
     events.push(`waitEnd:${stackName}`);
   });
 
+/**
+ * Runs the sweep with a clock frozen at `NOW`, so the time budget is never
+ * exhausted unless the test says so.
+ */
 const sweep = async (
   client: CloudFormationClient,
   waiter: StackDeleteWaiter,
-  dryRun = false
+  overrides: Partial<SweepStaleStacksOptions> = {}
 ) =>
   await sweepStaleStacks({
     client,
     now: NOW,
-    dryRun,
+    clock: () => NOW,
     waiter,
     log: () => {},
+    ...overrides,
   });
 
 describe('sweepStaleStacks', () => {
@@ -274,22 +283,21 @@ describe('sweepStaleStacks', () => {
 
     it('rejects a stack younger than the minimum age, even next to an older one', async () => {
       // Prepare
-      const ageInMs = (hours: number) => new Date(NOW - hours * HOUR_IN_MS);
       const stub = createStub({
         pages: [
           {
             Stacks: [
               makeStack('TooYoung', {
-                CreationTime: ageInMs(MIN_STACK_AGE_HOURS - 0.1),
+                CreationTime: createdHoursAgo(MIN_STACK_AGE_HOURS - 0.1),
               }),
               makeStack('ExactlyAtTheLimit', {
-                CreationTime: ageInMs(MIN_STACK_AGE_HOURS),
+                CreationTime: createdHoursAgo(MIN_STACK_AGE_HOURS),
               }),
               makeStack('OldEnough', {
-                CreationTime: ageInMs(MIN_STACK_AGE_HOURS + 0.1),
+                CreationTime: createdHoursAgo(MIN_STACK_AGE_HOURS + 0.1),
               }),
               makeStack('LmiShared-young', {
-                CreationTime: ageInMs(1),
+                CreationTime: createdHoursAgo(1),
                 Tags: undefined,
               }),
               makeStack('NoCreationTime', { CreationTime: undefined }),
@@ -356,7 +364,6 @@ describe('sweepStaleStacks', () => {
       'CREATE_IN_PROGRESS',
       'UPDATE_IN_PROGRESS',
       'DELETE_IN_PROGRESS',
-      'REVIEW_IN_PROGRESS',
       'UPDATE_ROLLBACK_IN_PROGRESS',
     ])('reports a %s stack instead of deleting it', async (status) => {
       // Prepare
@@ -372,6 +379,28 @@ describe('sweepStaleStacks', () => {
       expect(report.deleted).toEqual([]);
       expect(stub.deletedStacks()).toEqual([]);
       expect(report.ok).toBe(false);
+    });
+
+    it('deletes a REVIEW_IN_PROGRESS stack, which holds no resources', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [
+              makeStack('NeverExecuted', { StackStatus: 'REVIEW_IN_PROGRESS' }),
+            ],
+          },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.skippedInProgress).toEqual([]);
+      expect(stub.deletedStacks()).toEqual(['NeverExecuted']);
+      expect(report.deleted).toEqual(['NeverExecuted']);
+      expect(report.ok).toBe(true);
     });
 
     it('still deletes the other candidates', async () => {
@@ -435,10 +464,10 @@ describe('sweepStaleStacks', () => {
       expect(report.ok).toBe(true);
     });
 
-    it('never keeps more deletions in flight than the concurrency limit', async () => {
+    it('never keeps more than 5 deletions in flight', async () => {
       // Prepare
       const stackNames = Array.from(
-        { length: MAX_CONCURRENT_DELETIONS + 2 },
+        { length: 7 },
         (_value, index) => `Stack-${index}`
       );
       const stub = createStub({
@@ -463,7 +492,7 @@ describe('sweepStaleStacks', () => {
       const report = await sweep(stub.client, waiter);
 
       // Assess
-      expect(maxInFlight).toBe(MAX_CONCURRENT_DELETIONS);
+      expect(maxInFlight).toBe(5);
       expect(report.deleted).toHaveLength(stackNames.length);
       expect(report.ok).toBe(true);
     });
@@ -544,33 +573,26 @@ describe('sweepStaleStacks', () => {
       expect(report.ok).toBe(true);
     });
 
-    it('treats a stack that no longer exists as deleted', async () => {
-      // Prepare
-      const stub = createStub({
-        pages: [{ Stacks: [makeStack('Vanished')] }],
-        // No `recheck` entry: the re-check rejects with a "does not exist".
-      });
-      const waiter = createWaiter(stub.events, {
-        Vanished: new Error('Waiter timed out'),
-      });
-
-      // Act
-      const report = await sweep(stub.client, waiter);
-
-      // Assess
-      expect(stub.deletedStacks()).toEqual(['Vanished']);
-      expect(report.deleted).toEqual(['Vanished']);
-      expect(report.unresolved).toEqual([]);
-      expect(report.ok).toBe(true);
-    });
-
-    it('treats a DELETE_COMPLETE re-check as deleted', async () => {
-      // Prepare
-      const stub = createStub({
-        pages: [{ Stacks: [makeStack('Slow')] }],
+    it.each<{ case: string; recheck: StubOptions['recheck'] }>([
+      {
+        case: 'CloudFormation no longer knows',
+        recheck: {},
+      },
+      {
+        case: 'CloudFormation returns no description for',
+        recheck: { Slow: null },
+      },
+      {
+        case: 'is DELETE_COMPLETE by the time of the re-check',
         recheck: {
           Slow: makeStack('Slow', { StackStatus: 'DELETE_COMPLETE' }),
         },
+      },
+    ])('treats a stack that $case as deleted', async ({ recheck }) => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Slow')] }],
+        recheck,
       });
       const waiter = createWaiter(stub.events, {
         Slow: new Error('Waiter timed out'),
@@ -582,6 +604,7 @@ describe('sweepStaleStacks', () => {
       // Assess
       expect(stub.deletedStacks()).toEqual(['Slow']);
       expect(report.deleted).toEqual(['Slow']);
+      expect(report.unresolved).toEqual([]);
       expect(report.ok).toBe(true);
     });
 
@@ -647,6 +670,213 @@ describe('sweepStaleStacks', () => {
     });
   });
 
+  describe('time budget', () => {
+    it('starts no new deletion once the budget is exhausted', async () => {
+      // Prepare
+      const stackNames = Array.from(
+        { length: 7 },
+        (_value, index) => `Stack-${index}`
+      );
+      const stub = createStub({
+        pages: [
+          { Stacks: stackNames.map((stackName) => makeStack(stackName)) },
+        ],
+      });
+      let elapsedMs = 0;
+      // Each of the 5 concurrent waits burns 10 minutes of a 25 minute budget,
+      // so the deletions that have not started yet never will.
+      const waiter: StackDeleteWaiter = vi.fn(async () => {
+        elapsedMs += 10 * MINUTE_IN_MS;
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter, {
+        clock: () => NOW + elapsedMs,
+        timeBudgetMs: 25 * MINUTE_IN_MS,
+      });
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual([
+        'Stack-0',
+        'Stack-1',
+        'Stack-2',
+        'Stack-3',
+        'Stack-4',
+      ]);
+      expect(report.deleted).toHaveLength(5);
+      expect(report.unresolved).toEqual([
+        {
+          stackName: 'Stack-5',
+          status: 'CREATE_COMPLETE',
+          reason: 'Time budget exhausted, the delete was never attempted',
+        },
+        {
+          stackName: 'Stack-6',
+          status: 'CREATE_COMPLETE',
+          reason: 'Time budget exhausted, the delete was never attempted',
+        },
+      ]);
+      // The report is still complete: every candidate is accounted for, and the
+      // sweep returns normally so the workflow can read it.
+      expect(report.candidates).toHaveLength(7);
+      expect(report.discoveryFailed).toBe(false);
+      expect(report.ok).toBe(false);
+    });
+
+    it('reports a stack it was still waiting for when the budget ran out', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Slow')] }],
+      });
+      let elapsedMs = 0;
+      const waiter: StackDeleteWaiter = vi.fn(async () => {
+        elapsedMs += 30 * MINUTE_IN_MS;
+        throw new Error('Waiter timed out');
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter, {
+        clock: () => NOW + elapsedMs,
+        timeBudgetMs: 20 * MINUTE_IN_MS,
+      });
+
+      // Assess
+      expect(report.unresolved).toEqual([
+        {
+          stackName: 'Slow',
+          status: 'CREATE_COMPLETE',
+          reason:
+            'Time budget exhausted while waiting for the delete to complete',
+        },
+      ]);
+      expect(report.deleted).toEqual([]);
+      // Out of time means out of re-checks and retries too.
+      expect(stub.events).not.toContain('recheck:Slow');
+      expect(stub.deletedStacks()).toEqual(['Slow']);
+      expect(report.ok).toBe(false);
+    });
+
+    it.each([
+      {
+        case: 'the budget when it is the shorter of the two',
+        budgetMinutes: 5,
+        expectedSeconds: 300,
+      },
+      {
+        case: 'the per-stack maximum otherwise',
+        budgetMinutes: 60,
+        expectedSeconds: 1200,
+      },
+    ])(
+      'caps each wait at $case',
+      async ({ budgetMinutes, expectedSeconds }) => {
+        // Prepare
+        const stub = createStub({ pages: [{ Stacks: [makeStack('Alpha')] }] });
+        const waiter = createWaiter(stub.events);
+
+        // Act
+        await sweep(stub.client, waiter, {
+          timeBudgetMs: budgetMinutes * MINUTE_IN_MS,
+        });
+
+        // Assess
+        expect(waiter).toHaveBeenCalledWith(
+          stub.client,
+          stackIdOf('Alpha'),
+          expectedSeconds
+        );
+      }
+    );
+
+    it.each([
+      {
+        case: 'keeps deleting while the default budget lasts',
+        elapsedMinutes: 49,
+        expectedDeleted: ['Alpha', 'LmiShared-1234-x86'],
+        expectedUnresolved: [],
+      },
+      {
+        case: 'stops once the default budget is spent',
+        elapsedMinutes: 51,
+        expectedDeleted: ['Alpha'],
+        expectedUnresolved: [
+          {
+            stackName: 'LmiShared-1234-x86',
+            status: 'CREATE_COMPLETE',
+            reason: 'Time budget exhausted, the delete was never attempted',
+          },
+        ],
+      },
+    ])(
+      '$case',
+      async ({ elapsedMinutes, expectedDeleted, expectedUnresolved }) => {
+        // Prepare
+        const stub = createStub({
+          pages: [
+            { Stacks: [makeStack('Alpha'), makeStack('LmiShared-1234-x86')] },
+          ],
+        });
+        let elapsedMs = 0;
+        // Deleting `Alpha` in the first phase burns the time, so the shared
+        // stack's phase is the one that sees the budget as it stands.
+        const waiter: StackDeleteWaiter = vi.fn(async (_client, stackId) => {
+          if (stackNameOf(stackId) === 'Alpha') {
+            elapsedMs += elapsedMinutes * MINUTE_IN_MS;
+          }
+        });
+
+        // Act
+        const report = await sweep(stub.client, waiter, {
+          clock: () => NOW + elapsedMs,
+        });
+
+        // Assess
+        expect(report.deleted).toEqual(expectedDeleted);
+        expect(report.unresolved).toEqual(expectedUnresolved);
+      }
+    );
+
+    it('skips the retry when the budget ran out during the first pass', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          { Stacks: [makeStack('Alpha'), makeStack('LmiShared-1234-x86')] },
+        ],
+        recheck: {
+          Alpha: makeStack('Alpha', { StackStatus: 'DELETE_FAILED' }),
+        },
+      });
+      let elapsedMs = 0;
+      // `Alpha` fails while there is still time, then deleting the shared stack
+      // in the next phase burns what is left of the budget.
+      const waiter: StackDeleteWaiter = vi.fn(async (_client, stackId) => {
+        if (stackNameOf(stackId) === 'Alpha') {
+          throw new Error('Resource is still in use');
+        }
+        elapsedMs += 60 * MINUTE_IN_MS;
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter, {
+        clock: () => NOW + elapsedMs,
+        timeBudgetMs: 30 * MINUTE_IN_MS,
+      });
+
+      // Assess
+      expect(report.deleted).toEqual(['LmiShared-1234-x86']);
+      expect(report.unresolved).toEqual([
+        {
+          stackName: 'Alpha',
+          status: 'CREATE_COMPLETE',
+          reason: 'Time budget exhausted before the delete could be retried',
+        },
+      ]);
+      expect(stub.events).not.toContain('recheck:Alpha');
+      expect(stub.deletedStacks()).toEqual(['Alpha', 'LmiShared-1234-x86']);
+      expect(report.ok).toBe(false);
+    });
+  });
+
   describe('dry run', () => {
     it('reports the candidates without deleting anything', async () => {
       // Prepare
@@ -657,7 +887,7 @@ describe('sweepStaleStacks', () => {
               makeStack('Alpha'),
               makeStack('LmiShared-1234-x86', { Tags: undefined }),
               makeStack('Busy', { StackStatus: 'DELETE_IN_PROGRESS' }),
-              makeStack('Fresh', { CreationTime: new Date(NOW - HOUR_IN_MS) }),
+              makeStack('Fresh', { CreationTime: createdHoursAgo(1) }),
             ],
           },
         ],
@@ -665,7 +895,7 @@ describe('sweepStaleStacks', () => {
       const waiter = createWaiter(stub.events);
 
       // Act
-      const report = await sweep(stub.client, waiter, true);
+      const report = await sweep(stub.client, waiter, { dryRun: true });
 
       // Assess
       expect(report.dryRun).toBe(true);
@@ -689,7 +919,9 @@ describe('sweepStaleStacks', () => {
       const stub = createStub({ pages: [new Error('AccessDenied')] });
 
       // Act
-      const report = await sweep(stub.client, createWaiter(stub.events), true);
+      const report = await sweep(stub.client, createWaiter(stub.events), {
+        dryRun: true,
+      });
 
       // Assess
       expect(report.discoveryFailed).toBe(true);

--- a/packages/testing/tests/unit/sweepStaleStacks.test.ts
+++ b/packages/testing/tests/unit/sweepStaleStacks.test.ts
@@ -1,0 +1,753 @@
+import {
+  type CloudFormationClient,
+  DeleteStackCommand,
+  type DeleteStackCommandInput,
+  DescribeStacksCommand,
+  type Stack,
+  type StackStatus,
+} from '@aws-sdk/client-cloudformation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MAX_CONCURRENT_DELETIONS,
+  MIN_STACK_AGE_HOURS,
+  type StackDeleteWaiter,
+  sweepStaleStacks,
+} from '../../src/e2e/sweepStaleStacks.js';
+
+const NOW = new Date('2026-08-31T12:00:00.000Z').getTime();
+const HOUR_IN_MS = 3_600_000;
+const ACCOUNT_ID = '123456789012';
+const E2E_TAGS = [{ Key: 'Service', Value: 'Powertools-for-AWS-e2e-tests' }];
+
+const stackIdOf = (stackName: string): string =>
+  `arn:aws:cloudformation:eu-west-1:${ACCOUNT_ID}:stack/${stackName}/11111111-2222-3333-4444-555555555555`;
+
+const stackNameOf = (stackId: string): string => stackId.split('/')[1];
+
+/**
+ * A `DescribeStacks` entry that is a valid sweep candidate by default: a tagged
+ * root stack, created a day ago. Each test overrides only the attribute it is
+ * about.
+ */
+const makeStack = (
+  stackName: string,
+  overrides: Partial<Stack> = {}
+): Stack => ({
+  StackName: stackName,
+  StackId: stackIdOf(stackName),
+  StackStatus: 'CREATE_COMPLETE',
+  CreationTime: new Date(NOW - 24 * HOUR_IN_MS),
+  Tags: E2E_TAGS,
+  ...overrides,
+});
+
+type DescribeStacksPage = { Stacks?: Stack[]; NextToken?: string };
+
+type StubOptions = {
+  /**
+   * Responses returned by the successive paginated (unnamed) `DescribeStacks`
+   * calls. An `Error` element makes that page's call reject.
+   */
+  pages?: (DescribeStacksPage | Error)[];
+  /**
+   * Responses returned by `DescribeStacks` for a single stack id, i.e. the
+   * second-pass re-check, keyed by stack name. `null` stands for an empty
+   * `Stacks` array.
+   */
+  recheck?: Record<string, Stack | Error | null>;
+};
+
+/**
+ * A hand-rolled `CloudFormationClient` stub. It records the order of the calls
+ * it receives in `events`, which the ordering and dependency assertions rely
+ * on.
+ */
+const createStub = ({ pages = [], recheck = {} }: StubOptions = {}) => {
+  const events: string[] = [];
+  const deleteInputs: DeleteStackCommandInput[] = [];
+  let pageIndex = 0;
+
+  const send = vi.fn(async (command: unknown) => {
+    if (command instanceof DescribeStacksCommand) {
+      const stackId = command.input.StackName;
+      if (stackId) {
+        const stackName = stackNameOf(stackId);
+        events.push(`recheck:${stackName}`);
+        const outcome = recheck[stackName];
+        if (outcome instanceof Error) {
+          throw outcome;
+        }
+        if (outcome === null) {
+          return { Stacks: [] };
+        }
+        if (outcome === undefined) {
+          throw new Error(`Stack with id ${stackId} does not exist`);
+        }
+        return { Stacks: [outcome] };
+      }
+      const page = pages[pageIndex++];
+      events.push(`describe:page${pageIndex}`);
+      if (page instanceof Error) {
+        throw page;
+      }
+      return page ?? {};
+    }
+    if (command instanceof DeleteStackCommand) {
+      deleteInputs.push(command.input);
+      events.push(`delete:${stackNameOf(command.input.StackName as string)}`);
+      return {};
+    }
+    throw new Error('Unexpected command');
+  });
+
+  return {
+    client: { send } as unknown as CloudFormationClient,
+    deleteInputs,
+    events,
+    send,
+    deletedStacks: () =>
+      events
+        .filter((event) => event.startsWith('delete:'))
+        .map((event) => event.slice('delete:'.length)),
+  };
+};
+
+/**
+ * A waiter that resolves immediately unless the stack is listed in `failFor`,
+ * standing in for the real `waitUntilStackDeleteComplete`.
+ */
+const createWaiter = (
+  events: string[],
+  failFor: Record<string, Error> = {}
+): StackDeleteWaiter =>
+  vi.fn(async (_client, stackId) => {
+    const stackName = stackNameOf(stackId);
+    events.push(`waitStart:${stackName}`);
+    const failure = failFor[stackName];
+    if (failure) {
+      events.push(`waitFail:${stackName}`);
+      throw failure;
+    }
+    events.push(`waitEnd:${stackName}`);
+  });
+
+const sweep = async (
+  client: CloudFormationClient,
+  waiter: StackDeleteWaiter,
+  dryRun = false
+) =>
+  await sweepStaleStacks({
+    client,
+    now: NOW,
+    dryRun,
+    waiter,
+    log: () => {},
+  });
+
+describe('sweepStaleStacks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('discovery', () => {
+    it('follows the DescribeStacks pagination', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          { Stacks: [makeStack('First')], NextToken: 'next' },
+          { Stacks: [makeStack('Second')] },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates.map(({ stackName }) => stackName)).toEqual([
+        'First',
+        'Second',
+      ]);
+      expect(report.deleted).toEqual(['First', 'Second']);
+      expect(report.ok).toBe(true);
+    });
+
+    it('selects a stack that carries the exact e2e tag', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [
+              makeStack('Tagged', {
+                Tags: [
+                  { Key: 'Team', Value: 'powertools' },
+                  ...E2E_TAGS,
+                  { Key: 'Other', Value: 'value' },
+                ],
+              }),
+            ],
+          },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates).toEqual([
+        {
+          stackName: 'Tagged',
+          status: 'CREATE_COMPLETE',
+          ageHours: 24,
+          reason: 'tag',
+        },
+      ]);
+    });
+
+    it('selects an untagged stack whose name marks it as a shared LMI stack', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          { Stacks: [makeStack('LmiShared-1234-x86', { Tags: undefined })] },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates).toEqual([
+        {
+          stackName: 'LmiShared-1234-x86',
+          status: 'CREATE_COMPLETE',
+          ageHours: 24,
+          reason: 'lmi-shared-name',
+        },
+      ]);
+      expect(report.deleted).toEqual(['LmiShared-1234-x86']);
+    });
+
+    it.each([
+      {
+        case: 'the tag value only looks like the e2e one',
+        tags: [{ Key: 'Service', Value: 'Powertools-for-AWS-e2e-tests-v2' }],
+      },
+      {
+        case: 'the tag value differs in case',
+        tags: [{ Key: 'Service', Value: 'powertools-for-aws-e2e-tests' }],
+      },
+      {
+        case: 'the tag key differs',
+        tags: [{ Key: 'service', Value: 'Powertools-for-AWS-e2e-tests' }],
+      },
+      { case: 'there is no tag at all', tags: [] },
+    ])('rejects a stack when $case', async ({ tags }) => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('SomeoneElses', { Tags: tags })] }],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates).toEqual([]);
+      expect(stub.deletedStacks()).toEqual([]);
+      expect(report.ok).toBe(true);
+    });
+
+    it.each([
+      { case: 'RootId', overrides: { RootId: stackIdOf('Root') } },
+      { case: 'ParentId', overrides: { ParentId: stackIdOf('Parent') } },
+    ])('rejects a nested stack ($case is set)', async ({ overrides }) => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Nested', overrides)] }],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates).toEqual([]);
+      expect(stub.deletedStacks()).toEqual([]);
+    });
+
+    it('rejects a stack younger than the minimum age, even next to an older one', async () => {
+      // Prepare
+      const ageInMs = (hours: number) => new Date(NOW - hours * HOUR_IN_MS);
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [
+              makeStack('TooYoung', {
+                CreationTime: ageInMs(MIN_STACK_AGE_HOURS - 0.1),
+              }),
+              makeStack('ExactlyAtTheLimit', {
+                CreationTime: ageInMs(MIN_STACK_AGE_HOURS),
+              }),
+              makeStack('OldEnough', {
+                CreationTime: ageInMs(MIN_STACK_AGE_HOURS + 0.1),
+              }),
+              makeStack('LmiShared-young', {
+                CreationTime: ageInMs(1),
+                Tags: undefined,
+              }),
+              makeStack('NoCreationTime', { CreationTime: undefined }),
+            ],
+          },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates).toEqual([
+        {
+          stackName: 'OldEnough',
+          status: 'CREATE_COMPLETE',
+          ageHours: 12.1,
+          reason: 'tag',
+        },
+      ]);
+      expect(stub.deletedStacks()).toEqual(['OldEnough']);
+    });
+
+    it('rejects stacks that are already deleted', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          { Stacks: [makeStack('Gone', { StackStatus: 'DELETE_COMPLETE' })] },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.candidates).toEqual([]);
+      expect(stub.deletedStacks()).toEqual([]);
+    });
+
+    it('aborts without deleting anything when discovery fails partway', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          { Stacks: [makeStack('Discovered')], NextToken: 'next' },
+          new Error(`Throttling: Rate exceeded for account ${ACCOUNT_ID}`),
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.discoveryFailed).toBe(true);
+      expect(report.candidates).toEqual([]);
+      expect(report.deleted).toEqual([]);
+      expect(report.ok).toBe(false);
+      expect(stub.deletedStacks()).toEqual([]);
+      expect(stub.send).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('in-progress stacks', () => {
+    it.each<StackStatus>([
+      'CREATE_IN_PROGRESS',
+      'UPDATE_IN_PROGRESS',
+      'DELETE_IN_PROGRESS',
+      'REVIEW_IN_PROGRESS',
+      'UPDATE_ROLLBACK_IN_PROGRESS',
+    ])('reports a %s stack instead of deleting it', async (status) => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Busy', { StackStatus: status })] }],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.skippedInProgress).toEqual([{ stackName: 'Busy', status }]);
+      expect(report.deleted).toEqual([]);
+      expect(stub.deletedStacks()).toEqual([]);
+      expect(report.ok).toBe(false);
+    });
+
+    it('still deletes the other candidates', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [
+              makeStack('Busy', { StackStatus: 'UPDATE_IN_PROGRESS' }),
+              makeStack('Idle'),
+            ],
+          },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(report.deleted).toEqual(['Idle']);
+      expect(report.skippedInProgress).toEqual([
+        { stackName: 'Busy', status: 'UPDATE_IN_PROGRESS' },
+      ]);
+    });
+  });
+
+  describe('deletion order & concurrency', () => {
+    it('deletes the shared LMI stacks only after every other stack is gone', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [
+              makeStack('LmiShared-1234-arm64'),
+              makeStack('Alpha-Lmi-1234'),
+              makeStack('LmiShared-1234-x86'),
+              makeStack('Beta-Lmi-1234'),
+            ],
+          },
+        ],
+      });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events));
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual([
+        'Alpha-Lmi-1234',
+        'Beta-Lmi-1234',
+        'LmiShared-1234-arm64',
+        'LmiShared-1234-x86',
+      ]);
+      const firstSharedDelete = stub.events.indexOf(
+        'delete:LmiShared-1234-arm64'
+      );
+      for (const stackName of ['Alpha-Lmi-1234', 'Beta-Lmi-1234']) {
+        expect(stub.events.indexOf(`waitEnd:${stackName}`)).toBeLessThan(
+          firstSharedDelete
+        );
+      }
+      expect(report.ok).toBe(true);
+    });
+
+    it('never keeps more deletions in flight than the concurrency limit', async () => {
+      // Prepare
+      const stackNames = Array.from(
+        { length: MAX_CONCURRENT_DELETIONS + 2 },
+        (_value, index) => `Stack-${index}`
+      );
+      const stub = createStub({
+        pages: [
+          { Stacks: stackNames.map((stackName) => makeStack(stackName)) },
+        ],
+      });
+      let inFlight = 0;
+      let maxInFlight = 0;
+      // Blocking for a few ticks is what makes the overlap observable: without
+      // a limiter every stack would be waiting at the same time.
+      const waiter: StackDeleteWaiter = vi.fn(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5);
+        });
+        inFlight -= 1;
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter);
+
+      // Assess
+      expect(maxInFlight).toBe(MAX_CONCURRENT_DELETIONS);
+      expect(report.deleted).toHaveLength(stackNames.length);
+      expect(report.ok).toBe(true);
+    });
+  });
+
+  describe('second pass', () => {
+    it('retries a stack that is still DELETE_FAILED', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Stubborn')] }],
+        recheck: {
+          Stubborn: makeStack('Stubborn', { StackStatus: 'DELETE_FAILED' }),
+        },
+      });
+      const attempts: string[] = [];
+      const failFirstAttempt: StackDeleteWaiter = vi.fn(
+        async (_client, stackId) => {
+          const stackName = stackNameOf(stackId);
+          if (!attempts.includes(stackName)) {
+            attempts.push(stackName);
+            throw new Error('Resource is still in use');
+          }
+        }
+      );
+
+      // Act
+      const report = await sweep(stub.client, failFirstAttempt);
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual(['Stubborn', 'Stubborn']);
+      expect(stub.events).toContain('recheck:Stubborn');
+      expect(report.deleted).toEqual(['Stubborn']);
+      expect(report.unresolved).toEqual([]);
+      expect(report.ok).toBe(true);
+    });
+
+    it('deletes the shared LMI stacks last on the retry as well', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [makeStack('LmiShared-1234-x86'), makeStack('Alpha')],
+          },
+        ],
+        recheck: {
+          'LmiShared-1234-x86': makeStack('LmiShared-1234-x86', {
+            StackStatus: 'DELETE_FAILED',
+          }),
+          Alpha: makeStack('Alpha', { StackStatus: 'DELETE_FAILED' }),
+        },
+      });
+      const attempts: string[] = [];
+      const failFirstAttempt: StackDeleteWaiter = vi.fn(
+        async (_client, stackId) => {
+          const stackName = stackNameOf(stackId);
+          if (!attempts.includes(stackName)) {
+            attempts.push(stackName);
+            throw new Error('ENI still attached');
+          }
+          stub.events.push(`waitEnd:${stackName}`);
+        }
+      );
+
+      // Act
+      const report = await sweep(stub.client, failFirstAttempt);
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual([
+        'Alpha',
+        'LmiShared-1234-x86',
+        'Alpha',
+        'LmiShared-1234-x86',
+      ]);
+      expect(stub.events.indexOf('waitEnd:Alpha')).toBeLessThan(
+        stub.events.lastIndexOf('delete:LmiShared-1234-x86')
+      );
+      expect(report.deleted).toEqual(['Alpha', 'LmiShared-1234-x86']);
+      expect(report.ok).toBe(true);
+    });
+
+    it('treats a stack that no longer exists as deleted', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Vanished')] }],
+        // No `recheck` entry: the re-check rejects with a "does not exist".
+      });
+      const waiter = createWaiter(stub.events, {
+        Vanished: new Error('Waiter timed out'),
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter);
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual(['Vanished']);
+      expect(report.deleted).toEqual(['Vanished']);
+      expect(report.unresolved).toEqual([]);
+      expect(report.ok).toBe(true);
+    });
+
+    it('treats a DELETE_COMPLETE re-check as deleted', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Slow')] }],
+        recheck: {
+          Slow: makeStack('Slow', { StackStatus: 'DELETE_COMPLETE' }),
+        },
+      });
+      const waiter = createWaiter(stub.events, {
+        Slow: new Error('Waiter timed out'),
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter);
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual(['Slow']);
+      expect(report.deleted).toEqual(['Slow']);
+      expect(report.ok).toBe(true);
+    });
+
+    it('does not retry a stack CloudFormation has started an operation on', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Grabbed')] }],
+        recheck: {
+          Grabbed: makeStack('Grabbed', {
+            StackStatus: 'UPDATE_ROLLBACK_IN_PROGRESS',
+          }),
+        },
+      });
+      const waiter = createWaiter(stub.events, {
+        Grabbed: new Error('Delete failed'),
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter);
+
+      // Assess
+      expect(stub.deletedStacks()).toEqual(['Grabbed']);
+      expect(report.deleted).toEqual([]);
+      expect(report.unresolved).toEqual([
+        {
+          stackName: 'Grabbed',
+          status: 'UPDATE_ROLLBACK_IN_PROGRESS',
+          reason:
+            'CloudFormation is busy with the stack (UPDATE_ROLLBACK_IN_PROGRESS), it was not deleted again',
+        },
+      ]);
+      expect(report.ok).toBe(false);
+    });
+
+    it('reports a stack that will not delete, with account details redacted', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [{ Stacks: [makeStack('Broken')] }],
+        recheck: {
+          Broken: makeStack('Broken', { StackStatus: 'DELETE_FAILED' }),
+        },
+      });
+      const waiter = createWaiter(stub.events, {
+        Broken: new Error(
+          `The following resource(s) failed to delete: [Fn]. Role arn:aws:iam::${ACCOUNT_ID}:role/e2e is invalid or cannot be assumed by account ${ACCOUNT_ID}`
+        ),
+      });
+
+      // Act
+      const report = await sweep(stub.client, waiter);
+
+      // Assess
+      expect(report.unresolved).toEqual([
+        {
+          stackName: 'Broken',
+          status: 'DELETE_FAILED',
+          reason:
+            'The following resource(s) failed to delete: [Fn]. Role [REDACTED] is invalid or cannot be assumed by account [REDACTED]',
+        },
+      ]);
+      expect(report.deleted).toEqual([]);
+      expect(report.ok).toBe(false);
+    });
+  });
+
+  describe('dry run', () => {
+    it('reports the candidates without deleting anything', async () => {
+      // Prepare
+      const stub = createStub({
+        pages: [
+          {
+            Stacks: [
+              makeStack('Alpha'),
+              makeStack('LmiShared-1234-x86', { Tags: undefined }),
+              makeStack('Busy', { StackStatus: 'DELETE_IN_PROGRESS' }),
+              makeStack('Fresh', { CreationTime: new Date(NOW - HOUR_IN_MS) }),
+            ],
+          },
+        ],
+      });
+      const waiter = createWaiter(stub.events);
+
+      // Act
+      const report = await sweep(stub.client, waiter, true);
+
+      // Assess
+      expect(report.dryRun).toBe(true);
+      expect(report.candidates.map(({ stackName }) => stackName)).toEqual([
+        'Alpha',
+        'Busy',
+        'LmiShared-1234-x86',
+      ]);
+      expect(report.deleted).toEqual([]);
+      expect(report.skippedInProgress).toEqual([
+        { stackName: 'Busy', status: 'DELETE_IN_PROGRESS' },
+      ]);
+      expect(stub.deletedStacks()).toEqual([]);
+      expect(waiter).not.toHaveBeenCalled();
+      // A dry run changes nothing, so there is nothing to fail.
+      expect(report.ok).toBe(true);
+    });
+
+    it('is not ok when discovery failed', async () => {
+      // Prepare
+      const stub = createStub({ pages: [new Error('AccessDenied')] });
+
+      // Act
+      const report = await sweep(stub.client, createWaiter(stub.events), true);
+
+      // Assess
+      expect(report.discoveryFailed).toBe(true);
+      expect(report.ok).toBe(false);
+    });
+  });
+
+  it('reports the agreed shape when there is nothing to sweep', async () => {
+    // Prepare
+    const stub = createStub({ pages: [{ Stacks: [] }] });
+
+    // Act
+    const report = await sweep(stub.client, createWaiter(stub.events));
+
+    // Assess
+    expect(report).toEqual({
+      dryRun: false,
+      timestamp: '2026-08-31T12:00:00.000Z',
+      candidates: [],
+      deleted: [],
+      skippedInProgress: [],
+      unresolved: [],
+      discoveryFailed: false,
+      ok: true,
+    });
+  });
+
+  it('never asks CloudFormation to force-delete a stack', async () => {
+    // Prepare
+    const stub = createStub({
+      pages: [
+        { Stacks: [makeStack('Alpha'), makeStack('LmiShared-1234-x86')] },
+      ],
+      recheck: {
+        Alpha: makeStack('Alpha', { StackStatus: 'DELETE_FAILED' }),
+      },
+    });
+    const attempts: string[] = [];
+    const failFirstAttempt: StackDeleteWaiter = vi.fn(
+      async (_client, stackId) => {
+        const stackName = stackNameOf(stackId);
+        if (stackName === 'Alpha' && !attempts.includes(stackName)) {
+          attempts.push(stackName);
+          throw new Error('Resource is still in use');
+        }
+      }
+    );
+
+    // Act
+    await sweep(stub.client, failFirstAttempt);
+
+    // Assess
+    expect(stub.deleteInputs).toHaveLength(3);
+    for (const input of stub.deleteInputs) {
+      // Forcing a delete retains resources CloudFormation cannot delete, which
+      // would leave the account dirtier than the stack it removes.
+      expect(input.DeletionMode).toBeUndefined();
+      expect(input.RetainResources).toBeUndefined();
+    }
+  });
+});

--- a/packages/testing/tests/unit/sweepStaleStacks.test.ts
+++ b/packages/testing/tests/unit/sweepStaleStacks.test.ts
@@ -1,12 +1,14 @@
 import {
-  type CloudFormationClient,
+  CloudFormationClient,
   DeleteStackCommand,
   type DeleteStackCommandInput,
   DescribeStacksCommand,
+  type DescribeStacksCommandInput,
   type Stack,
   type StackStatus,
 } from '@aws-sdk/client-cloudformation';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   MIN_STACK_AGE_HOURS,
   type StackDeleteWaiter,
@@ -62,18 +64,34 @@ type StubOptions = {
 };
 
 /**
- * A hand-rolled `CloudFormationClient` stub. It records the order of the calls
- * it receives in `events`, which the ordering and dependency assertions rely
- * on.
+ * Intercepts `CloudFormationClient#send()` on the class itself, so the tests can
+ * hand the sweep a real client — which the SDK paginator insists on — while
+ * every call is answered locally.
+ */
+const cloudFormationMock = mockClient(CloudFormationClient);
+
+/**
+ * Arms the mocked client for one test and returns the handles the assertions
+ * need.
+ *
+ * Every call is appended to `events`, which is what the ordering and dependency
+ * assertions read: a single ordered log is the only way to tell "the shared
+ * stack was deleted after the others had finished" from "they overlapped".
  */
 const createStub = ({ pages = [], recheck = {} }: StubOptions = {}) => {
   const events: string[] = [];
   const deleteInputs: DeleteStackCommandInput[] = [];
   let pageIndex = 0;
 
-  const send = vi.fn(async (command: unknown) => {
-    if (command instanceof DescribeStacksCommand) {
-      const stackId = command.input.StackName;
+  cloudFormationMock.callsFake(() => {
+    throw new Error('Unexpected command');
+  });
+
+  cloudFormationMock
+    .on(DescribeStacksCommand)
+    .callsFake(async ({ StackName: stackId }: DescribeStacksCommandInput) => {
+      // A named (well, id'd) describe is the second-pass re-check; an unnamed
+      // one is the paginator walking the account.
       if (stackId) {
         const stackName = stackNameOf(stackId);
         events.push(`recheck:${stackName}`);
@@ -95,20 +113,20 @@ const createStub = ({ pages = [], recheck = {} }: StubOptions = {}) => {
         throw page;
       }
       return page ?? {};
-    }
-    if (command instanceof DeleteStackCommand) {
-      deleteInputs.push(command.input);
-      events.push(`delete:${stackNameOf(command.input.StackName as string)}`);
+    });
+
+  cloudFormationMock
+    .on(DeleteStackCommand)
+    .callsFake(async (input: DeleteStackCommandInput) => {
+      deleteInputs.push(input);
+      events.push(`delete:${stackNameOf(input.StackName as string)}`);
       return {};
-    }
-    throw new Error('Unexpected command');
-  });
+    });
 
   return {
-    client: { send } as unknown as CloudFormationClient,
+    client: new CloudFormationClient({}),
     deleteInputs,
     events,
-    send,
     deletedStacks: () =>
       events
         .filter((event) => event.startsWith('delete:'))
@@ -155,7 +173,12 @@ const sweep = async (
 
 describe('sweepStaleStacks', () => {
   beforeEach(() => {
+    cloudFormationMock.reset();
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    cloudFormationMock.restore();
   });
 
   describe('discovery', () => {
@@ -355,7 +378,8 @@ describe('sweepStaleStacks', () => {
       expect(report.deleted).toEqual([]);
       expect(report.ok).toBe(false);
       expect(stub.deletedStacks()).toEqual([]);
-      expect(stub.send).toHaveBeenCalledTimes(2);
+      // Two pages listed, nothing else: discovery stopped where it broke.
+      expect(stub.events).toEqual(['describe:page1', 'describe:page2']);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a nightly GitHub Actions workflow that removes leaked e2e CloudFormation stacks from the test account, as a final safety net for the hourly-billed LMI capacity provider infrastructure introduced by #5465. Stacks become eligible 12 hours after creation when they carry the `Service=Powertools-for-AWS-e2e-tests` tag or an `LmiShared-*` name.

### Changes

- Add `sweepStaleStacks` to `packages/testing` (new `e2e:sweep` script): paginated discovery via `DescribeStacks` (root stacks only, 12-hour age gate, exact tag or `LmiShared-` prefix), all-or-nothing discovery, two dependency-ordered deletion passes (function stacks before shared capacity providers), concurrency capped at 5, 20-minute per-stack waits by stack id, no force deletion
- Enforce an internal 50-minute time budget so the report is always emitted before the 60-minute job cap; leftover stacks are reported unresolved
- Skip and report stacks with operations in progress; `REVIEW_IN_PROGRESS` is terminal and holds no resources, so those are deleted
- Emit a sanitized single-line JSON report (account ids and ARNs redacted) on stdout, exit nonzero when stacks remain unresolved
- Add `sweep-stale-e2e-stacks.yml`: nightly cron plus manual dispatch defaulting to dry run (discovery only, job summary, no issue); reuses the existing `e2e-tests` OIDC environment; workflow concurrency group prevents overlapping sweeps
- Add `report_e2e_sweep.js`: on failed real runs, creates or comments on a single incident issue deduplicated by exact title (no labels managed, no auto-close); issue bodies are truncated below GitHub's size limit; the same formatter renders the job summary
- Apply the e2e service tag to caller-supplied `TestStack` stacks so the tag-based selector also covers the layer publisher stack; drop the now-redundant manual tag in `sharedCapacityProviderStack`
- Add 49 mocked unit tests covering pagination, selection, age and status handling, dependency ordering, bounded concurrency, retries, time budget, dry run, and report sanitization

**Issue number:** closes #5519

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.