### PR TITLE
fix(parser): stop malformed base64 from escaping safeParse

### DIFF
--- a/packages/parser/src/helpers/index.ts
+++ b/packages/parser/src/helpers/index.ts
@@ -102,7 +102,7 @@ const JSONStringified = <T extends ZodType>(schema: T) =>
  */
 const Base64Encoded = <T extends ZodType>(schema: T) =>
   z
-    .string()
+    .base64()
     .transform((data) => {
       const decompressed = decompress(data);
       const decoded = decoder.decode(fromBase64(data, 'base64'));

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -119,8 +119,11 @@ function parse<T extends StandardSchemaV1, E extends Envelope>(
   }
 
   const result = schema['~standard'].validate(data);
-  /* v8 ignore next -- @preserve */
   if (result instanceof Promise) {
+    // Some validators (e.g. Zod) fall back to async validation when a transform
+    // throws synchronously, returning a rejected promise. Attach a handler so it
+    // does not surface as an unhandled rejection before we throw below.
+    result.catch(() => {});
     throw new ParseError('Schema parsing supports only synchronous validation');
   }
 

--- a/packages/parser/tests/unit/helpers.test.ts
+++ b/packages/parser/tests/unit/helpers.test.ts
@@ -371,6 +371,17 @@ describe('Helper: Base64Encoded', () => {
     expect(() => extendedSchema.parse(data)).toThrow();
   });
 
+  it('returns a failed result instead of throwing when safeParse gets malformed base64', () => {
+    // Prepare
+    const schema = Base64Encoded(bodySchema);
+
+    // Act
+    const result = schema.safeParse('not base64!!');
+
+    // Assess
+    expect(result.success).toBe(false);
+  });
+
   it('parses extended KinesisDataStreamSchema', () => {
     // Prepare
     const testEvent = getTestEvent<KinesisDataStreamEvent>({

--- a/packages/parser/tests/unit/parser.test.ts
+++ b/packages/parser/tests/unit/parser.test.ts
@@ -4,7 +4,12 @@ import { EventBridgeEnvelope } from '../../src/envelopes/eventbridge.js';
 import { SqsEnvelope } from '../../src/envelopes/sqs.js';
 import { ParseError } from '../../src/errors.js';
 import { parse } from '../../src/parser.js';
-import type { EventBridgeEvent, SqsEvent } from '../../src/types/index.js';
+import { KinesisDataStreamSchema } from '../../src/schemas/kinesis.js';
+import type {
+  EventBridgeEvent,
+  KinesisDataStreamEvent,
+  SqsEvent,
+} from '../../src/types/index.js';
 import { getTestEvent } from './helpers/utils.js';
 
 describe('Parser', () => {
@@ -132,5 +137,38 @@ describe('Parser', () => {
       error: expect.any(ParseError),
       originalEvent: event,
     });
+  });
+
+  it('returns a failed result when a built-in schema carries malformed base64', () => {
+    // Prepare
+    const event = getTestEvent<KinesisDataStreamEvent>({
+      eventsPath: 'kinesis',
+      filename: 'stream',
+    });
+    event.Records[0].kinesis.data = 'not base64!!';
+
+    // Act
+    const result = parse(event, undefined, KinesisDataStreamSchema, true);
+
+    // Assess
+    expect(result).toStrictEqual({
+      success: false,
+      error: expect.any(ParseError),
+      originalEvent: event,
+    });
+  });
+
+  it('throws without leaking a rejection when a schema validates asynchronously', () => {
+    // Prepare
+    // A transform that throws synchronously makes Zod fall back to async
+    // validation, so `~standard.validate` returns a rejected promise
+    const schema = z.string().transform(() => {
+      throw new Error('cannot validate synchronously');
+    });
+
+    // Act & Assess
+    expect(() => parse('data', undefined, schema, true)).toThrow(
+      new ParseError('Schema parsing supports only synchronous validation')
+    );
   });
 });


### PR DESCRIPTION
## Summary

### Changes

`Base64Encoded` started its chain with `z.string()` and called `fromBase64` inside the transform. `fromBase64` throws a `TypeError` on invalid base64, and Zod 4 does not catch exceptions thrown inside transforms, so `safeParse` threw a `TypeError` instead of returning `{ success: false }`. This affected the helper directly, the built-in `KinesisDataStreamSchema` / `KinesisEnvelope`, `parse(event, undefined, KinesisDataStreamSchema, true)`, and the decorator / Middy middleware in `safeParse` mode.

Through `parse()` it was worse: Zod's `~standard.validate` catches the synchronous throw and falls back to `safeParseAsync`, returning a rejecting promise. `parse()` saw a `Promise`, threw the misleading "supports only synchronous validation" error, and never attached a handler to the rejected promise, so it surfaced as an unhandled rejection (`Runtime.UnhandledPromiseRejection` on the Lambda runtime).

- Guard `Base64Encoded` with `z.base64()` instead of `z.string()`, so invalid input becomes a normal Zod issue before the transform runs. This matches the existing `CloudWatchLogsSchema` and `KinesisFirehoseRecordSchema`, which already guard with `z.base64()` and were not affected.
- In `parse()`, attach a handler to the promise returned by an async validation before throwing, so a rejected promise from Zod's async fallback cannot leak. Dropped the `/* v8 ignore */` on that branch since it is reachable, and covered it with a test.

The decorator and Middy `safeParse` paths route through the same schemas, so they are fixed at the source by the helper change.

Added tests:
- `Base64Encoded(...).safeParse('not base64!!')` returns a failed result instead of throwing.
- `parse(event, undefined, KinesisDataStreamSchema, true)` with a malformed `kinesis.data` returns `{ success: false }` rather than throwing.
- A schema whose transform throws synchronously makes `parse()` throw the sync-only `ParseError` without leaking an unhandled rejection (the run fails if the handler is removed).

Verified each test fails against the pre-fix code, and the full parser unit suite (289 tests) passes with 100% coverage on `parser.ts` and `helpers/index.ts`.

**Issue number:** closes #5651

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.