### PR TITLE
fix(ci): skip unrelated release workflows without approval

### DIFF
--- a/.github/workflows/on_layer_docs_pr_merge.yml
+++ b/.github/workflows/on_layer_docs_pr_merge.yml
@@ -9,9 +9,11 @@ name: Auto-trigger docs rebuild on layer ARN docs PR merge
 #
 # SECURITY NOTE
 #
-# Deliberately uses `pull_request` (not `pull_request_target`), so PRs from forks keep
-# GitHub's default read-only token and no secrets - a forked PR could never reach the
-# `gh workflow run` step even if every other condition below matched.
+# Uses `pull_request_target` so unrelated fork PRs can skip without workflow approval.
+# The workflow definition comes from the default branch. This event can grant the
+# job's write permissions even for fork events, so all job conditions below are required.
+# The job only reads data from trusted `main` and dispatches a fixed workflow on `main`;
+# it never checks out or executes PR code.
 #
 # `github.event.pull_request.user.login` is set by GitHub from the identity that actually
 # called the API to open the PR - it isn't spoofable via branch name, PR title, or body.
@@ -22,12 +24,14 @@ name: Auto-trigger docs rebuild on layer ARN docs PR merge
 # GitHub exposes as the PR's author).
 #
 # Combined with `head.repo.full_name == github.repository` (rejects forks explicitly)
-# and `base.ref == 'main'`, only genuine automation-opened, same-repo, main-targeted
-# PRs can reach the dispatch step.
+# and the merge and branch checks, only merged, same-repo, bot-authored PRs with the
+# expected prefix can reach the dispatch step. Bot authorship does not attest which
+# workflow created the PR. Unrelated closures on `main` still create skipped runs.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+    branches: [main]
 
 permissions: {}
 
@@ -44,13 +48,19 @@ jobs:
       contents: read
       actions: write
     steps:
-      - name: Checkout main
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: main
       - name: Resolve latest published version
         id: version
-        run: echo "version=$(cat packages/commons/package.json | jq .version -r)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          version=$(gh api "repos/$REPOSITORY/contents/packages/commons/package.json?ref=main" --jq '.content' | base64 --decode | jq -er '.version | select(type == "string")')
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Expected a stable release version" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
       - name: Dispatch Rebuild latest docs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on_version_bump_pr_merge.yml
+++ b/.github/workflows/on_version_bump_pr_merge.yml
@@ -9,9 +9,11 @@ name: Auto-trigger Make Release on version bump PR merge
 #
 # SECURITY NOTE
 #
-# Deliberately uses `pull_request` (not `pull_request_target`), so PRs from forks keep
-# GitHub's default read-only token and no secrets - a forked PR could never reach the
-# `gh workflow run` step even if every other condition below matched.
+# Uses `pull_request_target` so unrelated fork PRs can skip without workflow approval.
+# The workflow definition comes from the default branch. This event can grant the
+# job's write permissions even for fork events, so all job conditions below are required.
+# The job only dispatches a fixed workflow on `main`; it never checks out or executes
+# PR code.
 #
 # `github.event.pull_request.user.login` is set by GitHub from the identity that actually
 # called the API to open the PR - it isn't spoofable via branch name, PR title, or body.
@@ -22,12 +24,14 @@ name: Auto-trigger Make Release on version bump PR merge
 # GitHub exposes as the PR's author).
 #
 # Combined with `head.repo.full_name == github.repository` (rejects forks explicitly)
-# and `base.ref == 'main'`, only genuine automation-opened, same-repo, main-targeted
-# PRs can reach the dispatch step.
+# and the merge and branch checks, only merged, same-repo, bot-authored PRs with the
+# expected prefix can reach the dispatch step. Bot authorship does not attest which
+# workflow created the PR. Unrelated closures on `main` still create skipped runs.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+    branches: [main]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Closing or merging an external contributor’s PR currently creates approval requests for the release merge workflows before their jobs can be skipped. Use `pull_request_target` for closures targeting `main` so unrelated PRs skip automatically while qualifying bot PRs still dispatch the next release step.

### Changes

- Preserve all existing merge, repository, bot-author, branch-prefix, and job-permission checks; update the security comments for the new event.
- Replace the docs checkout with a GitHub API read from trusted `main`, validate the stable version, and stop on lookup or validation failures.
- Keep both downstream workflow destinations and their `main` ref unchanged. Unrelated closures targeting `main` still produce skipped workflow records.

Validation: all workspace type checks and the full unit suite passed with 100% coverage. Workflow lint and 12 local version-lookup cases also passed. A private staging rehearsal passed 11 live PR cases and 18 payload fixtures, including successful release and docs dispatches, spoofed commit authors, and attempted workflow modification. Producer PRs came from a test factory and downstream publishing was stubbed; the complete release pipeline and live external-fork approval behavior were not exercised.

**Issue number:** closes #5687

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
