### PR TITLE
fix(event-handler): ignore body on GET/HEAD requests when converting to Web Request

### DIFF
--- a/packages/event-handler/src/http/converters.ts
+++ b/packages/event-handler/src/http/converters.ts
@@ -13,6 +13,7 @@ import type {
   ExtendedAPIGatewayProxyResult,
   ExtendedAPIGatewayProxyResultBody,
   HandlerResponse,
+  HttpMethod,
   HttpStatusCode,
   ResponseType,
   ResponseTypeMap,
@@ -37,6 +38,19 @@ import {
 } from './utils.js';
 
 /**
+ * Reads and normalises the HTTP method of an event, throwing when it is not one we route.
+ *
+ * @param rawMethod - The method as it appears on the event
+ */
+const toHttpMethod = (rawMethod: string): HttpMethod => {
+  const method = rawMethod.toUpperCase();
+  if (!isHttpMethod(method)) {
+    throw new InvalidHttpMethodError(method);
+  }
+  return method;
+};
+
+/**
  * Creates a request body from API Gateway event body, handling base64 decoding if needed.
  *
  * GET and HEAD requests are not allowed to carry a body when constructing a
@@ -49,7 +63,7 @@ import {
 const createBody = (
   body: string | null,
   isBase64Encoded: boolean,
-  httpMethod: string
+  httpMethod: HttpMethod
 ) => {
   if (httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.HEAD) {
     return null;
@@ -121,8 +135,9 @@ const populateV1QueryParams = (
  * @returns A Web API Request object
  */
 const proxyEventV1ToWebRequest = (event: APIGatewayProxyEvent): Request => {
-  const { httpMethod, path } = event;
+  const { path } = event;
   const { domainName } = event.requestContext;
+  const method = toHttpMethod(event.httpMethod);
 
   const headers = new Headers();
   populateV1Headers(headers, event);
@@ -134,9 +149,9 @@ const proxyEventV1ToWebRequest = (event: APIGatewayProxyEvent): Request => {
   populateV1QueryParams(url, event);
 
   return new Request(url.toString(), {
-    method: httpMethod,
+    method,
     headers,
-    body: createBody(event.body, event.isBase64Encoded, httpMethod),
+    body: createBody(event.body, event.isBase64Encoded, method),
   });
 };
 
@@ -148,10 +163,8 @@ const proxyEventV1ToWebRequest = (event: APIGatewayProxyEvent): Request => {
  */
 const proxyEventV2ToWebRequest = (event: APIGatewayProxyEventV2): Request => {
   const { rawPath, rawQueryString } = event;
-  const {
-    http: { method },
-    domainName,
-  } = event.requestContext;
+  const { domainName } = event.requestContext;
+  const method = toHttpMethod(event.requestContext.http.method);
 
   const headers = new Headers();
   for (const [name, value] of Object.entries(event.headers)) {
@@ -183,7 +196,8 @@ const proxyEventV2ToWebRequest = (event: APIGatewayProxyEventV2): Request => {
  * @returns A Web API Request object
  */
 const albEventToWebRequest = (event: ALBEvent): Request => {
-  const { httpMethod, path } = event;
+  const { path } = event;
+  const method = toHttpMethod(event.httpMethod);
 
   const headers = new Headers();
   populateV1Headers(headers, event);
@@ -195,9 +209,9 @@ const albEventToWebRequest = (event: ALBEvent): Request => {
   populateV1QueryParams(url, event);
 
   return new Request(url.toString(), {
-    method: httpMethod,
+    method,
     headers,
-    body: createBody(event.body ?? null, event.isBase64Encoded, httpMethod),
+    body: createBody(event.body ?? null, event.isBase64Encoded, method),
   });
 };
 
@@ -212,15 +226,7 @@ const proxyEventToWebRequest = (
   event: APIGatewayProxyEvent | APIGatewayProxyEventV2 | ALBEvent
 ): Request => {
   if (isAPIGatewayProxyEventV2(event)) {
-    const method = event.requestContext.http.method.toUpperCase();
-    if (!isHttpMethod(method)) {
-      throw new InvalidHttpMethodError(method);
-    }
     return proxyEventV2ToWebRequest(event);
-  }
-  const method = event.httpMethod.toUpperCase();
-  if (!isHttpMethod(method)) {
-    throw new InvalidHttpMethodError(method);
   }
   if (isALBEvent(event)) {
     return albEventToWebRequest(event);

--- a/packages/event-handler/src/http/converters.ts
+++ b/packages/event-handler/src/http/converters.ts
@@ -39,11 +39,22 @@ import {
 /**
  * Creates a request body from API Gateway event body, handling base64 decoding if needed.
  *
+ * GET and HEAD requests are not allowed to carry a body when constructing a
+ * Web API {@link Request | `Request`}, so any body present on the event is ignored for those methods.
+ *
  * @param body - The raw body from the API Gateway event
  * @param isBase64Encoded - Whether the body is base64 encoded
- * @returns The decoded body string or null
+ * @param httpMethod - The HTTP method of the request
  */
-const createBody = (body: string | null, isBase64Encoded: boolean) => {
+const createBody = (
+  body: string | null,
+  isBase64Encoded: boolean,
+  httpMethod: string
+) => {
+  if (httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.HEAD) {
+    return null;
+  }
+
   if (body === null) return null;
 
   if (!isBase64Encoded) {
@@ -125,7 +136,7 @@ const proxyEventV1ToWebRequest = (event: APIGatewayProxyEvent): Request => {
   return new Request(url.toString(), {
     method: httpMethod,
     headers,
-    body: createBody(event.body, event.isBase64Encoded),
+    body: createBody(event.body, event.isBase64Encoded, httpMethod),
   });
 };
 
@@ -161,7 +172,7 @@ const proxyEventV2ToWebRequest = (event: APIGatewayProxyEventV2): Request => {
   return new Request(url, {
     method,
     headers,
-    body: createBody(event.body ?? null, event.isBase64Encoded),
+    body: createBody(event.body ?? null, event.isBase64Encoded, method),
   });
 };
 
@@ -183,16 +194,10 @@ const albEventToWebRequest = (event: ALBEvent): Request => {
   const url = new URL(path, `${protocol}://${hostname}/`);
   populateV1QueryParams(url, event);
 
-  // ALB events represent GET and HEAD request bodies as empty strings
-  const body =
-    httpMethod === HttpVerbs.GET || httpMethod === HttpVerbs.HEAD
-      ? null
-      : createBody(event.body ?? null, event.isBase64Encoded);
-
   return new Request(url.toString(), {
     method: httpMethod,
     headers,
-    body: body,
+    body: createBody(event.body ?? null, event.isBase64Encoded, httpMethod),
   });
 };
 

--- a/packages/event-handler/tests/unit/http/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/http/Router/basic-routing.test.ts
@@ -331,6 +331,27 @@ describe.each([
   });
 });
 
+describe('Class: Router - GET request with a body', () => {
+  it.each([
+    { version: 'V1', createEvent: createTestEvent },
+    { version: 'V2', createEvent: createTestEventV2 },
+  ])(
+    'resolves a GET request that carries a body end to end ($version)',
+    async ({ createEvent }) => {
+      // Prepare
+      const app = new Router();
+      app.get('/test', async () => ({ result: 'ok' }));
+      const event = { ...createEvent('/test', 'GET'), body: '{"q":"x"}' };
+
+      // Act
+      const result = await app.resolve(event, context);
+
+      // Assess
+      expect(result.statusCode).toBe(HttpStatusCodes.OK);
+    }
+  );
+});
+
 describe('Class: Router - V1 Multivalue Headers Support', () => {
   it('handles ExtendedAPIGatewayProxyResult with multiValueHeaders field', async () => {
     // Prepare

--- a/packages/event-handler/tests/unit/http/converters.test.ts
+++ b/packages/event-handler/tests/unit/http/converters.test.ts
@@ -122,6 +122,40 @@ describe('Converters', () => {
       expect(request.headers.get('Content-Type')).toBe('application/json');
     });
 
+    it('ignores a body on GET request', () => {
+      // Prepare
+      const event = {
+        ...baseEvent,
+        httpMethod: HttpVerbs.GET,
+        body: '{"q":"x"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('GET');
+      expect(request.body).toBe(null);
+    });
+
+    it('ignores a body on HEAD request', () => {
+      // Prepare
+      const event = {
+        ...baseEvent,
+        httpMethod: HttpVerbs.HEAD,
+        body: '{"q":"x"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('HEAD');
+      expect(request.body).toBe(null);
+    });
+
     it('decodes base64 encoded body', () => {
       // Prepare
       const originalText = 'Hello World';
@@ -679,6 +713,38 @@ describe('Converters', () => {
       expect(request.method).toBe('POST');
       expect(request.text()).resolves.toBe('{"key":"value"}');
       expect(request.headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('ignores a body on GET request', () => {
+      // Prepare
+      const event = {
+        ...createTestEventV2('/test', HttpVerbs.GET),
+        body: '{"q":"x"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('GET');
+      expect(request.body).toBe(null);
+    });
+
+    it('ignores a body on HEAD request', () => {
+      // Prepare
+      const event = {
+        ...createTestEventV2('/test', HttpVerbs.HEAD),
+        body: '{"q":"x"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('HEAD');
+      expect(request.body).toBe(null);
     });
 
     it('decodes base64 encoded body', () => {

--- a/packages/event-handler/tests/unit/http/converters.test.ts
+++ b/packages/event-handler/tests/unit/http/converters.test.ts
@@ -156,6 +156,39 @@ describe('Converters', () => {
       expect(request.body).toBe(null);
     });
 
+    it('ignores a body on a lowercase get request', () => {
+      // Prepare
+      const event = {
+        ...baseEvent,
+        httpMethod: 'get',
+        body: '{"q":"x"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('GET');
+      expect(request.body).toBe(null);
+    });
+
+    it('normalizes a lowercase patch method', () => {
+      // Prepare
+      const event = {
+        ...baseEvent,
+        httpMethod: 'patch',
+        body: '{"key":"value"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('PATCH');
+    });
+
     it('decodes base64 encoded body', () => {
       // Prepare
       const originalText = 'Hello World';
@@ -745,6 +778,37 @@ describe('Converters', () => {
       expect(request).toBeInstanceOf(Request);
       expect(request.method).toBe('HEAD');
       expect(request.body).toBe(null);
+    });
+
+    it('ignores a body on a lowercase get request', () => {
+      // Prepare
+      const event = {
+        ...createTestEventV2('/test', 'get'),
+        body: '{"q":"x"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('GET');
+      expect(request.body).toBe(null);
+    });
+
+    it('normalizes a lowercase patch method', () => {
+      // Prepare
+      const event = {
+        ...createTestEventV2('/test', 'patch'),
+        body: '{"key":"value"}',
+      };
+
+      // Act
+      const request = proxyEventToWebRequest(event);
+
+      // Assess
+      expect(request).toBeInstanceOf(Request);
+      expect(request.method).toBe('PATCH');
     });
 
     it('decodes base64 encoded body', () => {


### PR DESCRIPTION
## Summary

### Changes

API Gateway v1/v2 events can include a body on GET or HEAD requests, even
though that's unusual. The V1 and V2 event converters
(`proxyEventV1ToWebRequest` and `proxyEventV2ToWebRequest`) passed the body
straight through to the Web `Request` constructor. Since a Web `Request`
with method GET/HEAD cannot carry a body, this throws an uncaught
`TypeError`, crashing the handler invocation and returning a 502 to the
client.

The ALB converter already guarded against this case. This PR moves that
guard into the shared `createBody` helper (used by all three converters) so
GET/HEAD requests always get a `null` body, matching the ALB converter's
existing behavior.

Added regression tests covering GET and HEAD requests with a body for both
the API Gateway v1 and v2 converters.

**Issue number:** closes #5673

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
