### PR TITLE
chore(maintenance): align CI matrices and repository templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/rfcs-request-for-comments.yml
+++ b/.github/DISCUSSION_TEMPLATE/rfcs-request-for-comments.yml
@@ -25,6 +25,9 @@ body:
         - JMESPath
         - Batch Processing
         - Validation
+        - Kafka
+        - Data Masking
+        - Signer
         - Commons
         - Automation
         - Governance

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,8 @@
 name: Bug report
 description: Report a reproducible bug to help us improve
 title: "Bug: <TITLE>"
-labels: ["bug", "triage"]
+labels: ["triage"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation_improvements.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvements.yml
@@ -1,7 +1,8 @@
 name: Documentation improvements
 description: Suggest a documentation update to improve everyone's experience
 title: "Docs: <TITLE>"
-labels: ["documentation", "triage"]
+labels: ["triage"]
+type: Task
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation_improvements.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvements.yml
@@ -2,7 +2,7 @@ name: Documentation improvements
 description: Suggest a documentation update to improve everyone's experience
 title: "Docs: <TITLE>"
 labels: ["triage"]
-type: Task
+type: Docs
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,8 @@
 name: Feature request
 description: Suggest an idea for Powertools for AWS Lambda
 title: "Feature request: <TITLE>"
-labels: ["feature-request", "triage"]
+labels: ["triage"]
+type: Enhancement
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,7 @@ name: Feature request
 description: Suggest an idea for Powertools for AWS Lambda
 title: "Feature request: <TITLE>"
 labels: ["triage"]
-type: Enhancement
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,7 +1,8 @@
 name: Maintenance
 description: Suggest an activity to help address tech debt, governance, and anything internal
 title: "Maintenance: <TITLE>"
-labels: ["internal", "triage"]
+labels: ["triage"]
+type: Task
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -2,7 +2,7 @@ name: Maintenance
 description: Suggest an activity to help address tech debt, governance, and anything internal
 title: "Maintenance: <TITLE>"
 labels: ["triage"]
-type: Task
+type: Maintenance
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/on_pr_updates.yml
+++ b/.github/workflows/on_pr_updates.yml
@@ -12,8 +12,8 @@ name: PR requirements
 
 # NOTES
 #
-# PR requirements are checked async in on_opened_pr.yml and enforced here synchronously
-# due to limitations in GH API.
+# Organization-level checks evaluate PR requirements asynchronously; this workflow enforces
+# the resulting do-not-merge label synchronously due to limitations in the GitHub API.
 
 on:
   pull_request:

--- a/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
+++ b/.github/workflows/reusable-run-linting-check-and-unit-tests.yml
@@ -59,6 +59,7 @@ jobs:
     strategy:
       matrix:
         version: [22, 24]
+        # packages/testing is private and intentionally excluded from this publishable package matrix.
         workspace: ${{ fromJSON(needs.resolve-workspaces.outputs.workspaces) }}
       fail-fast: false
     steps:

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -382,7 +382,7 @@ If it's a cold start invocation, this feature will:
 
 This has the advantage of keeping cold start metric separate from your application metrics, where you might have unrelated dimensions.
 
-!!! info "We do not emit 0 as a value for the ColdStart metric for cost-efficiency reasons. [Let us know](https://github.com/aws-powertools/powertools-lambda-typescript/issues/new?assignees=&labels=feature-request%2C+triage&template=feature_request.md&title=) if you'd prefer a flag to override it."
+!!! info "We do not emit 0 as a value for the ColdStart metric for cost-efficiency reasons. [Let us know](https://github.com/aws-powertools/powertools-lambda-typescript/issues/new?assignees=&labels=triage&template=feature_request.yml&title=) if you'd prefer a flag to override it."
 
 #### Setting function name
 

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -13,7 +13,7 @@
     "test": "vitest --run tests/unit",
     "test:unit": "vitest --run tests/unit",
     "test:unit:coverage": "vitest --run tests/unit --coverage.enabled --coverage.thresholds.100 --coverage.include='src/**'",
-    "test:unit:types": "echo 'Not Implemented'",
+    "test:unit:types": "vitest --run tests/types --typecheck",
     "test:unit:watch": "vitest tests/unit",
     "test:e2e:nodejs22x": "RUNTIME=nodejs22x vitest --run tests/e2e",
     "test:e2e:nodejs24x": "RUNTIME=nodejs24x vitest --run tests/e2e",

--- a/packages/signer/tests/types/signer.test-d.ts
+++ b/packages/signer/tests/types/signer.test-d.ts
@@ -1,0 +1,34 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { createSignedFetcher } from '../../src/fetch.js';
+import { SigV4Signer } from '../../src/sigv4.js';
+import type { Signer } from '../../src/types/index.js';
+
+describe('Signer type tests', () => {
+  it('creates a fetch-compatible function from a signer', () => {
+    // Prepare
+    const signer: Signer = {
+      sign: async (input, init) => new Request(input, init),
+    };
+
+    // Act
+    const signedFetch = createSignedFetcher(signer);
+
+    // Assess
+    expectTypeOf(signedFetch).toEqualTypeOf<typeof fetch>();
+  });
+
+  it('implements the signer interface with SigV4Signer', () => {
+    // Prepare & Act
+    const signer = new SigV4Signer({
+      service: 'execute-api',
+      region: 'us-east-1',
+      credentials: {
+        accessKeyId: 'access-key-id',
+        secretAccessKey: 'secret-access-key',
+      },
+    });
+
+    // Assess
+    expectTypeOf(signer).toMatchTypeOf<Signer>();
+  });
+});


### PR DESCRIPTION
## Summary

Align CI package coverage, issue metadata, and the RFC discussion form with the repository's current packages and organization configuration.

### Changes

- document the intentional exclusion of the private `packages/testing` workspace
- replace archived issue labels with the available Bug, Feature, Docs, and Maintenance Issue Types
- update stale issue links to avoid archived labels and use Issue Type search syntax
- rename the RFC template to `rfcs-request-for-comments.yml` and add missing utility areas
- correct stale PR-requirement links in documentation
- restore `packages/signer`'s `test:unit:types` script and add `packages/signer/tests/types/signer.test-d.ts`
- fix stale comment in `on_pr_updates.yml` organization-level check text

**Issue number:** closes #5631

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.