### PR TITLE
chore(tests): centralise TypeScript test configuration

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -53,6 +53,12 @@ Run from the repo root with `-w <workspace>`, or from the package directory:
 - `npm run lint` to check; `npm run lint:fix` to auto-fix (review its changes).
 - `npm run build:tests` to type-check source and tests without emitting — CI compiles them separately from running them. `npm run build` additionally compiles the CommonJS target.
 
+Test configs in `packages/*/tests/tsconfig.json` extend the root `tsconfig.test.json`, which inherits common compiler options from `tsconfig.json`. Keep only package-specific exceptions in the package test configs.
+
+The shared test config includes `packages/testing/src/setupEnv.ts` through `files` so custom matcher types are available even when a package overrides `include`; `${configDir}` resolves source and test paths relative to each package's test config.
+
+Vitest runs tests; TypeScript only checks them. Test projects disable `composite` and declaration output, retain incremental checking, and store their cache in each workspace's `.tsbuildinfo/tests.json`, separately from production build caches. Vitest's runtime `setupFiles` registration remains in its own configuration.
+
 ## Unit tests
 
 Tests use `vitest` and live in each package's `tests/unit` directory. Run with `npm run test:unit -w packages/<name>` (or `npm run test:unit` from the package directory). Write unit tests only — end-to-end tests happen when the user asks for them.

--- a/layers/tests/tsconfig.json
+++ b/layers/tests/tsconfig.json
@@ -1,8 +1,8 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../../tsconfig.test.json",
   "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true
   },
   "include": ["../src/**/*", "../package.json", "./**/*"]
 }

--- a/packages/batch/tests/tsconfig.json
+++ b/packages/batch/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/commons/tests/tsconfig.json
+++ b/packages/commons/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/data-masking/tests/tsconfig.json
+++ b/packages/data-masking/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/event-handler/tests/tsconfig.json
+++ b/packages/event-handler/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/idempotency/tests/tsconfig.json
+++ b/packages/idempotency/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/jmespath/tests/tsconfig.json
+++ b/packages/jmespath/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/kafka/tests/tsconfig.json
+++ b/packages/kafka/tests/tsconfig.json
@@ -1,9 +1,6 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "../../../tsconfig.test.json",
   "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true,
     "resolveJsonModule": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  }
 }

--- a/packages/logger/tests/tsconfig.json
+++ b/packages/logger/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/metrics/tests/tsconfig.json
+++ b/packages/metrics/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/parameters/tests/tsconfig.json
+++ b/packages/parameters/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/parser/tests/tsconfig.json
+++ b/packages/parser/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/signer/tests/tsconfig.json
+++ b/packages/signer/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/testing/tests/tsconfig.json
+++ b/packages/testing/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/testing/tests/types/toReceiveCommandWith.test-d.ts
+++ b/packages/testing/tests/types/toReceiveCommandWith.test-d.ts
@@ -1,6 +1,5 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { expect, expectTypeOf, it } from 'vitest';
-import '../../src/setupEnv.js';
 
 it('infers the expected input from the command constructor', () => {
   // Prepare

--- a/packages/tracer/tests/tsconfig.json
+++ b/packages/tracer/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../",
-    "noEmit": true
-  },
-  "include": ["../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/packages/validation/tests/tsconfig.json
+++ b/packages/validation/tests/tsconfig.json
@@ -1,8 +1,3 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "../../",
-    "noEmit": true
-  },
-  "include": ["../../testing/src/setupEnv.ts", "../src/**/*", "./**/*"]
+  "extends": "../../../tsconfig.test.json"
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "tsBuildInfoFile": "${configDir}/../.tsbuildinfo/tests.json"
+  },
+  "files": ["./packages/testing/src/setupEnv.ts"],
+  "include": ["${configDir}/../src/**/*", "${configDir}/**/*"]
+}


### PR DESCRIPTION
## Summary

Centralise test compiler settings and shared setup declarations so all 16 test projects inherit one configuration. Test type-checking now uses its own incremental caches instead of reusing production build caches.

### Changes

- Add `tsconfig.test.json`, extending the root compiler configuration with test-only overrides, shared `setupEnv.ts` inclusion, and `${configDir}` paths for package sources and tests.
- Disable composite/declaration output for test projects while retaining incremental checking in each workspace's `.tsbuildinfo/tests.json`.
- Reduce package test configs to the shared base while retaining Kafka's JSON-module override.
- Preserve the layer tests' existing compiler behaviour: `allowImportingTsExtensions` and `resolveJsonModule` were previously inherited from `layers/tsconfig.json`. They are now explicit in `layers/tests/tsconfig.json` because it extends the shared test base. Its existing `include` list, including `layers/package.json`, is unchanged.
- Remove the matcher type test's explicit setup import to verify inherited declarations, and document the configuration conventions.

Validation passed: clean ESM/CJS rebuilds, workspace and layer type-checks, all Vitest type suites, 3,718 unit tests with 100% coverage, and the layer-packaging unit test. Comparison of 48 resolved configurations confirmed no existing input files were dropped; compiler probes verified matcher typing and root-option inheritance across all 16 test projects. All 1,812 production output/cache hashes remained unchanged.

Type-check timings were effectively unchanged: 52.2 → 51.7 seconds cold and 41.1 → 41.1 seconds cached in a single before/after sample.

**Issue number:** closes #5694

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
