### PR TITLE
fix(data-masking): honor throwOnMissingField consistently and resolve paths before masking

### DIFF
--- a/docs/features/data-masking.md
+++ b/docs/features/data-masking.md
@@ -154,6 +154,10 @@ A top-level rule is applied to every path listed in `fields`. When `fields` is o
 !!! note
     A masking rule — top-level or per-field — coerces its target to a string before masking, so non-string values like numbers and booleans are stringified first (`null` and `undefined` pass through unchanged). A plain `fields` erase with no rule instead replaces any value with `*****` regardless of type.
 
+#### Missing fields
+
+By default, `erase` throws a `DataMaskingFieldNotFoundError` when a path in `fields` or a key in `maskingRules` matches nothing in the data, so a typo in a path cannot silently leave a value unmasked. Set `throwOnMissingField: false` on the `DataMasking` constructor to log a warning and continue instead.
+
 ### Encrypting data
 
 ???+ note "About static typing and encryption"

--- a/docs/features/data-masking.md
+++ b/docs/features/data-masking.md
@@ -156,7 +156,9 @@ A top-level rule is applied to every path listed in `fields`. When `fields` is o
 
 #### Missing fields
 
-By default, `erase` throws a `DataMaskingFieldNotFoundError` when a path in `fields` or a key in `maskingRules` matches nothing in the data, so a typo in a path cannot silently leave a value unmasked. Set `throwOnMissingField: false` on the `DataMasking` constructor to log a warning and continue instead.
+By default, `erase`, `encrypt` and `decrypt` throw a `DataMaskingFieldNotFoundError` when a path in `fields` or a key in `maskingRules` matches nothing in the data, so a typo in a path cannot silently leave a value unprotected. Set `throwOnMissingField: false` on the `DataMasking` constructor to log a warning and continue instead.
+
+A wildcard that expands to nothing, such as `orders[*].card` when `orders` is an empty array, is not a missing field. When a path and one of its descendants are both listed, only the parent is processed, since masking or encrypting it already covers everything beneath it.
 
 ### Encrypting data
 

--- a/packages/data-masking/src/DataMasking.ts
+++ b/packages/data-masking/src/DataMasking.ts
@@ -121,10 +121,7 @@ export class DataMasking {
   ): Set<string> {
     const touched = new Set<string>();
     for (const [field, rule] of Object.entries(rules)) {
-      for (const path of this.#resolveFieldPaths(
-        copy as Record<string, unknown>,
-        field
-      )) {
+      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
         setAtPath(copy, path, maskLeaf(getAtPath(copy, path), rule));
         touched.add(pathKey(path));
       }
@@ -140,19 +137,7 @@ export class DataMasking {
     skip?: Set<string>
   ): void {
     for (const field of fields) {
-      const paths = this.#resolveFieldPaths(
-        copy as Record<string, unknown>,
-        field
-      );
-      if (paths.length === 0) {
-        if (this.#throwOnMissingField) {
-          throw new DataMaskingFieldNotFoundError(
-            `Field not found: '${field}'`
-          );
-        }
-        console.warn(`Field not found: '${field}'`);
-      }
-      for (const path of paths) {
+      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
         if (skip?.has(pathKey(path))) continue;
         // A plain field erase replaces any value with the mask; a rule stringifies
         // the leaf first (null/undefined pass through), matching the Python utility.
@@ -274,6 +259,25 @@ export class DataMasking {
     }
 
     await Promise.all(operations);
+  }
+
+  /**
+   * Resolve a path expression, throwing or warning per `throwOnMissingField`
+   * when it matches nothing in the data.
+   */
+  #resolvePathsOrReportMissing<T>(copy: T, field: string): string[][] {
+    const paths = this.#resolveFieldPaths(
+      copy as Record<string, unknown>,
+      field
+    );
+    if (paths.length === 0) {
+      if (this.#throwOnMissingField) {
+        throw new DataMaskingFieldNotFoundError(`Field not found: '${field}'`);
+      }
+      console.warn(`Field not found: '${field}'`);
+    }
+
+    return paths;
   }
 
   #resolveFieldPaths(

--- a/packages/data-masking/src/DataMasking.ts
+++ b/packages/data-masking/src/DataMasking.ts
@@ -41,7 +41,7 @@ export class DataMasking {
   }
 
   /**
-   * Irreversibly mask the entire payload with the default mask value:
+   * Irreversibly masks the entire payload with the default mask value:
    * arrays element-wise preserving their length, and everything else
    * with a single mask string.
    *
@@ -49,10 +49,10 @@ export class DataMasking {
    */
   erase<T>(data: T): MaskedPayload<T>;
   /**
-   * Irreversibly mask fields in a data object. Returns a deep copy.
+   * Irreversibly masks fields in a data object and returns a deep copy.
    *
-   * The options compose three layers (see {@link EraseOptions}):
-   * - a top-level {@link MaskingRule} (`regexPattern` + `maskFormat`, `dynamicMask`,
+   * The options compose three layers (see {@link EraseOptions | `EraseOptions`}):
+   * - a top-level {@link MaskingRule | `MaskingRule`} (`regexPattern` + `maskFormat`, `dynamicMask`,
    *   or `customMask`) sets the default masking strategy;
    * - `fields` selects the paths to mask with that strategy — when omitted, a
    *   top-level rule is applied to every leaf value in the payload;
@@ -70,7 +70,7 @@ export class DataMasking {
    * ```
    *
    * @param data - The data to mask; returned as-is when `null` or `undefined`
-   * @param options - Options for the operation, see {@link EraseOptions}
+   * @param options - Options for the operation, see {@link EraseOptions | `EraseOptions`}
    */
   erase<T>(data: T, options: EraseOptions): T;
   erase(data: unknown, options?: EraseOptions): unknown {
@@ -126,8 +126,10 @@ export class DataMasking {
   }
 
   /**
-   * Encrypt data using the configured provider. With fields, encrypts
-   * specific values in place. Without fields, encrypts the entire payload.
+   * Encrypts data using the configured provider.
+   *
+   * With `fields`, encrypts the matched values in place and returns a deep copy;
+   * without `fields`, encrypts the entire payload into a single string.
    *
    * @example
    * ```typescript
@@ -136,6 +138,9 @@ export class DataMasking {
    *   context: { tenantId: 'acme' },
    * });
    * ```
+   *
+   * @param data - The data to encrypt
+   * @param options - Options for the operation, see {@link EncryptOptions | `EncryptOptions`}
    */
   async encrypt<T>(data: T, options?: EncryptOptions): Promise<T | string> {
     const provider = this.#requireProvider();
@@ -161,8 +166,10 @@ export class DataMasking {
   }
 
   /**
-   * Decrypt data using the configured provider. Automatically detects
-   * full-payload (string input) vs field-level (object input) format.
+   * Decrypts data using the configured provider.
+   *
+   * A string input is treated as a full encrypted payload; an object input is
+   * deep copied and the values at `fields` are decrypted in place.
    *
    * @example
    * ```typescript
@@ -170,11 +177,15 @@ export class DataMasking {
    *   fields: ['customer.ssn'],
    * });
    * ```
+   *
+   * @param data - The encrypted payload string or an object holding encrypted fields
+   * @param options - Options for the operation, see {@link DecryptOptions | `DecryptOptions`}
    */
   async decrypt<T>(data: T | string, options?: DecryptOptions): Promise<T> {
     const provider = this.#requireProvider();
 
     if (typeof data === 'string') {
+      // Safe by contract: a string payload is the output of `encrypt` without `fields`.
       return JSON.parse(await provider.decrypt(data, options?.context)) as T;
     }
 
@@ -197,6 +208,9 @@ export class DataMasking {
     return copy;
   }
 
+  /**
+   * Returns the configured encryption provider or throws when none was given.
+   */
   #requireProvider(): EncryptionProvider {
     if (!this.#provider) {
       throw new DataMaskingEncryptionError(
@@ -207,6 +221,11 @@ export class DataMasking {
     return this.#provider;
   }
 
+  /**
+   * Returns a structured clone of `data`, wrapping cloning failures in a package error.
+   *
+   * @param data - The data to clone
+   */
   #deepCopy<T>(data: T): T {
     try {
       return structuredClone(data);
@@ -217,13 +236,22 @@ export class DataMasking {
     }
   }
 
-  async #transformFields<T>(
-    data: T,
+  /**
+   * Replaces the value at every path matched by `fields` with the result of `transform`,
+   * mutating `data` in place.
+   *
+   * All paths are resolved before the first `transform` call, so a missing field
+   * cannot leave earlier provider calls in flight without a rejection handler.
+   *
+   * @param data - The object to transform in place
+   * @param fields - Path expressions selecting the values to transform
+   * @param transform - Async function producing the replacement for a value
+   */
+  async #transformFields(
+    data: unknown,
     fields: string[],
     transform: (value: unknown) => Promise<unknown>
   ): Promise<void> {
-    // Resolve every path before calling the provider, so a missing field cannot
-    // leave earlier provider calls in flight with no rejection handler.
     const targets = new Map<string, MaskTarget>();
     for (const field of fields) {
       for (const path of this.#resolvePaths(data, field)) {
@@ -231,20 +259,20 @@ export class DataMasking {
       }
     }
 
+    const transformAt = async (path: string[]): Promise<void> => {
+      const result = await transform(getAtPath(data, path));
+      setAtPath(data, path, result);
+    };
     const operations: Promise<void>[] = [];
     for (const { path } of withoutSubsumed(targets)) {
-      operations.push(
-        transform(getAtPath(data, path)).then((result) =>
-          setAtPath(data, path, result)
-        )
-      );
+      operations.push(transformAt(path));
     }
 
     await Promise.all(operations);
   }
 
   /**
-   * Expand a path expression into every concrete path it matches in `data`,
+   * Expands a path expression into every concrete path it matches in `data`,
    * throwing or warning per `throwOnMissingField` when it matches nothing.
    *
    * A wildcard over an empty collection is a match with no paths, not a missing
@@ -252,27 +280,30 @@ export class DataMasking {
    * (`__proto__`, `constructor`, `prototype`) never resolve, whether named directly
    * or reached through a wildcard, which keeps the in-place assignment free of
    * prototype pollution.
+   *
+   * @param data - The object to resolve the expression against
+   * @param expression - Dot-notation path, optionally with `.*` or `[*]` wildcards
    */
   #resolvePaths(data: unknown, expression: string): string[][] {
     const segments = expression.split(/\.|\[(\*)\]\.?/).filter(Boolean);
     const paths: string[][] = [];
     let missing = false;
 
-    const walk = (obj: unknown, i: number, current: string[]): void => {
-      if (i === segments.length) {
+    const walk = (node: unknown, depth: number, current: string[]): void => {
+      if (depth === segments.length) {
         paths.push(current);
 
         return;
       }
-      if (obj == null || typeof obj !== 'object') {
+      if (node == null || typeof node !== 'object') {
         missing = true;
 
         return;
       }
-      const entries = resolveWildcardEntries(obj, segments[i]);
-      if (entries.length === 0 && segments[i] !== '*') missing = true;
+      const entries = childEntries(node, segments[depth]);
+      if (entries.length === 0 && segments[depth] !== '*') missing = true;
       for (const [key, child] of entries) {
-        walk(child, i + 1, [...current, key]);
+        walk(child, depth + 1, [...current, key]);
       }
     };
     if (segments.length === 0) {
@@ -294,12 +325,19 @@ export class DataMasking {
   }
 }
 
+/** Keys that never resolve as path segments, so masking cannot touch an object's prototype. */
 const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 /** A resolved concrete path and the rule to mask it with; no rule means the default mask. */
 type MaskTarget = { path: string[]; rule?: MaskingRule };
 
-/** Record `path` as a target unless an earlier expression already claimed it. */
+/**
+ * Records `path` as a target unless an earlier expression already claimed it.
+ *
+ * @param targets - Targets collected so far, keyed by {@link pathKey | `pathKey`}
+ * @param path - The concrete path to claim
+ * @param rule - The rule to mask the path with; omit for the default mask
+ */
 const claim = (
   targets: Map<string, MaskTarget>,
   path: string[],
@@ -310,9 +348,12 @@ const claim = (
 };
 
 /**
- * Drop targets that sit beneath another target: masking or encrypting a parent
- * already covers everything under it, and applying it first would hand the
- * parent's rule already-transformed children.
+ * Drops targets that sit beneath another target.
+ *
+ * Masking or encrypting a parent already covers everything under it, and applying
+ * a child first would hand the parent's rule already-transformed children.
+ *
+ * @param targets - Targets collected by {@link claim | `claim`}
  */
 const withoutSubsumed = (targets: Map<string, MaskTarget>): MaskTarget[] => {
   const kept: MaskTarget[] = [];
@@ -323,6 +364,12 @@ const withoutSubsumed = (targets: Map<string, MaskTarget>): MaskTarget[] => {
   return kept;
 };
 
+/**
+ * Returns whether any proper prefix of `path` is itself a target.
+ *
+ * @param targets - Targets collected by {@link claim | `claim`}
+ * @param path - The concrete path to check
+ */
 const hasTargetedAncestor = (
   targets: Map<string, MaskTarget>,
   path: string[]
@@ -335,62 +382,105 @@ const hasTargetedAncestor = (
 };
 
 /**
- * Whether `key` names an own, non-reserved entry of `obj`. A present key with an
- * `undefined` value counts; on arrays only index keys do, so `length` never resolves.
+ * Reads the property `key` of `node`.
+ *
+ * @param node - A plain object or array reached by walking a resolved path
+ * @param key - Own property name or array index
  */
-const hasOwnEntry = (obj: object, key: string): boolean =>
+const propertyOf = (node: unknown, key: string): unknown =>
+  // Safe: `key` always comes from `childEntries` on this same `node`, so it is an own,
+  // non-reserved property and `node` is a container the path already walked through.
+  (node as Record<string, unknown>)[key];
+
+/**
+ * Returns whether `key` names an own, non-reserved entry of `node`.
+ *
+ * A present key with an `undefined` value counts; on arrays only index keys do, so
+ * `length` never resolves.
+ *
+ * @param node - The object or array to inspect
+ * @param key - The candidate property name
+ */
+const hasOwnEntry = (node: object, key: string): boolean =>
   !RESERVED_KEYS.has(key) &&
-  Object.hasOwn(obj, key) &&
-  (!Array.isArray(obj) || /^\d+$/.test(key));
+  Object.hasOwn(node, key) &&
+  (!Array.isArray(node) || /^\d+$/.test(key));
 
-const resolveWildcardEntries = (
-  obj: object,
-  segment: string
-): [string, unknown][] => {
+/**
+ * Lists the `[key, value]` entries of `node` selected by one path segment.
+ *
+ * A literal segment yields at most one entry; the `*` wildcard yields every array
+ * index or every own, non-reserved object key.
+ *
+ * @param node - The object or array to read from
+ * @param segment - A property name, array index, or `*`
+ */
+const childEntries = (node: object, segment: string): [string, unknown][] => {
   if (segment !== '*') {
-    if (!hasOwnEntry(obj, segment)) return [];
-
-    return [[segment, (obj as Record<string, unknown>)[segment]]];
-  }
-  if (Array.isArray(obj)) {
-    return obj.map((v, i) => [String(i), v]);
+    return hasOwnEntry(node, segment)
+      ? [[segment, propertyOf(node, segment)]]
+      : [];
   }
 
-  return Object.keys(obj)
-    .filter((k) => !RESERVED_KEYS.has(k))
-    .map((k) => [k, (obj as Record<string, unknown>)[k]]);
+  const entries: [string, unknown][] = [];
+  if (Array.isArray(node)) {
+    for (const [index, value] of node.entries()) {
+      entries.push([String(index), value]);
+    }
+
+    return entries;
+  }
+  for (const key of Object.keys(node)) {
+    if (!RESERVED_KEYS.has(key)) entries.push([key, propertyOf(node, key)]);
+  }
+
+  return entries;
 };
 
+/**
+ * Reads the value at `path`.
+ *
+ * @param data - The object the path was resolved against
+ * @param path - A concrete path produced by `#resolvePaths`
+ */
 const getAtPath = (data: unknown, path: string[]): unknown => {
-  let current = data as Record<string, unknown>;
+  let current = data;
   for (const key of path) {
-    current = current[key] as Record<string, unknown>;
+    current = propertyOf(current, key);
   }
 
   return current;
 };
 
 /**
- * Set `value` at the location identified by `path`, mutating `data` in place.
+ * Sets `value` at the location identified by `path`, mutating `data` in place.
  *
  * Walks every path segment except the last to reach the parent container, then
  * assigns the value to the final segment. Assumes the path was produced by
  * `#resolvePaths` against the same object, so it is non-empty, free of
  * reserved keys, and its intermediate containers exist.
+ *
+ * @param data - The object the path was resolved against
+ * @param path - A concrete path produced by `#resolvePaths`
+ * @param value - The replacement value
  */
 const setAtPath = (data: unknown, path: string[], value: unknown): void => {
-  let current = data as Record<string, unknown>;
-  for (let i = 0; i < path.length - 1; i++) {
-    current = current[path[i]] as Record<string, unknown>;
+  let parent = data;
+  for (const key of path.slice(0, -1)) {
+    parent = propertyOf(parent, key);
   }
-  current[path[path.length - 1]] = value;
+  // Safe: `parent` is an intermediate container that `#resolvePaths` walked through.
+  (parent as Record<string, unknown>)[path[path.length - 1]] = value;
 };
 
 /**
- * Apply a single {@link MaskingRule} to a string value.
+ * Applies a single masking rule to a string value.
  *
- * The strategies are mutually exclusive by construction (see {@link MaskingRule}),
+ * The strategies are mutually exclusive by construction (see {@link MaskingRule | `MaskingRule`}),
  * so each branch checks for the one property that identifies its variant.
+ *
+ * @param value - The string to mask
+ * @param rule - The rule to apply
  */
 const applyMaskingRule = (value: string, rule: MaskingRule): string => {
   if (rule.regexPattern)
@@ -402,32 +492,48 @@ const applyMaskingRule = (value: string, rule: MaskingRule): string => {
   return DEFAULT_MASK_VALUE;
 };
 
-/** Whether a top-level rule object actually configures a masking strategy. */
+/**
+ * Returns whether a top-level rule object actually configures a masking strategy.
+ *
+ * @param rule - The remaining top-level options after `fields` and `maskingRules` are removed
+ */
 const isMaskingRule = (rule: MaskingRule): boolean =>
   rule.regexPattern !== undefined ||
   rule.customMask !== undefined ||
   rule.dynamicMask !== undefined;
 
 /**
- * Mask a single leaf value with a rule.
+ * Masks a single leaf value with a rule.
  *
  * Leaves are stringified first so the rule applies uniformly to non-string
  * primitives (e.g. `dynamicMask` over a number), matching erase's contract that
  * masked values become strings. `null`/`undefined` pass through unchanged.
+ *
+ * @param value - The leaf value to mask
+ * @param rule - The rule to apply
  */
 const maskLeaf = (value: unknown, rule: MaskingRule): unknown =>
   isNullOrUndefined(value) ? value : applyMaskingRule(String(value), rule);
 
-/** Recursively apply a rule to every leaf value, mutating `node` in place. */
+/**
+ * Recursively applies a rule to every leaf value, mutating `node` in place.
+ *
+ * @param node - The object or array to walk
+ * @param rule - The rule to apply to each leaf
+ */
 const applyRuleToLeaves = (node: object, rule: MaskingRule): void => {
-  for (const [key, child] of resolveWildcardEntries(node, '*')) {
+  for (const [key, child] of childEntries(node, '*')) {
     if (child !== null && typeof child === 'object') {
       applyRuleToLeaves(child, rule);
     } else {
-      (node as Record<string, unknown>)[key] = maskLeaf(child, rule);
+      setAtPath(node, [key], maskLeaf(child, rule));
     }
   }
 };
 
-/** Stable string key for a resolved path, used to dedupe targets. */
+/**
+ * Builds a stable string key for a resolved path, used to dedupe targets.
+ *
+ * @param path - The concrete path to key
+ */
 const pathKey = (path: string[]): string => JSON.stringify(path);

--- a/packages/data-masking/src/DataMasking.ts
+++ b/packages/data-masking/src/DataMasking.ts
@@ -98,31 +98,21 @@ export class DataMasking {
 
     const copy = this.#deepCopy(data);
 
-    // Resolve every path against the untouched copy before masking anything, so a
-    // rule that collapses a parent cannot make another expression's path vanish.
-    const targets: MaskTarget[] = [];
-    const overridden = new Set<string>();
+    // Resolve every path against the untouched copy before masking anything. Rules
+    // are claimed first so they win over the top-level rule for the paths they name.
+    const targets = new Map<string, MaskTarget>();
     for (const [field, rule] of Object.entries(maskingRules ?? {})) {
-      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
-        targets.push({ path, rule });
-        overridden.add(pathKey(path));
+      for (const path of this.#resolvePaths(copy, field)) {
+        claim(targets, path, rule);
       }
     }
     for (const field of fields ?? []) {
-      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
-        // Per-field rules win over the top-level rule for the paths they name.
-        if (overridden.has(pathKey(path))) continue;
-        targets.push({
-          path,
-          rule: hasTopLevelRule ? topLevelRule : undefined,
-        });
+      for (const path of this.#resolvePaths(copy, field)) {
+        claim(targets, path, hasTopLevelRule ? topLevelRule : undefined);
       }
     }
 
-    // Deepest paths first, so masking a parent never traverses a leaf that has
-    // already been replaced with a string.
-    targets.sort((a, b) => b.path.length - a.path.length);
-    for (const { path, rule } of targets) {
+    for (const { path, rule } of withoutSubsumed(targets)) {
       // A plain field erase replaces any value with the mask; a rule stringifies
       // the leaf first (null/undefined pass through), matching the Python utility.
       setAtPath(
@@ -160,7 +150,10 @@ export class DataMasking {
     }
 
     const copy = this.#deepCopy(data);
-    await this.#transformFields(copy, options.fields, (value) => {
+    await this.#transformFields(copy, options.fields, async (value) => {
+      // Nothing to protect; matches how a masking rule passes `undefined` through.
+      if (value === undefined) return value;
+
       return provider.encrypt(JSON.stringify(value), options.context);
     });
 
@@ -188,6 +181,7 @@ export class DataMasking {
     const copy = this.#deepCopy(data);
     if (options?.fields) {
       await this.#transformFields(copy, options.fields, async (value) => {
+        if (value === undefined) return value;
         if (!isString(value)) {
           console.warn(
             `Skipping decryption of non-string value of type ${typeof value}; expected an encrypted string`
@@ -228,63 +222,73 @@ export class DataMasking {
     fields: string[],
     transform: (value: unknown) => Promise<unknown>
   ): Promise<void> {
-    const operations: Promise<void>[] = [];
-
+    // Resolve every path before calling the provider, so a missing field cannot
+    // leave earlier provider calls in flight with no rejection handler.
+    const targets = new Map<string, MaskTarget>();
     for (const field of fields) {
-      for (const path of this.#resolvePathsOrReportMissing(data, field)) {
-        operations.push(
-          transform(getAtPath(data, path)).then((result) =>
-            setAtPath(data, path, result)
-          )
-        );
+      for (const path of this.#resolvePaths(data, field)) {
+        claim(targets, path);
       }
+    }
+
+    const operations: Promise<void>[] = [];
+    for (const { path } of withoutSubsumed(targets)) {
+      operations.push(
+        transform(getAtPath(data, path)).then((result) =>
+          setAtPath(data, path, result)
+        )
+      );
     }
 
     await Promise.all(operations);
   }
 
   /**
-   * Resolve a path expression, throwing or warning per `throwOnMissingField`
-   * when it matches nothing in the data.
-   */
-  #resolvePathsOrReportMissing(data: unknown, field: string): string[][] {
-    const paths = this.#resolveFieldPaths(data, field);
-    if (paths.length === 0) {
-      if (this.#throwOnMissingField) {
-        throw new DataMaskingFieldNotFoundError(`Field not found: '${field}'`);
-      }
-      console.warn(`Field not found: '${field}'`);
-    }
-
-    return paths;
-  }
-
-  /**
-   * Expand a path expression into every concrete path it matches in `data`.
+   * Expand a path expression into every concrete path it matches in `data`,
+   * throwing or warning per `throwOnMissingField` when it matches nothing.
    *
-   * Reserved keys (`__proto__`, `constructor`, `prototype`) never resolve, whether
-   * named directly or reached through a wildcard, which is what keeps the later
-   * in-place assignment free of prototype pollution.
+   * A wildcard over an empty collection is a match with no paths, not a missing
+   * field; only an absent non-wildcard segment counts as missing. Reserved keys
+   * (`__proto__`, `constructor`, `prototype`) never resolve, whether named directly
+   * or reached through a wildcard, which keeps the in-place assignment free of
+   * prototype pollution.
    */
-  #resolveFieldPaths(data: unknown, expression: string): string[][] {
+  #resolvePaths(data: unknown, expression: string): string[][] {
     const segments = expression.split(/\.|\[(\*)\]\.?/).filter(Boolean);
-    if (segments.length === 0) return [];
-
     const paths: string[][] = [];
+    let missing = false;
+
     const walk = (obj: unknown, i: number, current: string[]): void => {
       if (i === segments.length) {
         paths.push(current);
 
         return;
       }
-      if (obj == null || typeof obj !== 'object') return;
+      if (obj == null || typeof obj !== 'object') {
+        missing = true;
 
-      for (const [key, child] of resolveWildcardEntries(obj, segments[i])) {
+        return;
+      }
+      const entries = resolveWildcardEntries(obj, segments[i]);
+      if (entries.length === 0 && segments[i] !== '*') missing = true;
+      for (const [key, child] of entries) {
         walk(child, i + 1, [...current, key]);
       }
     };
+    if (segments.length === 0) {
+      missing = true;
+    } else {
+      walk(data, 0, []);
+    }
 
-    walk(data, 0, []);
+    if (paths.length === 0 && missing) {
+      if (this.#throwOnMissingField) {
+        throw new DataMaskingFieldNotFoundError(
+          `Field not found: '${expression}'`
+        );
+      }
+      console.warn(`Field not found: '${expression}'`);
+    }
 
     return paths;
   }
@@ -295,13 +299,56 @@ const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 /** A resolved concrete path and the rule to mask it with; no rule means the default mask. */
 type MaskTarget = { path: string[]; rule?: MaskingRule };
 
+/** Record `path` as a target unless an earlier expression already claimed it. */
+const claim = (
+  targets: Map<string, MaskTarget>,
+  path: string[],
+  rule?: MaskingRule
+): void => {
+  const key = pathKey(path);
+  if (!targets.has(key)) targets.set(key, { path, rule });
+};
+
+/**
+ * Drop targets that sit beneath another target: masking or encrypting a parent
+ * already covers everything under it, and applying it first would hand the
+ * parent's rule already-transformed children.
+ */
+const withoutSubsumed = (targets: Map<string, MaskTarget>): MaskTarget[] => {
+  const kept: MaskTarget[] = [];
+  for (const target of targets.values()) {
+    if (!hasTargetedAncestor(targets, target.path)) kept.push(target);
+  }
+
+  return kept;
+};
+
+const hasTargetedAncestor = (
+  targets: Map<string, MaskTarget>,
+  path: string[]
+): boolean => {
+  for (let depth = 1; depth < path.length; depth++) {
+    if (targets.has(pathKey(path.slice(0, depth)))) return true;
+  }
+
+  return false;
+};
+
+/**
+ * Whether `key` names an own, non-reserved entry of `obj`. A present key with an
+ * `undefined` value counts; on arrays only index keys do, so `length` never resolves.
+ */
+const hasOwnEntry = (obj: object, key: string): boolean =>
+  !RESERVED_KEYS.has(key) &&
+  Object.hasOwn(obj, key) &&
+  (!Array.isArray(obj) || /^\d+$/.test(key));
+
 const resolveWildcardEntries = (
   obj: object,
   segment: string
 ): [string, unknown][] => {
   if (segment !== '*') {
-    // A present key with an `undefined` value still resolves; only absent keys do not.
-    if (RESERVED_KEYS.has(segment) || !Object.hasOwn(obj, segment)) return [];
+    if (!hasOwnEntry(obj, segment)) return [];
 
     return [[segment, (obj as Record<string, unknown>)[segment]]];
   }
@@ -328,7 +375,7 @@ const getAtPath = (data: unknown, path: string[]): unknown => {
  *
  * Walks every path segment except the last to reach the parent container, then
  * assigns the value to the final segment. Assumes the path was produced by
- * `#resolveFieldPaths` against the same object, so it is non-empty, free of
+ * `#resolvePaths` against the same object, so it is non-empty, free of
  * reserved keys, and its intermediate containers exist.
  */
 const setAtPath = (data: unknown, path: string[], value: unknown): void => {
@@ -373,13 +420,7 @@ const maskLeaf = (value: unknown, rule: MaskingRule): unknown =>
 
 /** Recursively apply a rule to every leaf value, mutating `node` in place. */
 const applyRuleToLeaves = (node: object, rule: MaskingRule): void => {
-  const entries: [string, unknown][] = Array.isArray(node)
-    ? node.map((v, i) => [String(i), v])
-    : Object.keys(node)
-        .filter((k) => !RESERVED_KEYS.has(k))
-        .map((k) => [k, (node as Record<string, unknown>)[k]]);
-
-  for (const [key, child] of entries) {
+  for (const [key, child] of resolveWildcardEntries(node, '*')) {
     if (child !== null && typeof child === 'object') {
       applyRuleToLeaves(child, rule);
     } else {
@@ -388,5 +429,5 @@ const applyRuleToLeaves = (node: object, rule: MaskingRule): void => {
   }
 };
 
-/** Stable string key for a resolved path, used to dedupe overridden paths. */
+/** Stable string key for a resolved path, used to dedupe targets. */
 const pathKey = (path: string[]): string => JSON.stringify(path);

--- a/packages/data-masking/src/DataMasking.ts
+++ b/packages/data-masking/src/DataMasking.ts
@@ -98,56 +98,41 @@ export class DataMasking {
 
     const copy = this.#deepCopy(data);
 
-    // Per-field rules win, so apply them first (against the original values) and
-    // skip those concrete paths when the `fields` pass runs.
-    const overridden = maskingRules
-      ? this.#applyMaskingRules(copy, maskingRules)
-      : new Set<string>();
-    if (fields) {
-      this.#eraseFields(
+    // Resolve every path against the untouched copy before masking anything, so a
+    // rule that collapses a parent cannot make another expression's path vanish.
+    const targets: MaskTarget[] = [];
+    const overridden = new Set<string>();
+    for (const [field, rule] of Object.entries(maskingRules ?? {})) {
+      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
+        targets.push({ path, rule });
+        overridden.add(pathKey(path));
+      }
+    }
+    for (const field of fields ?? []) {
+      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
+        // Per-field rules win over the top-level rule for the paths they name.
+        if (overridden.has(pathKey(path))) continue;
+        targets.push({
+          path,
+          rule: hasTopLevelRule ? topLevelRule : undefined,
+        });
+      }
+    }
+
+    // Deepest paths first, so masking a parent never traverses a leaf that has
+    // already been replaced with a string.
+    targets.sort((a, b) => b.path.length - a.path.length);
+    for (const { path, rule } of targets) {
+      // A plain field erase replaces any value with the mask; a rule stringifies
+      // the leaf first (null/undefined pass through), matching the Python utility.
+      setAtPath(
         copy,
-        fields,
-        hasTopLevelRule ? topLevelRule : undefined,
-        overridden
+        path,
+        rule ? maskLeaf(getAtPath(copy, path), rule) : DEFAULT_MASK_VALUE
       );
     }
 
     return copy;
-  }
-
-  #applyMaskingRules<T>(
-    copy: T,
-    rules: Record<string, MaskingRule>
-  ): Set<string> {
-    const touched = new Set<string>();
-    for (const [field, rule] of Object.entries(rules)) {
-      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
-        setAtPath(copy, path, maskLeaf(getAtPath(copy, path), rule));
-        touched.add(pathKey(path));
-      }
-    }
-
-    return touched;
-  }
-
-  #eraseFields<T>(
-    copy: T,
-    fields: string[],
-    rule?: MaskingRule,
-    skip?: Set<string>
-  ): void {
-    for (const field of fields) {
-      for (const path of this.#resolvePathsOrReportMissing(copy, field)) {
-        if (skip?.has(pathKey(path))) continue;
-        // A plain field erase replaces any value with the mask; a rule stringifies
-        // the leaf first (null/undefined pass through), matching the Python utility.
-        setAtPath(
-          copy,
-          path,
-          rule ? maskLeaf(getAtPath(copy, path), rule) : DEFAULT_MASK_VALUE
-        );
-      }
-    }
   }
 
   /**
@@ -246,10 +231,7 @@ export class DataMasking {
     const operations: Promise<void>[] = [];
 
     for (const field of fields) {
-      for (const path of this.#resolveFieldPaths(
-        data as Record<string, unknown>,
-        field
-      )) {
+      for (const path of this.#resolvePathsOrReportMissing(data, field)) {
         operations.push(
           transform(getAtPath(data, path)).then((result) =>
             setAtPath(data, path, result)
@@ -265,11 +247,8 @@ export class DataMasking {
    * Resolve a path expression, throwing or warning per `throwOnMissingField`
    * when it matches nothing in the data.
    */
-  #resolvePathsOrReportMissing<T>(copy: T, field: string): string[][] {
-    const paths = this.#resolveFieldPaths(
-      copy as Record<string, unknown>,
-      field
-    );
+  #resolvePathsOrReportMissing(data: unknown, field: string): string[][] {
+    const paths = this.#resolveFieldPaths(data, field);
     if (paths.length === 0) {
       if (this.#throwOnMissingField) {
         throw new DataMaskingFieldNotFoundError(`Field not found: '${field}'`);
@@ -280,11 +259,16 @@ export class DataMasking {
     return paths;
   }
 
-  #resolveFieldPaths(
-    data: Record<string, unknown>,
-    expression: string
-  ): string[][] {
+  /**
+   * Expand a path expression into every concrete path it matches in `data`.
+   *
+   * Reserved keys (`__proto__`, `constructor`, `prototype`) never resolve, whether
+   * named directly or reached through a wildcard, which is what keeps the later
+   * in-place assignment free of prototype pollution.
+   */
+  #resolveFieldPaths(data: unknown, expression: string): string[][] {
     const segments = expression.split(/\.|\[(\*)\]\.?/).filter(Boolean);
+    if (segments.length === 0) return [];
 
     const paths: string[][] = [];
     const walk = (obj: unknown, i: number, current: string[]): void => {
@@ -308,16 +292,18 @@ export class DataMasking {
 
 const RESERVED_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
+/** A resolved concrete path and the rule to mask it with; no rule means the default mask. */
+type MaskTarget = { path: string[]; rule?: MaskingRule };
+
 const resolveWildcardEntries = (
   obj: object,
   segment: string
 ): [string, unknown][] => {
   if (segment !== '*') {
-    const next = (obj as Record<string, unknown>)[segment];
+    // A present key with an `undefined` value still resolves; only absent keys do not.
+    if (RESERVED_KEYS.has(segment) || !Object.hasOwn(obj, segment)) return [];
 
-    if (next === undefined) return [];
-
-    return [[segment, next]];
+    return [[segment, (obj as Record<string, unknown>)[segment]]];
   }
   if (Array.isArray(obj)) {
     return obj.map((v, i) => [String(i), v]);
@@ -331,7 +317,6 @@ const resolveWildcardEntries = (
 const getAtPath = (data: unknown, path: string[]): unknown => {
   let current = data as Record<string, unknown>;
   for (const key of path) {
-    if (RESERVED_KEYS.has(key)) return undefined;
     current = current[key] as Record<string, unknown>;
   }
 
@@ -341,20 +326,17 @@ const getAtPath = (data: unknown, path: string[]): unknown => {
 /**
  * Set `value` at the location identified by `path`, mutating `data` in place.
  *
- * Walks every path segment except the last to reach the parent container,
- * then assigns the value to the final segment. Assumes the path was produced
- * by `#resolveFieldPaths` against the same object, so intermediate containers
- * are known to exist. Assignments to reserved keys (`__proto__`, `constructor`,
- * `prototype`) are skipped to prevent prototype pollution.
+ * Walks every path segment except the last to reach the parent container, then
+ * assigns the value to the final segment. Assumes the path was produced by
+ * `#resolveFieldPaths` against the same object, so it is non-empty, free of
+ * reserved keys, and its intermediate containers exist.
  */
 const setAtPath = (data: unknown, path: string[], value: unknown): void => {
   let current = data as Record<string, unknown>;
   for (let i = 0; i < path.length - 1; i++) {
     current = current[path[i]] as Record<string, unknown>;
   }
-  const lastKey = path.at(-1);
-  if (!lastKey || RESERVED_KEYS.has(lastKey)) return;
-  current[lastKey] = value;
+  current[path[path.length - 1]] = value;
 };
 
 /**

--- a/packages/data-masking/src/types.ts
+++ b/packages/data-masking/src/types.ts
@@ -13,7 +13,12 @@ export interface EncryptionProvider {
 export interface DataMaskingConstructorOptions {
   /** Encryption provider for encrypt/decrypt operations. */
   provider?: EncryptionProvider;
-  /** Whether to throw when a field path doesn't match. Default: `true`. */
+  /**
+   * Whether `erase`, `encrypt` and `decrypt` throw when a path in `fields` or a key in
+   * `maskingRules` matches nothing in the data. When `false`, a warning is logged and
+   * the path is skipped. A wildcard over an empty collection is not a missing field.
+   * Default: `true`.
+   */
   throwOnMissingField?: boolean;
 }
 

--- a/packages/data-masking/src/types.ts
+++ b/packages/data-masking/src/types.ts
@@ -9,7 +9,7 @@ export interface EncryptionProvider {
   decrypt(data: string, context?: Record<string, string>): Promise<string>;
 }
 
-/** Options for the {@link DataMasking} constructor. */
+/** Options for the {@link DataMasking | `DataMasking`} constructor. */
 export interface DataMaskingConstructorOptions {
   /** Encryption provider for encrypt/decrypt operations. */
   provider?: EncryptionProvider;
@@ -23,7 +23,7 @@ export interface DataMaskingConstructorOptions {
 }
 
 /**
- * Per-field custom masking configuration for {@link DataMasking.erase}.
+ * Per-field custom masking configuration for {@link DataMasking.erase | `DataMasking.erase`}.
  *
  * The masking strategies are mutually exclusive: provide `regexPattern` together
  * with `maskFormat`, or `dynamicMask`, or `customMask`, or an empty rule (`{}`)
@@ -60,17 +60,17 @@ export type MaskingRule =
     };
 
 /**
- * Options for {@link DataMasking.erase}.
+ * Options for {@link DataMasking.erase | `DataMasking.erase`}.
  *
  * All three layers are optional and compose:
- * - a top-level {@link MaskingRule} (`regexPattern` + `maskFormat`, `dynamicMask`, or
+ * - a top-level {@link MaskingRule | `MaskingRule`} (`regexPattern` + `maskFormat`, `dynamicMask`, or
  *   `customMask`) sets the default masking strategy;
  * - `fields` selects the dot-notation paths to mask — when omitted, a top-level rule is
  *   applied to every leaf value in the payload;
  * - `maskingRules` provides per-field rules that take precedence over the top-level rule
  *   for the paths they name.
  *
- * Calling {@link DataMasking.erase} with no options at all replaces the entire payload
+ * Calling {@link DataMasking.erase | `DataMasking.erase`} with no options at all replaces the entire payload
  * with the default mask value.
  */
 export type EraseOptions = MaskingRule & {
@@ -81,7 +81,7 @@ export type EraseOptions = MaskingRule & {
 };
 
 /**
- * Return type of {@link DataMasking.erase} when called without options:
+ * Return type of {@link DataMasking.erase | `DataMasking.erase`} when called without options:
  * arrays are masked element-wise preserving length, `null` and `undefined`
  * pass through unchanged, and everything else collapses to the mask string.
  */
@@ -91,7 +91,7 @@ export type MaskedPayload<T> = T extends null | undefined
     ? string[]
     : string;
 
-/** Options for {@link DataMasking.encrypt}. */
+/** Options for {@link DataMasking.encrypt | `DataMasking.encrypt`}. */
 export interface EncryptOptions {
   /** Dot-notation path expressions for fields to encrypt (supports `.*` and `[*]` wildcards). If omitted, entire payload is encrypted. */
   fields?: string[];
@@ -101,7 +101,7 @@ export interface EncryptOptions {
   providerOptions?: Record<string, unknown>;
 }
 
-/** Options for {@link DataMasking.decrypt}. */
+/** Options for {@link DataMasking.decrypt | `DataMasking.decrypt`}. */
 export interface DecryptOptions {
   /** Dot-notation path expressions for fields to decrypt (supports `.*` and `[*]` wildcards). */
   fields?: string[];

--- a/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
+++ b/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
@@ -1,11 +1,16 @@
 import fc from 'fast-check';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import {
   DataMaskingEncryptionError,
   DataMaskingFieldNotFoundError,
 } from '../../src/errors.js';
 import { DataMasking } from '../../src/index.js';
 import type { EncryptionProvider } from '../../src/types.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 const createMockProvider = (): EncryptionProvider => ({
   encrypt: vi.fn(async (data: string) => `ENC:${data}`),
@@ -129,6 +134,26 @@ describe('DataMasking.encrypt()', () => {
     expect(result).toEqual({ orders: [] });
   });
 
+  it('leaves a present but undefined value untouched and round-trips it', async () => {
+    // Prepare
+    const provider = createMockProvider();
+    const masker = new DataMasking({ provider });
+    const data = { ssn: undefined, name: 'Jane' };
+
+    // Act
+    const encrypted = await masker.encrypt(data, { fields: ['ssn', 'name'] });
+    const decrypted = await masker.decrypt(encrypted, {
+      fields: ['ssn', 'name'],
+    });
+
+    // Assess
+    expect(encrypted).toEqual({ ssn: undefined, name: 'ENC:"Jane"' });
+    expect(decrypted).toEqual({ ssn: undefined, name: 'Jane' });
+    expect(provider.encrypt).toHaveBeenCalledTimes(1);
+    expect(provider.decrypt).toHaveBeenCalledTimes(1);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
   it('encrypts only the parent when both a parent and its child are listed', async () => {
     // Prepare
     const provider = createMockProvider();
@@ -145,7 +170,6 @@ describe('DataMasking.encrypt()', () => {
 
   it('skips missing field with a warning when throwOnMissingField is false', async () => {
     // Prepare
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const lenientMasker = new DataMasking({
       provider: createMockProvider(),
       throwOnMissingField: false,
@@ -159,8 +183,7 @@ describe('DataMasking.encrypt()', () => {
 
     // Assess
     expect(result).toEqual({ ssn: 'ENC:"123"' });
-    expect(warnSpy).toHaveBeenCalledWith("Field not found: 'snn'");
-    warnSpy.mockRestore();
+    expect(console.warn).toHaveBeenCalledWith("Field not found: 'snn'");
   });
 
   it('does not mutate original input', async () => {
@@ -251,7 +274,6 @@ describe('DataMasking.decrypt() - field level', () => {
   });
 
   it('passes through non-string values during field-level decrypt and warns', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = { num: 42, text: 'ENC:"hello"' };
@@ -259,11 +281,10 @@ describe('DataMasking.decrypt() - field level', () => {
     const result = await masker.decrypt(data, { fields: ['num', 'text'] });
 
     expect(result).toEqual({ num: 42, text: 'hello' });
-    expect(warnSpy).toHaveBeenCalledOnce();
-    expect(warnSpy).toHaveBeenCalledWith(
+    expect(console.warn).toHaveBeenCalledOnce();
+    expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('non-string value of type number')
     );
-    warnSpy.mockRestore();
   });
 
   it('rejects the whole operation and leaves the original untouched when one field fails to decrypt', async () => {

--- a/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
+++ b/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
@@ -1,6 +1,9 @@
 import fc from 'fast-check';
 import { describe, expect, it, vi } from 'vitest';
-import { DataMaskingEncryptionError } from '../../src/errors.js';
+import {
+  DataMaskingEncryptionError,
+  DataMaskingFieldNotFoundError,
+} from '../../src/errors.js';
 import { DataMasking } from '../../src/index.js';
 import type { EncryptionProvider } from '../../src/types.js';
 
@@ -90,6 +93,37 @@ describe('DataMasking.encrypt()', () => {
     );
   });
 
+  it('throws DataMaskingFieldNotFoundError for missing field when throwOnMissingField is true', async () => {
+    // Prepare
+    const masker = new DataMasking({ provider: createMockProvider() });
+    const data = { ssn: '123' };
+
+    // Act & Assess
+    await expect(masker.encrypt(data, { fields: ['snn'] })).rejects.toThrow(
+      DataMaskingFieldNotFoundError
+    );
+  });
+
+  it('skips missing field with a warning when throwOnMissingField is false', async () => {
+    // Prepare
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lenientMasker = new DataMasking({
+      provider: createMockProvider(),
+      throwOnMissingField: false,
+    });
+    const data = { ssn: '123' };
+
+    // Act
+    const result = await lenientMasker.encrypt(data, {
+      fields: ['snn', 'ssn'],
+    });
+
+    // Assess
+    expect(result).toEqual({ ssn: 'ENC:"123"' });
+    expect(warnSpy).toHaveBeenCalledWith("Field not found: 'snn'");
+    warnSpy.mockRestore();
+  });
+
   it('does not mutate original input', async () => {
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
@@ -153,6 +187,17 @@ describe('DataMasking.decrypt() - field level', () => {
       name: 'Jane',
       customer: { ssn: '123-45-6789', city: 'Anytown' },
     });
+  });
+
+  it('throws DataMaskingFieldNotFoundError for missing field when throwOnMissingField is true', async () => {
+    // Prepare
+    const masker = new DataMasking({ provider: createMockProvider() });
+    const encrypted = { ssn: 'ENC:"123"' };
+
+    // Act & Assess
+    await expect(
+      masker.decrypt(encrypted, { fields: ['snn'] })
+    ).rejects.toThrow(DataMaskingFieldNotFoundError);
   });
 
   it('returns a copy when decrypting object without fields', async () => {

--- a/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
+++ b/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
@@ -104,6 +104,45 @@ describe('DataMasking.encrypt()', () => {
     );
   });
 
+  it('resolves every field before calling the provider', async () => {
+    // Prepare
+    const provider = createMockProvider();
+    const masker = new DataMasking({ provider });
+    const data = { ssn: '123' };
+
+    // Act & Assess
+    await expect(
+      masker.encrypt(data, { fields: ['ssn', 'snn'] })
+    ).rejects.toThrow(DataMaskingFieldNotFoundError);
+    expect(provider.encrypt).not.toHaveBeenCalled();
+  });
+
+  it('does not report a wildcard over an empty collection as a missing field', async () => {
+    // Prepare
+    const masker = new DataMasking({ provider: createMockProvider() });
+    const data = { orders: [] };
+
+    // Act
+    const result = await masker.encrypt(data, { fields: ['orders[*].card'] });
+
+    // Assess
+    expect(result).toEqual({ orders: [] });
+  });
+
+  it('encrypts only the parent when both a parent and its child are listed', async () => {
+    // Prepare
+    const provider = createMockProvider();
+    const masker = new DataMasking({ provider });
+    const data = { a: { b: 'x' } };
+
+    // Act
+    const result = await masker.encrypt(data, { fields: ['a', 'a.b'] });
+
+    // Assess
+    expect(result).toEqual({ a: 'ENC:{"b":"x"}' });
+    expect(provider.encrypt).toHaveBeenCalledTimes(1);
+  });
+
   it('skips missing field with a warning when throwOnMissingField is false', async () => {
     // Prepare
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
+++ b/packages/data-masking/tests/unit/encrypt-decrypt.test.ts
@@ -19,6 +19,7 @@ const createMockProvider = (): EncryptionProvider => ({
 
 describe('DataMasking.encrypt()', () => {
   it('encrypts specified fields in place', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = {
@@ -26,10 +27,12 @@ describe('DataMasking.encrypt()', () => {
       customer: { ssn: '123-45-6789', city: 'Anytown' },
     };
 
+    // Act
     const result = await masker.encrypt(data, {
       fields: ['customer.ssn'],
     });
 
+    // Assess
     expect(result).toEqual({
       name: 'Jane',
       customer: { ssn: 'ENC:"123-45-6789"', city: 'Anytown' },
@@ -37,9 +40,11 @@ describe('DataMasking.encrypt()', () => {
   });
 
   it('passes encryption context to provider', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
 
+    // Act
     await masker.encrypt(
       { secret: 'val' },
       {
@@ -48,12 +53,14 @@ describe('DataMasking.encrypt()', () => {
       }
     );
 
+    // Assess
     expect(provider.encrypt).toHaveBeenCalledWith('"val"', {
       tenantId: 'acme',
     });
   });
 
   it('encrypts nested and array fields', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = {
@@ -63,17 +70,21 @@ describe('DataMasking.encrypt()', () => {
       ],
     };
 
+    // Act
     const result = await masker.encrypt(data, {
       fields: ['orders[*].card'],
     });
 
     if (typeof result === 'string') throw new Error('Expected object');
+
+    // Assess
     expect(result.orders[0].card).toBe('ENC:"4111"');
     expect(result.orders[1].card).toBe('ENC:"5500"');
     expect(result.orders[0].id).toBe(1);
   });
 
   it('prevents prototype pollution when __proto__ is used as a field path', async () => {
+    // Prepare
     const provider = createMockProvider();
     const lenientMasker = new DataMasking({
       provider,
@@ -81,18 +92,23 @@ describe('DataMasking.encrypt()', () => {
     });
     const data = { safe: 'value' };
 
+    // Act
     const result = await lenientMasker.encrypt(data, {
       fields: ['__proto__', 'safe'],
     });
 
     if (typeof result === 'string') throw new Error('Expected object');
+
+    // Assess
     expect(result.safe).toBe('ENC:"value"');
     expect(Object.getPrototypeOf(result)).toEqual(Object.getPrototypeOf({}));
   });
 
   it('throws DataMaskingEncryptionError without provider', async () => {
+    // Prepare
     const masker = new DataMasking();
 
+    // Act & Assess
     await expect(masker.encrypt({ a: 1 }, { fields: ['a'] })).rejects.toThrow(
       DataMaskingEncryptionError
     );
@@ -187,53 +203,66 @@ describe('DataMasking.encrypt()', () => {
   });
 
   it('does not mutate original input', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = { secret: 'original' };
 
+    // Act
     await masker.encrypt(data, { fields: ['secret'] });
 
+    // Assess
     expect(data.secret).toBe('original');
   });
 });
 
 describe('DataMasking.encrypt() - full payload', () => {
   it('encrypts entire payload when no fields specified', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = { name: 'Jane', ssn: '123-45-6789' };
 
+    // Act
     const result = await masker.encrypt(data);
 
+    // Assess
     expect(typeof result).toBe('string');
     expect(result).toBe(`ENC:${JSON.stringify(data)}`);
   });
 
   it('passes encryption context for full payload', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
 
+    // Act
     await masker.encrypt({ a: 1 }, { context: { env: 'prod' } });
 
+    // Assess
     expect(provider.encrypt).toHaveBeenCalledWith('{"a":1}', { env: 'prod' });
   });
 });
 
 describe('DataMasking.decrypt() - full payload', () => {
   it('decrypts opaque string and restores original data', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const original = { name: 'Jane', age: 30 };
     const encrypted = `ENC:${JSON.stringify(original)}`;
 
+    // Act
     const result = await masker.decrypt(encrypted);
 
+    // Assess
     expect(result).toEqual(original);
   });
 });
 
 describe('DataMasking.decrypt() - field level', () => {
   it('decrypts specified fields and restores original values', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const encrypted = {
@@ -241,10 +270,12 @@ describe('DataMasking.decrypt() - field level', () => {
       customer: { ssn: 'ENC:"123-45-6789"', city: 'Anytown' },
     };
 
+    // Act
     const result = await masker.decrypt(encrypted, {
       fields: ['customer.ssn'],
     });
 
+    // Assess
     expect(result).toEqual({
       name: 'Jane',
       customer: { ssn: '123-45-6789', city: 'Anytown' },
@@ -263,23 +294,29 @@ describe('DataMasking.decrypt() - field level', () => {
   });
 
   it('returns a copy when decrypting object without fields', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = { name: 'Jane', age: 30 };
 
+    // Act
     const result = await masker.decrypt(data);
 
+    // Assess
     expect(result).toEqual(data);
     expect(provider.decrypt).not.toHaveBeenCalled();
   });
 
   it('passes through non-string values during field-level decrypt and warns', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
     const data = { num: 42, text: 'ENC:"hello"' };
 
+    // Act
     const result = await masker.decrypt(data, { fields: ['num', 'text'] });
 
+    // Assess
     expect(result).toEqual({ num: 42, text: 'hello' });
     expect(console.warn).toHaveBeenCalledOnce();
     expect(console.warn).toHaveBeenCalledWith(
@@ -288,6 +325,7 @@ describe('DataMasking.decrypt() - field level', () => {
   });
 
   it('rejects the whole operation and leaves the original untouched when one field fails to decrypt', async () => {
+    // Prepare
     const provider: EncryptionProvider = {
       encrypt: vi.fn(async (data: string) => `ENC:${data}`),
       decrypt: vi.fn(async (data: string) => {
@@ -299,6 +337,7 @@ describe('DataMasking.decrypt() - field level', () => {
     const masker = new DataMasking({ provider });
     const data = { good: 'ENC:"ok"', bad: 'BAD' };
 
+    // Act & Assess
     await expect(
       masker.decrypt(data, { fields: ['good', 'bad'] })
     ).rejects.toThrow('decryption failed');
@@ -306,6 +345,7 @@ describe('DataMasking.decrypt() - field level', () => {
   });
 
   it('rejects the whole operation and leaves the original untouched when one field fails to encrypt', async () => {
+    // Prepare
     const provider: EncryptionProvider = {
       encrypt: vi.fn(async (data: string) => {
         if (data.includes('boom')) throw new Error('encryption failed');
@@ -317,6 +357,7 @@ describe('DataMasking.decrypt() - field level', () => {
     const masker = new DataMasking({ provider });
     const data = { a: 'fine', b: 'boom' };
 
+    // Act & Assess
     await expect(masker.encrypt(data, { fields: ['a', 'b'] })).rejects.toThrow(
       'encryption failed'
     );
@@ -324,8 +365,10 @@ describe('DataMasking.decrypt() - field level', () => {
   });
 
   it('throws DataMaskingEncryptionError without provider', async () => {
+    // Prepare
     const masker = new DataMasking();
 
+    // Act & Assess
     await expect(
       masker.decrypt({ a: 'encrypted' }, { fields: ['a'] })
     ).rejects.toThrow(DataMaskingEncryptionError);
@@ -336,9 +379,11 @@ const pathKey = fc.stringMatching(/^[a-z][a-z0-9_]{0,10}$/);
 
 describe('DataMasking encrypt/decrypt - property tests', () => {
   it('full-payload encrypt then decrypt is identity', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
 
+    // Act & Assess
     await fc.assert(
       fc.asyncProperty(fc.jsonValue(), async (data) => {
         if (data === null || data === undefined) return;
@@ -352,9 +397,11 @@ describe('DataMasking encrypt/decrypt - property tests', () => {
   });
 
   it('parent.* encrypt then decrypt restores original values', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
 
+    // Act & Assess
     await fc.assert(
       fc.asyncProperty(
         pathKey,
@@ -375,9 +422,11 @@ describe('DataMasking encrypt/decrypt - property tests', () => {
   });
 
   it('parent[*].child encrypt then decrypt restores original values', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
 
+    // Act & Assess
     await fc.assert(
       fc.asyncProperty(
         pathKey,
@@ -401,9 +450,11 @@ describe('DataMasking encrypt/decrypt - property tests', () => {
   });
 
   it('field-level encrypt then decrypt restores original values', async () => {
+    // Prepare
     const provider = createMockProvider();
     const masker = new DataMasking({ provider });
 
+    // Act & Assess
     await fc.assert(
       fc.asyncProperty(
         fc.dictionary(pathKey, fc.string(), { minKeys: 1 }),

--- a/packages/data-masking/tests/unit/erase.test.ts
+++ b/packages/data-masking/tests/unit/erase.test.ts
@@ -1,10 +1,15 @@
 import fc from 'fast-check';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import {
   DataMaskingFieldNotFoundError,
   DataMaskingUnsupportedTypeError,
 } from '../../src/errors.js';
 import { DataMasking } from '../../src/index.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('DataMasking.erase()', () => {
   const masker = new DataMasking();
@@ -167,15 +172,13 @@ describe('DataMasking.erase()', () => {
   });
 
   it('skips missing field with a warning when throwOnMissingField is false', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { name: 'Jane' };
 
     const result = lenientMasker.erase(data, { fields: ['nonexistent'] });
 
     expect(result).toEqual({ name: 'Jane' });
-    expect(warnSpy).toHaveBeenCalledWith("Field not found: 'nonexistent'");
-    warnSpy.mockRestore();
+    expect(console.warn).toHaveBeenCalledWith("Field not found: 'nonexistent'");
   });
 
   it('handles circular references by cloning them via structuredClone', () => {
@@ -319,7 +322,6 @@ describe('DataMasking.erase() - custom masking rules', () => {
 
   it('skips a rule that matches no field with a warning when throwOnMissingField is false', () => {
     // Prepare
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { ssn: '123-45-6789', name: 'Jane' };
 
@@ -333,8 +335,7 @@ describe('DataMasking.erase() - custom masking rules', () => {
 
     // Assess
     expect(result).toEqual({ ssn: '123-45-6789', name: 'XXXX' });
-    expect(warnSpy).toHaveBeenCalledWith("Field not found: 'snn'");
-    warnSpy.mockRestore();
+    expect(console.warn).toHaveBeenCalledWith("Field not found: 'snn'");
   });
 
   it.each([

--- a/packages/data-masking/tests/unit/erase.test.ts
+++ b/packages/data-masking/tests/unit/erase.test.ts
@@ -98,6 +98,55 @@ describe('DataMasking.erase()', () => {
     expect(masker.erase(undefined)).toBeUndefined();
   });
 
+  it('applies a rule once to a path reached by overlapping field expressions', () => {
+    // Prepare
+    const data = { a: { b: '123' } };
+
+    // Act
+    const result = masker.erase(data, {
+      fields: ['a.*', 'a.b'],
+      regexPattern: /\d/,
+      maskFormat: '#',
+    });
+
+    // Assess
+    expect(result).toEqual({ a: { b: '#23' } });
+  });
+
+  it.each([
+    { label: 'an empty array', data: { orders: [] } },
+    { label: 'an empty object', data: { orders: {} } },
+  ])(
+    'does not report a wildcard over $label as a missing field',
+    ({ data }) => {
+      // Act
+      const result = masker.erase(data, { fields: ['orders.*.card'] });
+
+      // Assess
+      expect(result).toEqual(data);
+    }
+  );
+
+  it('reports a wildcard whose entries all lack the next segment as missing', () => {
+    // Prepare
+    const data = { users: { alice: { name: 'Alice' } } };
+
+    // Act & Assess
+    expect(() => masker.erase(data, { fields: ['users.*.ssn'] })).toThrow(
+      DataMaskingFieldNotFoundError
+    );
+  });
+
+  it('does not resolve non-index keys on arrays', () => {
+    // Prepare
+    const data = { items: [1, 2] };
+
+    // Act & Assess
+    expect(() => masker.erase(data, { fields: ['items.length'] })).toThrow(
+      DataMaskingFieldNotFoundError
+    );
+  });
+
   it('masks a field that is present with an undefined value', () => {
     // Prepare
     const data = { ssn: undefined, name: 'Jane' };
@@ -320,6 +369,49 @@ describe('DataMasking.erase() - custom masking rules', () => {
 
     // Assess
     expect(result).toEqual({ a: 'M' });
+  });
+
+  it('lets a rule on a parent see the original values of its children', () => {
+    // Prepare
+    const data = { cards: ['4111', '4222'] };
+
+    // Act
+    const result = masker.erase(data, {
+      fields: ['cards[*]'],
+      maskingRules: { cards: { dynamicMask: true } },
+    });
+
+    // Assess
+    expect(result).toEqual({ cards: '*********' });
+  });
+
+  it('applies the first rule given to a path reached by several expressions', () => {
+    // Prepare
+    const data = { a: { b: '123' } };
+
+    // Act
+    const result = masker.erase(data, {
+      maskingRules: {
+        'a.*': { customMask: 'X' },
+        'a.b': { dynamicMask: true },
+      },
+    });
+
+    // Assess
+    expect(result).toEqual({ a: { b: 'X' } });
+  });
+
+  it('does not report a wildcard over an empty collection as a missing field', () => {
+    // Prepare
+    const data = { orders: [] };
+
+    // Act
+    const result = masker.erase(data, {
+      maskingRules: { 'orders[*].card': { dynamicMask: true } },
+    });
+
+    // Assess
+    expect(result).toEqual({ orders: [] });
   });
 
   it('passes a present but undefined value through a masking rule', () => {

--- a/packages/data-masking/tests/unit/erase.test.ts
+++ b/packages/data-masking/tests/unit/erase.test.ts
@@ -185,6 +185,23 @@ describe('DataMasking.erase()', () => {
     expect(result.secrets.__proto__).toBe('injected');
   });
 
+  it.each([
+    { label: 'a reserved key', field: '__proto__' },
+    { label: 'an own __proto__ key', field: 'secrets.__proto__' },
+    { label: 'an empty expression', field: '' },
+  ])('reports $label as a missing field', ({ field }) => {
+    // Prepare
+    const data = JSON.parse(
+      '{"secrets": {"__proto__": "injected", "safe": "value"}}'
+    );
+
+    // Act & Assess
+    expect(() => masker.erase(data, { fields: [field] })).toThrow(
+      DataMaskingFieldNotFoundError
+    );
+    expect(Object.getPrototypeOf(data)).toBe(Object.prototype);
+  });
+
   it('prevents prototype pollution when __proto__ is used as a direct field path', () => {
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { safe: 'value' };

--- a/packages/data-masking/tests/unit/erase.test.ts
+++ b/packages/data-masking/tests/unit/erase.test.ts
@@ -230,6 +230,36 @@ describe('DataMasking.erase() - custom masking rules', () => {
     expect(result.email).toBe('j****@example.com');
   });
 
+  it('throws DataMaskingFieldNotFoundError for a rule that matches no field when throwOnMissingField is true', () => {
+    // Prepare
+    const data = { ssn: '123-45-6789' };
+
+    // Act & Assess
+    expect(() =>
+      masker.erase(data, { maskingRules: { snn: { dynamicMask: true } } })
+    ).toThrow(DataMaskingFieldNotFoundError);
+  });
+
+  it('skips a rule that matches no field with a warning when throwOnMissingField is false', () => {
+    // Prepare
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const lenientMasker = new DataMasking({ throwOnMissingField: false });
+    const data = { ssn: '123-45-6789', name: 'Jane' };
+
+    // Act
+    const result = lenientMasker.erase(data, {
+      maskingRules: {
+        snn: { dynamicMask: true },
+        name: { customMask: 'XXXX' },
+      },
+    });
+
+    // Assess
+    expect(result).toEqual({ ssn: '123-45-6789', name: 'XXXX' });
+    expect(warnSpy).toHaveBeenCalledWith("Field not found: 'snn'");
+    warnSpy.mockRestore();
+  });
+
   it('applies dynamic mask matching original length', () => {
     const data = { ssn: '123-45-6789' };
 

--- a/packages/data-masking/tests/unit/erase.test.ts
+++ b/packages/data-masking/tests/unit/erase.test.ts
@@ -15,33 +15,40 @@ describe('DataMasking.erase()', () => {
   const masker = new DataMasking();
 
   it('masks specified nested fields with default mask value', () => {
+    // Prepare
     const data = {
       name: 'Jane',
       customer: { ssn: '123-45-6789', city: 'Anytown' },
     };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['customer.ssn'],
     });
 
+    // Assess
     expect(result.customer.ssn).toBe('*****');
     expect(result.customer.city).toBe('Anytown');
     expect(result.name).toBe('Jane');
   });
 
   it('masks multiple fields', () => {
+    // Prepare
     const data = { email: 'j@example.com', phone: '555-1234', name: 'Jane' };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['email', 'phone'],
     });
 
+    // Assess
     expect(result.email).toBe('*****');
     expect(result.phone).toBe('*****');
     expect(result.name).toBe('Jane');
   });
 
   it('masks wildcard array paths', () => {
+    // Prepare
     const data = {
       orders: [
         { id: 1, payment: '4111-1111' },
@@ -49,16 +56,19 @@ describe('DataMasking.erase()', () => {
       ],
     };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['orders[*].payment'],
     });
 
+    // Assess
     expect(result.orders[0].payment).toBe('*****');
     expect(result.orders[1].payment).toBe('*****');
     expect(result.orders[0].id).toBe(1);
   });
 
   it('skips array elements where the nested field is missing', () => {
+    // Prepare
     const data = {
       items: [
         { id: 1, secret: 'hidden' },
@@ -67,38 +77,47 @@ describe('DataMasking.erase()', () => {
       ],
     };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['items[*].secret'],
     });
 
+    // Assess
     expect(result.items[0].secret).toBe('*****');
     expect(result.items[1]).toEqual({ id: 2 });
     expect(result.items[2].secret).toBe('*****');
   });
 
   it('handles wildcard on an empty array', () => {
+    // Prepare
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { orders: [] as unknown[] };
 
+    // Act
     const result = lenientMasker.erase(data, {
       fields: ['orders[*].payment'],
     });
 
+    // Assess
     expect(result.orders).toEqual([]);
   });
 
   it('masks a deeply nested field', () => {
+    // Prepare
     const data = {
       a: { b: { c: { d: { secret: 'hidden', keep: 'visible' } } } },
     };
 
+    // Act
     const result = masker.erase(data, { fields: ['a.b.c.d.secret'] });
 
+    // Assess
     expect(result.a.b.c.d.secret).toBe('*****');
     expect(result.a.b.c.d.keep).toBe('visible');
   });
 
   it('returns null/undefined as-is', () => {
+    // Act & Assess
     expect(masker.erase(null)).toBeNull();
     expect(masker.erase(undefined)).toBeUndefined();
   });
@@ -164,53 +183,67 @@ describe('DataMasking.erase()', () => {
   });
 
   it('throws DataMaskingFieldNotFoundError for missing field when throwOnMissingField is true', () => {
+    // Prepare
     const data = { name: 'Jane' };
 
+    // Act & Assess
     expect(() => masker.erase(data, { fields: ['nonexistent'] })).toThrow(
       DataMaskingFieldNotFoundError
     );
   });
 
   it('skips missing field with a warning when throwOnMissingField is false', () => {
+    // Prepare
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { name: 'Jane' };
 
+    // Act
     const result = lenientMasker.erase(data, { fields: ['nonexistent'] });
 
+    // Assess
     expect(result).toEqual({ name: 'Jane' });
     expect(console.warn).toHaveBeenCalledWith("Field not found: 'nonexistent'");
   });
 
   it('handles circular references by cloning them via structuredClone', () => {
+    // Prepare
     const data: Record<string, unknown> = { name: 'Jane' };
     data.self = data;
 
+    // Act
     const result = masker.erase(data, { fields: ['name'] });
 
+    // Assess
     expect(result.name).toBe('*****');
   });
 
   it('throws DataMaskingUnsupportedTypeError for non-cloneable data', () => {
+    // Prepare
     const data = { fn: () => {} };
 
+    // Act & Assess
     expect(() => masker.erase(data, { fields: ['fn'] })).toThrow(
       DataMaskingUnsupportedTypeError
     );
   });
 
   it('masks all properties of an object with .* wildcard', () => {
+    // Prepare
     const data = {
       credentials: { username: 'admin', password: 's3cret', token: 'abc123' },
     };
 
+    // Act
     const result = masker.erase(data, { fields: ['credentials.*'] });
 
+    // Assess
     expect(result.credentials.username).toBe('*****');
     expect(result.credentials.password).toBe('*****');
     expect(result.credentials.token).toBe('*****');
   });
 
   it('masks nested fields via .* on an intermediate object', () => {
+    // Prepare
     const data = {
       users: {
         alice: { ssn: '111', name: 'Alice' },
@@ -218,8 +251,10 @@ describe('DataMasking.erase()', () => {
       },
     };
 
+    // Act
     const result = masker.erase(data, { fields: ['users.*.ssn'] });
 
+    // Assess
     expect(result.users.alice.ssn).toBe('*****');
     expect(result.users.bob.ssn).toBe('*****');
     expect(result.users.alice.name).toBe('Alice');
@@ -227,12 +262,15 @@ describe('DataMasking.erase()', () => {
   });
 
   it('ignores __proto__ keys during .* object wildcard traversal', () => {
+    // Prepare
     const data = JSON.parse(
       '{"secrets": {"__proto__": "injected", "safe": "value"}}'
     );
 
+    // Act
     const result = masker.erase(data, { fields: ['secrets.*'] });
 
+    // Assess
     expect(result.secrets.safe).toBe('*****');
     expect(result.secrets.__proto__).toBe('injected');
   });
@@ -255,25 +293,31 @@ describe('DataMasking.erase()', () => {
   });
 
   it('prevents prototype pollution when __proto__ is used as a direct field path', () => {
+    // Prepare
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { safe: 'value' };
 
+    // Act
     const result = lenientMasker.erase(data, {
       fields: ['__proto__', 'constructor', 'safe'],
     });
 
+    // Assess
     expect(result.safe).toBe('*****');
     expect(Object.getPrototypeOf(result)).toEqual(Object.getPrototypeOf({}));
   });
 
   it('prevents prototype pollution on nested paths like foo.__proto__', () => {
+    // Prepare
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { foo: { bar: 'value' } };
 
+    // Act
     const result = lenientMasker.erase(data, {
       fields: ['foo.__proto__', 'foo.bar'],
     });
 
+    // Assess
     expect(result.foo.bar).toBe('*****');
     expect(Object.getPrototypeOf(result.foo)).toEqual(
       Object.getPrototypeOf({})
@@ -281,13 +325,16 @@ describe('DataMasking.erase()', () => {
   });
 
   it('skips primitives inside array wildcard paths', () => {
+    // Prepare
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
     const data = { items: ['a', 'b', 'c'] };
 
+    // Act
     const result = lenientMasker.erase(data, {
       fields: ['items[*].nested'],
     });
 
+    // Assess
     expect(result.items).toEqual(['a', 'b', 'c']);
   });
 });
@@ -296,8 +343,10 @@ describe('DataMasking.erase() - custom masking rules', () => {
   const masker = new DataMasking();
 
   it('applies regex pattern masking', () => {
+    // Prepare
     const data = { email: 'jane@example.com' };
 
+    // Act
     const result = masker.erase(data, {
       maskingRules: {
         email: {
@@ -307,6 +356,7 @@ describe('DataMasking.erase() - custom masking rules', () => {
       },
     });
 
+    // Assess
     expect(result.email).toBe('j****@example.com');
   });
 
@@ -429,51 +479,63 @@ describe('DataMasking.erase() - custom masking rules', () => {
   });
 
   it('applies dynamic mask matching original length', () => {
+    // Prepare
     const data = { ssn: '123-45-6789' };
 
+    // Act
     const result = masker.erase(data, {
       maskingRules: {
         ssn: { dynamicMask: true },
       },
     });
 
+    // Assess
     expect(result.ssn).toBe('***********');
     expect(result.ssn.length).toBe('123-45-6789'.length);
   });
 
   it('applies custom mask string', () => {
+    // Prepare
     const data = { zip: '90210' };
 
+    // Act
     const result = masker.erase(data, {
       maskingRules: {
         zip: { customMask: 'XXXXX' },
       },
     });
 
+    // Assess
     expect(result.zip).toBe('XXXXX');
   });
 
   it('stringifies non-string values before applying a rule', () => {
+    // Prepare
     const data: Record<string, unknown> = { age: 30 };
 
+    // Act
     const result = masker.erase(data, {
       maskingRules: {
         age: { dynamicMask: true },
       },
     });
 
+    // Assess
     expect(result.age).toBe('**'); // String(30) -> '30' -> '**'
   });
 
   it('applies default mask when no rule options specified', () => {
+    // Prepare
     const data = { secret: 'hidden' };
 
+    // Act
     const result = masker.erase(data, {
       maskingRules: {
         secret: {},
       },
     });
 
+    // Assess
     expect(result.secret).toBe('*****');
   });
 });
@@ -482,21 +544,26 @@ describe('DataMasking.erase() - top-level masking rule', () => {
   const masker = new DataMasking();
 
   it('applies a top-level rule to every listed field', () => {
+    // Prepare
     const data = { ssn: '123-45-6789', card: '4111-1111', name: 'Jane' };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['ssn', 'card'],
       dynamicMask: true,
     });
 
+    // Assess
     expect(result.ssn).toBe('***********');
     expect(result.card).toBe('*********');
     expect(result.name).toBe('Jane');
   });
 
   it('lets per-field maskingRules override the top-level rule', () => {
+    // Prepare
     const data = { ssn: '123-45-6789', card: '4111-1111' };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['ssn', 'card'],
       dynamicMask: true,
@@ -506,13 +573,17 @@ describe('DataMasking.erase() - top-level masking rule', () => {
     });
 
     // ssn falls through to the top-level dynamic mask, card uses its own rule
+
+    // Assess
     expect(result.ssn).toBe('***********');
     expect(result.card).toBe('XXXX');
   });
 
   it('masks fields named only in maskingRules even without listing them in fields', () => {
+    // Prepare
     const data = { ssn: '123-45-6789', card: '4111-1111', name: 'Jane' };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['ssn'],
       dynamicMask: true,
@@ -521,83 +592,104 @@ describe('DataMasking.erase() - top-level masking rule', () => {
       },
     });
 
+    // Assess
     expect(result.ssn).toBe('***********');
     expect(result.card).toBe('XXXX');
     expect(result.name).toBe('Jane');
   });
 
   it('applies a top-level rule to every leaf when no fields are given', () => {
+    // Prepare
     const data = {
       ssn: '123-45-6789',
       customer: { card: '4111', city: 'Anytown' },
     };
 
+    // Act
     const result = masker.erase(data, { dynamicMask: true });
 
+    // Assess
     expect(result.ssn).toBe('***********');
     expect(result.customer.card).toBe('****');
     expect(result.customer.city).toBe('*******');
   });
 
   it('stringifies non-string leaves when applying a top-level rule to all leaves', () => {
+    // Prepare
     const data: Record<string, unknown> = { age: 30, active: true };
 
+    // Act
     const result = masker.erase(data, {
       dynamicMask: true,
     });
 
+    // Assess
     expect(result.age).toBe('**'); // String(30) -> '30' -> '**'
     expect(result.active).toBe('****'); // String(true) -> 'true' -> '****'
   });
 
   it('applies a top-level rule to array elements element-wise', () => {
+    // Prepare
     const data = { cards: ['4111', '5500-0000'] };
 
+    // Act
     const result = masker.erase(data, { dynamicMask: true });
 
+    // Assess
     expect(result.cards).toEqual(['****', '*********']);
   });
 
   it('masks a top-level scalar payload with a top-level rule', () => {
+    // Act
     const result = masker.erase('123-45-6789', { dynamicMask: true });
 
+    // Assess
     expect(result).toBe('***********');
   });
 
   it('passes null/undefined leaves through unchanged when masking all leaves', () => {
+    // Prepare
     const data: Record<string, unknown> = {
       ssn: '123',
       maybe: null,
       missing: undefined,
     };
 
+    // Act
     const result = masker.erase(data, { customMask: 'X' });
 
+    // Assess
     expect(result.ssn).toBe('X');
     expect(result.maybe).toBeNull();
     expect(result.missing).toBeUndefined();
   });
 
   it('stringifies non-string fields before applying a top-level rule', () => {
+    // Prepare
     const data: Record<string, unknown> = { age: 30 };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['age'],
       dynamicMask: true,
     });
 
+    // Assess
     expect(result.age).toBe('**'); // String(30) -> '30' -> '**'
   });
 
   it('applies a top-level regex rule across listed fields', () => {
+    // Prepare
     const data = { primary: 'jane@example.com', backup: 'bob@example.com' };
 
+    // Act
     const result = masker.erase(data, {
       fields: ['primary', 'backup'],
       regexPattern: /^(.)([^@]*)(@.*)$/,
       maskFormat: '$1****$3',
     });
 
+    // Assess
     expect(result.primary).toBe('j****@example.com');
     expect(result.backup).toBe('b****@example.com');
   });
@@ -609,7 +701,10 @@ describe('DataMasking.erase() - property tests', () => {
   const masker = new DataMasking();
 
   it('never mutates the original input', () => {
+    // Prepare
     const lenientMasker = new DataMasking({ throwOnMissingField: false });
+
+    // Act & Assess
     fc.assert(
       fc.property(fc.dictionary(pathKey, fc.jsonValue()), (data) => {
         const original = structuredClone(data);
@@ -621,6 +716,7 @@ describe('DataMasking.erase() - property tests', () => {
   });
 
   it('with no fields returns the default mask, masking arrays element-wise', () => {
+    // Act & Assess
     fc.assert(
       fc.property(fc.jsonValue(), (data) => {
         if (data === null || data === undefined) return;
@@ -636,6 +732,7 @@ describe('DataMasking.erase() - property tests', () => {
   });
 
   it('replaces every value under parent.* with the mask', () => {
+    // Act & Assess
     fc.assert(
       fc.property(
         pathKey,
@@ -657,6 +754,7 @@ describe('DataMasking.erase() - property tests', () => {
   });
 
   it('masks nested field under each key with parent.*.child', () => {
+    // Act & Assess
     fc.assert(
       fc.property(
         pathKey,
@@ -688,6 +786,7 @@ describe('DataMasking.erase() - property tests', () => {
   });
 
   it('replaces every element field under parent[*].child with the mask', () => {
+    // Act & Assess
     fc.assert(
       fc.property(
         pathKey,
@@ -711,6 +810,7 @@ describe('DataMasking.erase() - property tests', () => {
   });
 
   it('[*] skips array elements missing the targeted field', () => {
+    // Act & Assess
     fc.assert(
       fc.property(
         pathKey,
@@ -739,6 +839,7 @@ describe('DataMasking.erase() - property tests', () => {
   });
 
   it('replaces every targeted top-level field with the mask', () => {
+    // Act & Assess
     fc.assert(
       fc.property(
         fc.dictionary(pathKey, fc.string(), { minKeys: 1 }),

--- a/packages/data-masking/tests/unit/erase.test.ts
+++ b/packages/data-masking/tests/unit/erase.test.ts
@@ -98,6 +98,17 @@ describe('DataMasking.erase()', () => {
     expect(masker.erase(undefined)).toBeUndefined();
   });
 
+  it('masks a field that is present with an undefined value', () => {
+    // Prepare
+    const data = { ssn: undefined, name: 'Jane' };
+
+    // Act
+    const result = masker.erase(data, { fields: ['ssn'] });
+
+    // Assess
+    expect(result).toEqual({ ssn: '*****', name: 'Jane' });
+  });
+
   it('throws DataMaskingFieldNotFoundError for missing field when throwOnMissingField is true', () => {
     const data = { name: 'Jane' };
 
@@ -258,6 +269,53 @@ describe('DataMasking.erase() - custom masking rules', () => {
     expect(result).toEqual({ ssn: '123-45-6789', name: 'XXXX' });
     expect(warnSpy).toHaveBeenCalledWith("Field not found: 'snn'");
     warnSpy.mockRestore();
+  });
+
+  it.each([
+    { order: 'parent first', rules: ['a', 'a.b'] },
+    { order: 'child first', rules: ['a.b', 'a'] },
+  ])(
+    'resolves every rule before masking so key order does not matter ($order)',
+    ({ rules }) => {
+      // Prepare
+      const data = { a: { b: 'x' } };
+      const maskingRules = Object.fromEntries(
+        rules.map((field) => [field, { customMask: 'M' }])
+      );
+
+      // Act
+      const result = masker.erase(data, { maskingRules });
+
+      // Assess
+      expect(result).toEqual({ a: 'M' });
+    }
+  );
+
+  it('does not report a field as missing when a rule collapses its parent', () => {
+    // Prepare
+    const data = { a: { b: 'x' } };
+
+    // Act
+    const result = masker.erase(data, {
+      fields: ['a.b'],
+      maskingRules: { a: { customMask: 'M' } },
+    });
+
+    // Assess
+    expect(result).toEqual({ a: 'M' });
+  });
+
+  it('passes a present but undefined value through a masking rule', () => {
+    // Prepare
+    const data = { ssn: undefined, name: 'Jane' };
+
+    // Act
+    const result = masker.erase(data, {
+      maskingRules: { ssn: { customMask: 'X' }, name: { customMask: 'X' } },
+    });
+
+    // Assess
+    expect(result).toEqual({ ssn: undefined, name: 'X' });
   });
 
   it('applies dynamic mask matching original length', () => {

--- a/packages/data-masking/vitest.config.ts
+++ b/packages/data-masking/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineProject } from 'vitest/config';
 export default defineProject({
   test: {
     environment: 'node',
+    setupFiles: ['../testing/src/setupEnv.ts'],
     typecheck: {
       tsconfig: './tests/tsconfig.json',
       include: ['./tests/types/**/*.ts'],


### PR DESCRIPTION
## Summary

A `maskingRules` key that matched nothing was silently skipped while the same path in `fields` threw, and `encrypt` and `decrypt` ignored `throwOnMissingField` entirely. Fixing that exposed ordering problems in how paths were applied, so path resolution and target selection are now done up front for all three operations. Scope grew beyond the issue as filed; each addition came from reviewing the initial fix and is listed on the issue.

### Changes

- `erase`, `encrypt` and `decrypt` all resolve every path expression through one private method that throws or warns per `throwOnMissingField`; `encrypt` and `decrypt` resolve before calling the provider so a missing field cannot leave provider calls in flight
- Targets are collected into a first-wins map keyed by path, and any target beneath another target is dropped, so a rule on a parent sees the original children and overlapping expressions apply a rule once
- A wildcard over an empty collection is a match with no paths rather than a missing field; only an absent non-wildcard segment counts as missing
- Path resolution uses `Object.hasOwn`, so present keys holding `undefined` resolve; reserved keys, empty expressions and non-index keys on arrays never resolve, and the guards in `getAtPath` and `setAtPath` are removed as unreachable
- `encrypt` and `decrypt` leave `undefined` values untouched, matching how a masking rule passes them through
- `applyRuleToLeaves` reuses `resolveWildcardEntries` instead of duplicating it
- Docs gain a "Missing fields" section and the `throwOnMissingField` JSDoc names all three operations
- Package `vitest.config.ts` loads the shared `setupEnv.ts`, and the tests use its console mock instead of local spies

**Issue number:** closes #5626

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
