### PR TITLE
fix(batch): populate response() before full batch throw and normalize non-Error throws

### DIFF
--- a/docs/features/batch.md
+++ b/docs/features/batch.md
@@ -428,7 +428,7 @@ We can automatically inject the [Lambda context](https://docs.aws.amazon.com/lam
 
 ### Working with full batch failures
 
-By default, the `BatchProcessor` will throw a `FullBatchFailureError` if all records in the batch fail to process, we do this to reflect the failure in your operational metrics.
+By default, the `BatchProcessor` will throw a `FullBatchFailureError` if all records in the batch fail to process, we do this to reflect the failure in your operational metrics. If you call `process()` yourself and catch this error, `response()` still lists every failed record.
 
 When working with functions that handle batches with a small number of records, or when you use errors as a flow control mechanism, this behavior might not be desirable as your function might generate an unnaturally high number of errors. When this happens, the [Lambda service will scale down the concurrency of your function](https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html#services-sqs-backoff-strategy){target="_blank"}, potentially impacting performance.
 

--- a/packages/batch/src/BasePartialBatchProcessor.ts
+++ b/packages/batch/src/BasePartialBatchProcessor.ts
@@ -84,15 +84,19 @@ abstract class BasePartialBatchProcessor extends BasePartialProcessor {
   /**
    * Clean up logic to be run after processing a batch
    *
-   * If the entire batch failed this method will throw a {@link FullBatchFailureError | `FullBatchFailureError`} with the list of
-   * errors that occurred during processing, unless the `throwOnFullBatchFailure` option is set to `false`.
+   * Builds the partial failure response based on the event type, so that
+   * {@link BasePartialBatchProcessor.response | `response()`} reports every failed record.
    *
-   * Otherwise, it will build the partial failure response based on the event type.
+   * If the entire batch failed this method will then throw a {@link FullBatchFailureError | `FullBatchFailureError`} with the list of
+   * errors that occurred during processing, unless the `throwOnFullBatchFailure` option is set to `false`.
    */
   public clean(): void {
     if (!this.hasMessagesToReport()) {
       return;
     }
+
+    const messages: PartialItemFailures[] = this.getMessagesToReport();
+    this.batchResponse = { batchItemFailures: messages };
 
     if (
       this.options?.throwOnFullBatchFailure !== false &&
@@ -100,9 +104,6 @@ abstract class BasePartialBatchProcessor extends BasePartialProcessor {
     ) {
       throw new FullBatchFailureError(this.errors);
     }
-
-    const messages: PartialItemFailures[] = this.getMessagesToReport();
-    this.batchResponse = { batchItemFailures: messages };
   }
 
   /**

--- a/packages/batch/src/BasePartialProcessor.ts
+++ b/packages/batch/src/BasePartialProcessor.ts
@@ -1,4 +1,5 @@
 import { BatchProcessingStore } from './BatchProcessingStore.js';
+import { toError } from './errors.js';
 import type {
   BaseRecord,
   BatchProcessingOptions,
@@ -98,14 +99,15 @@ abstract class BasePartialProcessor {
    * the processor can keep track of the error and the record that failed.
    *
    * @param record - Record that failed processing
-   * @param error - Error that was thrown
+   * @param error - Error that was thrown; non-Error values are wrapped in an `Error`
    */
   public failureHandler(
     record: EventSourceDataClassTypes,
     error: Error
   ): FailureResponse {
-    const entry: FailureResponse = ['fail', error.message, record];
-    this.errors.push(error);
+    const normalizedError = toError(error);
+    const entry: FailureResponse = ['fail', normalizedError.message, record];
+    this.errors.push(normalizedError);
     this.failureMessages.push(record);
 
     return entry;

--- a/packages/batch/src/BatchProcessor.ts
+++ b/packages/batch/src/BatchProcessor.ts
@@ -1,5 +1,5 @@
 import { BasePartialBatchProcessor } from './BasePartialBatchProcessor.js';
-import { BatchProcessingError } from './errors.js';
+import { BatchProcessingError, toError } from './errors.js';
 import type { BaseRecord, FailureResponse, SuccessResponse } from './types.js';
 
 /**
@@ -180,7 +180,7 @@ class BatchProcessor extends BasePartialBatchProcessor {
       const result = await this.handler(data, this.options?.context);
       return this.successHandler(record, result);
     } catch (error) {
-      return this.failureHandler(record, error as Error);
+      return this.failureHandler(record, toError(error));
     }
   }
 

--- a/packages/batch/src/BatchProcessorSync.ts
+++ b/packages/batch/src/BatchProcessorSync.ts
@@ -1,5 +1,5 @@
 import { BasePartialBatchProcessor } from './BasePartialBatchProcessor.js';
-import { BatchProcessingError } from './errors.js';
+import { BatchProcessingError, toError } from './errors.js';
 import type { BaseRecord, FailureResponse, SuccessResponse } from './types.js';
 
 /**
@@ -117,7 +117,7 @@ import type { BaseRecord, FailureResponse, SuccessResponse } from './types.js';
 
       return this.successHandler(record, result);
     } catch (error) {
-      return this.failureHandler(record, error as Error);
+      return this.failureHandler(record, toError(error));
     }
   }
 }

--- a/packages/batch/src/errors.ts
+++ b/packages/batch/src/errors.ts
@@ -73,11 +73,49 @@ class ParsingError extends BatchProcessingError {
   }
 }
 
+/**
+ * Message for a thrown value that is not an `Error`, preferring its own
+ * `message` and falling back to a generic one when it cannot be stringified.
+ *
+ * @param value - The thrown value
+ */
+const messageOf = (value: unknown): string => {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'message' in value &&
+    typeof value.message === 'string'
+  ) {
+    return value.message;
+  }
+  try {
+    return String(value);
+  } catch {
+    return 'Unknown error';
+  }
+};
+
+/**
+ * Coerce a thrown value into an `Error`, keeping the original as `cause`.
+ *
+ * Record handlers can throw anything, and the failure path must never
+ * throw again while recording it.
+ *
+ * @param value - The thrown value
+ */
+const toError = (value: unknown): Error => {
+  if (value instanceof Error) {
+    return value;
+  }
+  return new Error(messageOf(value), { cause: value });
+};
+
 export {
   BatchProcessingError,
   FullBatchFailureError,
   ParsingError,
   SqsFifoMessageGroupShortCircuitError,
   SqsFifoShortCircuitError,
+  toError,
   UnexpectedBatchTypeError,
 };

--- a/packages/batch/tests/unit/BatchProcessor.test.ts
+++ b/packages/batch/tests/unit/BatchProcessor.test.ts
@@ -1,5 +1,6 @@
+import { setTimeout } from 'node:timers/promises';
 import context from '@aws-lambda-powertools/testing-utils/context';
-import type { Context } from 'aws-lambda';
+import type { Context, SQSRecord } from 'aws-lambda';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   BatchProcessingError,
@@ -110,6 +111,28 @@ describe('Class: AsyncBatchProcessor', () => {
           FullBatchFailureError
         );
       });
+
+      it('reports every record in the response after a full batch failure', async () => {
+        // Prepare
+        const firstRecord = sqsRecordFactory('fail');
+        const secondRecord = sqsRecordFactory('fail');
+        const records = [firstRecord, secondRecord];
+        const processor = new BatchProcessor(EventType.SQS);
+        processor.register(records, asyncSqsRecordHandler, options);
+
+        // Act
+        await expect(processor.process()).rejects.toThrowError(
+          FullBatchFailureError
+        );
+
+        // Assess
+        expect(processor.response()).toStrictEqual({
+          batchItemFailures: [
+            { itemIdentifier: firstRecord.messageId },
+            { itemIdentifier: secondRecord.messageId },
+          ],
+        });
+      });
     });
 
     describe.each(cases)('Kinesis Records $description', ({ options }) => {
@@ -174,6 +197,28 @@ describe('Class: AsyncBatchProcessor', () => {
         await expect(processor.process()).rejects.toThrowError(
           FullBatchFailureError
         );
+      });
+
+      it('reports every record in the response after a full batch failure', async () => {
+        // Prepare
+        const firstRecord = kinesisRecordFactory('fail');
+        const secondRecord = kinesisRecordFactory('fail');
+        const records = [firstRecord, secondRecord];
+        const processor = new BatchProcessor(EventType.KinesisDataStreams);
+        processor.register(records, asyncKinesisRecordHandler, options);
+
+        // Act
+        await expect(processor.process()).rejects.toThrowError(
+          FullBatchFailureError
+        );
+
+        // Assess
+        expect(processor.response()).toStrictEqual({
+          batchItemFailures: [
+            { itemIdentifier: firstRecord.kinesis.sequenceNumber },
+            { itemIdentifier: secondRecord.kinesis.sequenceNumber },
+          ],
+        });
       });
     });
 
@@ -240,6 +285,28 @@ describe('Class: AsyncBatchProcessor', () => {
           FullBatchFailureError
         );
       });
+
+      it('reports every record in the response after a full batch failure', async () => {
+        // Prepare
+        const firstRecord = dynamodbRecordFactory('fail');
+        const secondRecord = dynamodbRecordFactory('fail');
+        const records = [firstRecord, secondRecord];
+        const processor = new BatchProcessor(EventType.DynamoDBStreams);
+        processor.register(records, asyncDynamodbRecordHandler, options);
+
+        // Act
+        await expect(processor.process()).rejects.toThrowError(
+          FullBatchFailureError
+        );
+
+        // Assess
+        expect(processor.response()).toStrictEqual({
+          batchItemFailures: [
+            { itemIdentifier: firstRecord.dynamodb?.SequenceNumber },
+            { itemIdentifier: secondRecord.dynamodb?.SequenceNumber },
+          ],
+        });
+      });
     });
   });
 
@@ -276,6 +343,63 @@ describe('Class: AsyncBatchProcessor', () => {
       await expect(() => processor.process()).rejects.toThrowError(
         FullBatchFailureError
       );
+    });
+  });
+
+  describe('Handler throwing a non-Error value', () => {
+    it('records the failure and completes the batch when the handler throws undefined', async () => {
+      // Prepare
+      const firstRecord = sqsRecordFactory('fail');
+      const secondRecord = sqsRecordFactory('success');
+      const records = [firstRecord, secondRecord];
+      const processor = new BatchProcessor(EventType.SQS);
+      const handler = async (record: SQSRecord): Promise<string> => {
+        if (record.body.includes('fail')) {
+          throw undefined;
+        }
+        await setTimeout(1);
+        return record.body;
+      };
+
+      // Act
+      processor.register(records, handler, options);
+      const processedMessages = await processor.process();
+
+      // Assess
+      expect(processedMessages).toStrictEqual([
+        ['fail', 'undefined', firstRecord],
+        ['success', secondRecord.body, secondRecord],
+      ]);
+      expect(processor.errors[0]).toBeInstanceOf(Error);
+      expect(processor.response()).toStrictEqual({
+        batchItemFailures: [{ itemIdentifier: firstRecord.messageId }],
+      });
+    });
+
+    it('uses the thrown value as the failure message when the handler throws a string', async () => {
+      // Prepare
+      const firstRecord = sqsRecordFactory('fail');
+      const secondRecord = sqsRecordFactory('success');
+      const records = [firstRecord, secondRecord];
+      const processor = new BatchProcessor(EventType.SQS);
+      const handler = async (record: SQSRecord): Promise<string> => {
+        if (record.body.includes('fail')) {
+          throw 'boom';
+        }
+        return record.body;
+      };
+
+      // Act
+      processor.register(records, handler, options);
+      const processedMessages = await processor.process();
+
+      // Assess
+      expect(processedMessages).toStrictEqual([
+        ['fail', 'boom', firstRecord],
+        ['success', secondRecord.body, secondRecord],
+      ]);
+      expect(processor.errors[0]).toBeInstanceOf(Error);
+      expect(processor.errors[0].message).toBe('boom');
     });
   });
 

--- a/packages/batch/tests/unit/BatchProcessor.test.ts
+++ b/packages/batch/tests/unit/BatchProcessor.test.ts
@@ -1,4 +1,3 @@
-import { setTimeout } from 'node:timers/promises';
 import context from '@aws-lambda-powertools/testing-utils/context';
 import type { Context, SQSRecord } from 'aws-lambda';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -8,7 +7,11 @@ import {
   EventType,
   FullBatchFailureError,
 } from '../../src/index.js';
-import type { BatchProcessingOptions } from '../../src/types.js';
+import type {
+  BatchProcessingOptions,
+  EventSourceDataClassTypes,
+  FailureResponse,
+} from '../../src/types.js';
 import {
   dynamodbRecordFactory,
   kinesisRecordFactory,
@@ -347,59 +350,80 @@ describe('Class: AsyncBatchProcessor', () => {
   });
 
   describe('Handler throwing a non-Error value', () => {
-    it('records the failure and completes the batch when the handler throws undefined', async () => {
-      // Prepare
-      const firstRecord = sqsRecordFactory('fail');
-      const secondRecord = sqsRecordFactory('success');
-      const records = [firstRecord, secondRecord];
-      const processor = new BatchProcessor(EventType.SQS);
-      const handler = async (record: SQSRecord): Promise<string> => {
+    const throwingHandler =
+      (thrown: unknown) =>
+      async (record: SQSRecord): Promise<string> => {
         if (record.body.includes('fail')) {
-          throw undefined;
-        }
-        await setTimeout(1);
-        return record.body;
-      };
-
-      // Act
-      processor.register(records, handler, options);
-      const processedMessages = await processor.process();
-
-      // Assess
-      expect(processedMessages).toStrictEqual([
-        ['fail', 'undefined', firstRecord],
-        ['success', secondRecord.body, secondRecord],
-      ]);
-      expect(processor.errors[0]).toBeInstanceOf(Error);
-      expect(processor.response()).toStrictEqual({
-        batchItemFailures: [{ itemIdentifier: firstRecord.messageId }],
-      });
-    });
-
-    it('uses the thrown value as the failure message when the handler throws a string', async () => {
-      // Prepare
-      const firstRecord = sqsRecordFactory('fail');
-      const secondRecord = sqsRecordFactory('success');
-      const records = [firstRecord, secondRecord];
-      const processor = new BatchProcessor(EventType.SQS);
-      const handler = async (record: SQSRecord): Promise<string> => {
-        if (record.body.includes('fail')) {
-          throw 'boom';
+          throw thrown;
         }
         return record.body;
       };
 
+    it.each([
+      { description: 'undefined', thrown: undefined, message: 'undefined' },
+      { description: 'a string', thrown: 'boom', message: 'boom' },
+      {
+        description: 'an object with a message',
+        thrown: { message: 'not found', code: 'NotFound' },
+        message: 'not found',
+      },
+      {
+        description: 'an object without a string message',
+        thrown: { message: 42 },
+        message: '[object Object]',
+      },
+      {
+        description: 'a value with no string form',
+        thrown: Object.create(null),
+        message: 'Unknown error',
+      },
+    ])(
+      'records the failure and completes the batch when the handler throws $description',
+      async ({ thrown, message }) => {
+        // Prepare
+        const firstRecord = sqsRecordFactory('fail');
+        const secondRecord = sqsRecordFactory('success');
+        const records = [firstRecord, secondRecord];
+        const processor = new BatchProcessor(EventType.SQS);
+
+        // Act
+        processor.register(records, throwingHandler(thrown), options);
+        const processedMessages = await processor.process();
+
+        // Assess
+        expect(processedMessages).toStrictEqual([
+          ['fail', message, firstRecord],
+          ['success', secondRecord.body, secondRecord],
+        ]);
+        expect(processor.errors[0]).toBeInstanceOf(Error);
+        expect(processor.errors[0].cause).toBe(thrown);
+        expect(processor.response()).toStrictEqual({
+          batchItemFailures: [{ itemIdentifier: firstRecord.messageId }],
+        });
+      }
+    );
+
+    it('passes an Error to a failureHandler override', async () => {
+      // Prepare
+      const messages: string[] = [];
+      class LoggingProcessor extends BatchProcessor {
+        public failureHandler(
+          record: EventSourceDataClassTypes,
+          error: Error
+        ): FailureResponse {
+          messages.push(error.message);
+          return super.failureHandler(record, error);
+        }
+      }
+      const records = [sqsRecordFactory('fail'), sqsRecordFactory('success')];
+      const processor = new LoggingProcessor(EventType.SQS);
+
       // Act
-      processor.register(records, handler, options);
-      const processedMessages = await processor.process();
+      processor.register(records, throwingHandler(undefined), options);
+      await processor.process();
 
       // Assess
-      expect(processedMessages).toStrictEqual([
-        ['fail', 'boom', firstRecord],
-        ['success', secondRecord.body, secondRecord],
-      ]);
-      expect(processor.errors[0]).toBeInstanceOf(Error);
-      expect(processor.errors[0].message).toBe('boom');
+      expect(messages).toStrictEqual(['undefined']);
     });
   });
 

--- a/packages/batch/tests/unit/SqsFifoPartialProcessor.test.ts
+++ b/packages/batch/tests/unit/SqsFifoPartialProcessor.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  FullBatchFailureError,
   processPartialResponse,
   processPartialResponseSync,
   SqsFifoMessageGroupShortCircuitError,
@@ -182,6 +183,33 @@ describe('SQS FIFO Processors', () => {
         );
         expect(processor.errors.length).toBe(3);
         expect(processor.errors[1]).toBeInstanceOf(SqsFifoShortCircuitError);
+      });
+
+      it('reports every record in the response after a full batch failure', async () => {
+        // Prepare
+        const firstRecord = sqsRecordFactory('fail', '1');
+        const secondRecord = sqsRecordFactory('success', '2');
+        const processor = new processorClass();
+        processor.register([firstRecord, secondRecord], sqsRecordHandler);
+
+        // Act
+        if (isAsync) {
+          await expect(processor.process()).rejects.toThrowError(
+            FullBatchFailureError
+          );
+        } else {
+          expect(() => processor.processSync()).toThrowError(
+            FullBatchFailureError
+          );
+        }
+
+        // Assess
+        expect(processor.response()).toStrictEqual({
+          batchItemFailures: [
+            { itemIdentifier: firstRecord.messageId },
+            { itemIdentifier: secondRecord.messageId },
+          ],
+        });
       });
     });
   }


### PR DESCRIPTION
## Summary

`clean()` threw `FullBatchFailureError` before storing the partial failure response, so a handler that caught the error and returned `processor.response()` sent an empty `batchItemFailures`, which the event source treats as a fully successful batch. Separately, `failureHandler()` read `error.message` unconditionally, so a record handler throwing `undefined` or `null` raised a `TypeError` inside the per-record `catch`, rejected the whole batch while other records were still running, and again left `response()` empty.

This PR builds the response before the full-batch check and coerces every thrown value into an `Error` before it reaches the failure path.

### Changes

- `BasePartialBatchProcessor.clean()` now assigns `batchResponse` before throwing `FullBatchFailureError`, so `response()` reports every failed record on `BatchProcessor`, `BatchProcessorSync` and both SQS FIFO processors.
- New `toError()` helper in `errors.ts` that passes `Error` instances through, prefers a string `message` on plain objects, guards the string coercion so a value with no primitive form cannot throw again, and keeps the original value as `cause`.
- `BatchProcessor.processRecord()` and `BatchProcessorSync.processRecordSync()` call `toError()` in their `catch`, so `failureHandler` overrides always receive an `Error`. `BasePartialProcessor.failureHandler()` applies the same coercion for custom processors that call it directly.
- Docs: note in "Working with full batch failures" that `response()` still lists every failed record after catching `FullBatchFailureError`.
- Tests: `response()` after a full batch failure for SQS, Kinesis, DynamoDB and both FIFO processors; handler throwing `undefined`, a string, an object with and without a string `message`, and a null-prototype object; a `failureHandler` override reading `error.message` after a non-Error throw.

**Issue number:** closes #5624

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
