### PR TITLE
fix(idempotency): delete only acquired records in the Middy onError hook

### DIFF
--- a/docs/features/idempotency.md
+++ b/docs/features/idempotency.md
@@ -327,7 +327,8 @@ sequenceDiagram
 
 If you are using `makeIdempotent` on any other function, any unhandled exceptions that are thrown _inside_ the wrapped function will cause the record in the persistence layer to be deleted, and allow the function to be executed again if retried.
 
-If an error is thrown _outside_ the scope of the decorated function and after your function has been called, the persistent record will not be affected. In this case, idempotency will be maintained for your decorated function. Example:
+If an error is thrown _outside_ the scope of the decorated function and after your function has been called, the persistent record will not be affected. In this case, idempotency will be maintained for your decorated function.
+The same applies to the `makeHandlerIdempotent` Middy middleware: the record is kept when the middleware itself rejects a request, and once your handler has returned. It is still deleted when a middleware registered after it fails before your handler has returned. Example:
 
 === "Handling exceptions"
 

--- a/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
+++ b/packages/idempotency/src/middleware/makeHandlerIdempotent.ts
@@ -60,6 +60,30 @@ const setIdempotencySkipFlag = (request: MiddyLikeRequest): void => {
 
 /**
  * @internal
+ * Records whether this request acquired an in-progress record it has not yet completed.
+ *
+ * @param request - The Middy request object
+ * @param owned - Whether the request owns an unfinished in-progress record
+ */
+const setIdempotencyRecordOwnership = (
+  request: MiddyLikeRequest,
+  owned: boolean
+): void => {
+  request.internal[`${IDEMPOTENCY_KEY}.ownsRecord`] = owned;
+};
+
+/**
+ * @internal
+ * Checks whether this request owns an unfinished in-progress record.
+ *
+ * @param request - The Middy request object
+ */
+const ownsIdempotencyRecord = (request: MiddyLikeRequest): boolean => {
+  return request.internal[`${IDEMPOTENCY_KEY}.ownsRecord`] === true;
+};
+
+/**
+ * @internal
  * Utility function to get the idempotency key from the request internal storage
  * and determine if the request should skip the idempotency middleware
  *
@@ -109,10 +133,12 @@ const makeHandlerIdempotent = (
    *
    * If idempotency is enabled and the idempotency key is present in the payload,
    * we then run the idempotency operations. These are handled in {@link IdempotencyHandler.handleMiddyBefore}.
+   * A stored response is returned early; otherwise this request now owns the
+   * in-progress record and `onError` is allowed to delete it.
    *
    * @param request - The Middy request object
    */
-  const before = (request: MiddyLikeRequest): unknown => {
+  const before = async (request: MiddyLikeRequest): Promise<unknown> => {
     const idempotencyConfig = options.config ?? new IdempotencyConfig({});
     const persistenceStore = options.persistenceStore;
     const keyPrefix = options.keyPrefix;
@@ -132,6 +158,9 @@ const makeHandlerIdempotent = (
       functionPayloadToBeHashed: undefined,
     });
     setIdempotencyHandlerInRequestInternal(request, idempotencyHandler);
+    // `request.internal` can be shared across invocations, so reset per-request state
+    request.internal[`${IDEMPOTENCY_KEY}.skip`] = false;
+    setIdempotencyRecordOwnership(request, false);
 
     // set the payload to be hashed
     idempotencyHandler.setFunctionPayloadToBeHashed(request.event as JSONValue);
@@ -145,7 +174,20 @@ const makeHandlerIdempotent = (
 
     idempotencyConfig.registerLambdaContext(request.context);
 
-    return idempotencyHandler.handleMiddyBefore(request, cleanupMiddlewares);
+    // the cleanup callback only runs when a stored response is replayed
+    let replayed = false;
+    const result = await idempotencyHandler.handleMiddyBefore(
+      request,
+      async (request) => {
+        replayed = true;
+        await cleanupMiddlewares(request);
+      }
+    );
+    if (!replayed) {
+      setIdempotencyRecordOwnership(request, true);
+    }
+
+    return result;
   };
 
   /**
@@ -155,6 +197,9 @@ const makeHandlerIdempotent = (
    * idempotency store to indicate that the execution has completed and
    * store its result. This is handled in {@link IdempotencyHandler.handleMiddyAfter}.
    *
+   * Ownership is released before saving so that a failure to store the result
+   * does not delete the record, in line with the function wrapper.
+   *
    * @param request - The Middy request object
    */
   const after = async (request: MiddyLikeRequest): Promise<void> => {
@@ -163,6 +208,7 @@ const makeHandlerIdempotent = (
     }
     const idempotencyHandler =
       getIdempotencyHandlerFromRequestInternal(request);
+    setIdempotencyRecordOwnership(request, false);
     await idempotencyHandler.handleMiddyAfter(request.response);
   };
 
@@ -172,10 +218,14 @@ const makeHandlerIdempotent = (
    * When an error is thrown in the handler, we need to delete the record from the
    * idempotency store. This is handled in {@link IdempotencyHandler.handleMiddyOnError}.
    *
+   * The record is left untouched when this request never acquired it, for example
+   * when `before` rejected a concurrent or mismatching request, or once the
+   * handler has returned and its result is being stored.
+   *
    * @param request - The Middy request object
    */
   const onError = async (request: MiddyLikeRequest): Promise<void> => {
-    if (shouldSkipIdempotency(request)) {
+    if (shouldSkipIdempotency(request) || !ownsIdempotencyRecord(request)) {
       return;
     }
     const idempotencyHandler =

--- a/packages/idempotency/tests/unit/makeIdempotent.test.ts
+++ b/packages/idempotency/tests/unit/makeIdempotent.test.ts
@@ -6,11 +6,13 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MAX_RETRIES } from '../../src/constants.js';
 import { IdempotencyHandler } from '../../src/IdempotencyHandler.js';
 import {
+  IdempotencyAlreadyInProgressError,
   IdempotencyConfig,
   IdempotencyInconsistentStateError,
   IdempotencyItemAlreadyExistsError,
   IdempotencyRecordStatus,
   IdempotencyUnknownError,
+  IdempotencyValidationError,
   makeIdempotent,
 } from '../../src/index.js';
 import { makeHandlerIdempotent } from '../../src/middleware/makeHandlerIdempotent.js';
@@ -157,6 +159,10 @@ describe('Function: makeIdempotent', () => {
         mockIdempotencyOptions.persistenceStore,
         'saveInProgress'
       ).mockRejectedValue(new Error('Something went wrong'));
+      const deleteRecordSpy = vi.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'deleteRecord'
+      );
 
       // Act && Assess
       await expect(handler(event, context)).rejects.toMatchObject({
@@ -164,6 +170,7 @@ describe('Function: makeIdempotent', () => {
         message: 'Failed to save in progress record to idempotency store',
         cause: new Error('Something went wrong'),
       });
+      expect(deleteRecordSpy).toHaveBeenCalledTimes(0);
     }
   );
 
@@ -181,6 +188,10 @@ describe('Function: makeIdempotent', () => {
         mockIdempotencyOptions.persistenceStore,
         'saveSuccess'
       ).mockRejectedValue(new Error('Something went wrong'));
+      const deleteRecordSpy = vi.spyOn(
+        mockIdempotencyOptions.persistenceStore,
+        'deleteRecord'
+      );
 
       // Act && Assess
       await expect(handler(event, context)).rejects.toMatchObject({
@@ -188,8 +199,178 @@ describe('Function: makeIdempotent', () => {
         message: 'Failed to update success record to idempotency store',
         cause: new Error('Something went wrong'),
       });
+      expect(deleteRecordSpy).toHaveBeenCalledTimes(0);
     }
   );
+
+  it('deletes the record when a later middleware fails before the handler runs (middleware)', async () => {
+    // Prepare
+    const handler = middy(fnSuccessfull)
+      .use(makeHandlerIdempotent(mockIdempotencyOptions))
+      .use({ before: fnError });
+    const deleteRecordSpy = vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'deleteRecord'
+    );
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrowError(
+      'Something went wrong'
+    );
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a completed record with an undefined response when the handler throws (middleware)', async () => {
+    // Prepare
+    const handler = middy(fnError).use(
+      makeHandlerIdempotent(mockIdempotencyOptions)
+    );
+    vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    ).mockRejectedValue(
+      new IdempotencyItemAlreadyExistsError(
+        'Record exists',
+        new IdempotencyRecord({
+          idempotencyKey: 'idempotencyKey',
+          expiryTimestamp: Date.now() + 10000,
+          inProgressExpiryTimestamp: 0,
+          payloadHash: 'payloadHash',
+          status: IdempotencyRecordStatus.COMPLETED,
+        })
+      )
+    );
+    const deleteRecordSpy = vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'deleteRecord'
+    );
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrowError(
+      'Something went wrong'
+    );
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('resets ownership between invocations sharing the same internal storage (middleware)', async () => {
+    // Prepare
+    const handler = middy(fnError, { internal: {} }).use(
+      makeHandlerIdempotent(mockIdempotencyOptions)
+    );
+    const deleteRecordSpy = vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'deleteRecord'
+    );
+    await expect(handler(event, context)).rejects.toThrowError(
+      'Something went wrong'
+    );
+    vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    ).mockRejectedValue(
+      new IdempotencyItemAlreadyExistsError(
+        'Record exists',
+        new IdempotencyRecord({
+          idempotencyKey: 'idempotencyKey',
+          expiryTimestamp: Date.now() + 10000,
+          inProgressExpiryTimestamp: Date.now() + 10000,
+          payloadHash: 'payloadHash',
+          status: IdempotencyRecordStatus.INPROGRESS,
+        })
+      )
+    );
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toBeInstanceOf(
+      IdempotencyAlreadyInProgressError
+    );
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the record of a concurrent execution when rejecting a duplicate request (middleware)', async () => {
+    // Prepare
+    const handler = middy(fnSuccessfull).use(
+      makeHandlerIdempotent(mockIdempotencyOptions)
+    );
+    vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveInProgress'
+    ).mockRejectedValue(
+      new IdempotencyItemAlreadyExistsError(
+        'Record exists',
+        new IdempotencyRecord({
+          idempotencyKey: 'idempotencyKey',
+          expiryTimestamp: Date.now() + 10000,
+          inProgressExpiryTimestamp: Date.now() + 10000,
+          payloadHash: 'payloadHash',
+          status: IdempotencyRecordStatus.INPROGRESS,
+        })
+      )
+    );
+    const deleteRecordSpy = vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'deleteRecord'
+    );
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toBeInstanceOf(
+      IdempotencyAlreadyInProgressError
+    );
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('keeps the completed record when rejecting a request with a different payload (middleware)', async () => {
+    // Prepare
+    const persistenceStore = new PersistenceLayerTestClass();
+    const handler = middy(fnSuccessfull).use(
+      makeHandlerIdempotent({
+        persistenceStore,
+        config: new IdempotencyConfig({ payloadValidationJmesPath: 'foo' }),
+      })
+    );
+    vi.spyOn(persistenceStore, 'saveInProgress').mockRejectedValue(
+      new IdempotencyItemAlreadyExistsError(
+        'Record exists',
+        new IdempotencyRecord({
+          idempotencyKey: 'idempotencyKey',
+          expiryTimestamp: Date.now() + 10000,
+          inProgressExpiryTimestamp: 0,
+          responseData: { response: false },
+          payloadHash: 'differentPayloadHash',
+          status: IdempotencyRecordStatus.COMPLETED,
+        })
+      )
+    );
+    const deleteRecordSpy = vi.spyOn(persistenceStore, 'deleteRecord');
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toBeInstanceOf(
+      IdempotencyValidationError
+    );
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('keeps the completed record when a later middleware fails after the result was saved (middleware)', async () => {
+    // Prepare
+    const handler = middy(fnSuccessfull)
+      .use({ after: fnError })
+      .use(makeHandlerIdempotent(mockIdempotencyOptions));
+    const saveSuccessSpy = vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'saveSuccess'
+    );
+    const deleteRecordSpy = vi.spyOn(
+      mockIdempotencyOptions.persistenceStore,
+      'deleteRecord'
+    );
+
+    // Act && Assess
+    await expect(handler(event, context)).rejects.toThrowError(
+      'Something went wrong'
+    );
+    expect(saveSuccessSpy).toHaveBeenCalledTimes(1);
+    expect(deleteRecordSpy).toHaveBeenCalledTimes(0);
+  });
 
   it.each([{ type: 'wrapper' }, { type: 'middleware' }])(
     'thows an error if the persistence layer throws an error when deleting a record ($type)',


### PR DESCRIPTION
## Summary

The `makeHandlerIdempotent` middleware's `onError` hook runs whenever any earlier step throws, including its own `before` hook. It deleted the idempotency record unconditionally, so a rejected duplicate (`IdempotencyAlreadyInProgressError`) removed the lock of the still-running original invocation, and a rejected payload mismatch (`IdempotencyValidationError`) removed the original request's completed record. Either way a subsequent retry executed the handler again. Reproduced on Lambda + DynamoDB; the `makeIdempotent` wrapper is unaffected because its `try/catch` only wraps the function call.

The middleware now tracks whether the current request acquired an unfinished in-progress record and deletes only in that case.

### Changes

- `before` marks the request as owning the record when `handleMiddyBefore` did not replay a stored response, detected via the replay cleanup callback. Both per-request flags are reset at the start of `before`, since Middy reuses a user-supplied `internal` object across warm invocations; this also closes the same stale-flag leak in the existing `.skip` flag.
- `after` releases ownership before saving the result, so a `saveSuccess` failure no longer deletes the record, in line with the wrapper.
- `onError` returns early unless the request owns the record.
- Docs: "Handling exceptions" states when the middleware keeps the record and when it still deletes it.
- Tests: six new cases in `makeIdempotent.test.ts` covering the concurrent duplicate, payload mismatch, undefined stored response, later `after` failure, shared `internal` storage, and a later `before` failure that must still delete; the `saveSuccess` failure case now asserts no delete.

### Design note

Ownership is tracked in the middleware via `request.internal`, next to the existing `.skip` flag, rather than as a field on `IdempotencyHandler`. A core-class flag would be a smaller diff (set after `saveInProgress` resolves, cleared on `saveSuccess`, checked in `handleMiddyOnError`), but the problem is specific to Middy's lifecycle: `onError` fires for failures in `before`, which the wrapper and decorator paths never encounter. Keeping the state in the middleware leaves `IdempotencyHandler` untouched and keeps all per-request Middy state in one place.

**Issue number:** closes #5675

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
