### PR TITLE
fix(ci): harden the release manifest patch and e2e sweep incident lookup

### DIFF
--- a/.github/scripts/release_patch_package_json.js
+++ b/.github/scripts/release_patch_package_json.js
@@ -89,5 +89,5 @@ const betaPackages = [];
   // Temporarily update the original package.json file.
   // This version will be picked up during the `npm publish` step, so that
   // the version number and metadata in the registry are correct and match the tarball.
-  writeFileSync('package.json', JSON.stringify(newPkgJson, null, 2));
+  writeFileSync(packageJsonPath, JSON.stringify(newPkgJson, null, 2));
 })();

--- a/.github/scripts/report_e2e_sweep.js
+++ b/.github/scripts/report_e2e_sweep.js
@@ -2,19 +2,26 @@ const INCIDENT_TITLE = 'E2E stale stack cleanup failing';
 const MAX_SECTION_ENTRIES = 50;
 const MAX_BODY_LENGTH = 60_000;
 
-/** Find the open incident issue by its exact title. */
-const findIncident = async ({ github, owner, repo }) => {
-  const { data: issues } = await github.rest.issues.listForRepo({
-    owner,
-    repo,
-    state: 'open',
-    per_page: 100,
-  });
+/** Whether an item returned by the issues API is the incident issue. */
+const isIncident = (issue) =>
+  issue.title === INCIDENT_TITLE && issue.pull_request === undefined;
 
-  return issues.find(
-    (issue) =>
-      issue.title === INCIDENT_TITLE && issue.pull_request === undefined
+/**
+ * Find the open incident issue by its exact title, paging through every open
+ * issue and stopping at the first page that contains it.
+ */
+const findIncident = async ({ github, owner, repo }) => {
+  const matches = await github.paginate(
+    github.rest.issues.listForRepo,
+    { owner, repo, state: 'open', per_page: 100 },
+    (response, done) => {
+      const incident = response.data.find(isIncident);
+      if (incident !== undefined) done();
+      return incident === undefined ? [] : [incident];
+    }
   );
+
+  return matches[0];
 };
 
 /** Render one bounded report section as Markdown. */


### PR DESCRIPTION
## Summary

Fixes the two remaining latent defects from #5641 in the `.github/scripts` helpers. The release manifest patcher could overwrite the wrong `package.json` when run from anywhere but the package directory, and the e2e sweep reporter could miss its own incident issue once the repo has more than 100 open items, creating a duplicate on every failed sweep.

### Changes

- `release_patch_package_json.js` writes the patched manifest back to the path it read from, instead of a cwd-relative `package.json`. Every `prepack` caller passes `.` so nothing changes for releases, but the usage string's `node .github/scripts/release_patch_package_json.js packages/logger` from the repo root no longer clobbers the root manifest.
- `report_e2e_sweep.js` finds the incident issue with `github.paginate` over open issues and stops at the first page containing it, so the lookup works regardless of how many newer open issues and PRs exist. The title-and-not-a-PR predicate is a small `isIncident` helper.
- Items 1 to 3 of the issue concerned `post_release.js`, which #5618 removed along with its workflow, so there is nothing left to fix there.
- Notes for reviewers: verified with a mocked Octokit client whose `paginate` emulates the real page and `done()` semantics (incident on page 3 of 4 is found with only 3 pages fetched; a PR with the incident title is ignored; absence pages to the end and creates the issue; a successful sweep makes no API calls), and by running the manifest patcher from a directory holding a sentinel `package.json`. No committed tests since `.github/scripts` has no test harness.

**Issue number:** closes #5641

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
