### PR TITLE
fix(event-handler): preserve binary Web Response bodies

### DIFF
--- a/docs/features/event-handler/http.md
+++ b/docs/features/event-handler/http.md
@@ -749,6 +749,9 @@ a [Nodejs stream](https://nodejs.org/api/stream.html){target="_blank"}, or
 a [Web stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API#browser_compatibility){target="_blank"}
 directly from your handler. We will automatically serialize the response by setting the `isBase64Encoded` flag to `true` and `base64` encoding the binary data.
 
+When you return a Web `Response`, the router uses its `Content-Type` header to identify binary data. Buffered responses with `image/*`, `audio/*`, `video/*`, `application/pdf`, `application/zip`, or `application/octet-stream` content types are automatically base64 encoded.
+Matching is case-insensitive and ignores content-type parameters. For other binary content types, [set `reqCtx.isBase64Encoded` to `true`](#set-isbase64encoded-parameter).
+
 !!! note "Content types"
     The default header will be set to `application/json`. If you wish to change this,
     e.g., in the case of images, PDFs, videos, etc, then you should use the `reqCtx.res.headers` object to set the appropriate header.

--- a/packages/event-handler/src/http/utils.ts
+++ b/packages/event-handler/src/http/utils.ts
@@ -440,6 +440,11 @@ export const applyHandlerResult = (
   });
 };
 
+/**
+ * Determines whether response headers identify binary or compressed content.
+ *
+ * @param headers - The response headers.
+ */
 export const getBase64EncodingFromHeaders = (headers: Headers): boolean => {
   const contentEncoding = headers.get(
     'content-encoding'
@@ -458,11 +463,16 @@ export const getBase64EncodingFromHeaders = (headers: Headers): boolean => {
   const contentType = headers.get('content-type');
   /* v8 ignore else -- @preserve */
   if (contentType != null) {
-    const type = contentType.split(';')[0].trim();
+    const type = contentType.split(';')[0].trim().toLowerCase();
     if (
       type.startsWith('image/') ||
       type.startsWith('audio/') ||
-      type.startsWith('video/')
+      type.startsWith('video/') ||
+      [
+        'application/pdf',
+        'application/zip',
+        'application/octet-stream',
+      ].includes(type)
     ) {
       return true;
     }

--- a/packages/event-handler/tests/unit/http/Router/basic-routing.test.ts
+++ b/packages/event-handler/tests/unit/http/Router/basic-routing.test.ts
@@ -598,14 +598,57 @@ describe.each([
     }
   );
 
-  it('does not set isBase64Encoded for text content-types', async () => {
+  it.each([
+    'application/pdf',
+    'application/zip',
+    'application/octet-stream',
+    'Application/PDF',
+    'application/zip; version=1',
+    'APPLICATION/OCTET-STREAM; charset=binary',
+  ])(
+    'preserves binary bytes in a Web Response with %s content-type',
+    async (contentType) => {
+      // Prepare
+      const app = new Router();
+      const bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0xff, 0xfe, 0x00]);
+      app.get(
+        '/binary',
+        () =>
+          new Response(bytes, {
+            headers: { 'content-type': contentType },
+          })
+      );
+
+      // Act
+      const result = await app.resolve(createEvent('/binary', 'GET'), context);
+      const received = Buffer.from(
+        result.body ?? '',
+        result.isBase64Encoded ? 'base64' : 'utf8'
+      );
+
+      // Assess
+      expect(result.statusCode).toBe(200);
+      expect(result.headers?.['content-type']).toBe(contentType);
+      expect(received.toString('hex')).toBe(Buffer.from(bytes).toString('hex'));
+      expect(result.isBase64Encoded).toBe(true);
+    }
+  );
+
+  it.each([
+    'text/plain',
+    'text/html; charset=utf-8',
+    'application/json',
+    'application/problem+json',
+    'application/xml',
+  ])('does not set isBase64Encoded for %s', async (contentType) => {
     // Prepare
     const app = new Router();
+    const body = '"text data"';
     app.get(
       '/text',
       () =>
-        new Response('text data', {
-          headers: { 'content-type': 'text/plain' },
+        new Response(body, {
+          headers: { 'content-type': contentType },
         })
     );
 
@@ -614,8 +657,8 @@ describe.each([
 
     // Assess
     expect(result.statusCode).toBe(200);
-    expect(result.body).toBe('text data');
-    expect(result.headers?.['content-type']).toBe('text/plain');
+    expect(result.body).toBe(body);
+    expect(result.headers?.['content-type']).toBe(contentType);
     expect(result.isBase64Encoded).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Returning a Web `Response` with PDF, ZIP, or octet-stream bytes could silently corrupt the body by decoding it as UTF-8. These content types now use base64 serialization, preserving the original bytes across REST API, HTTP API, and ALB responses.

### Changes

- Recognize `application/pdf`, `application/zip`, and `application/octet-stream` as binary content types, including mixed-case values and parameters.
- Add byte-preservation regressions across all three integrations and controls for text, JSON, and XML responses.
- Document automatic encoding for Web responses and the explicit flag for other binary content types.
- Validate workspace test types, staged-file linting, and the unit suite with 100% coverage.

**Issue number:** closes #5698

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
